### PR TITLE
Add `pre-commit` hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.md]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -19,10 +19,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          # self update is currently broken on Windows runners:
-          #   https://github.com/rust-lang/rustup/issues/3709
-          rustup update --no-self-update ${{ matrix.toolchain }}
-          rustup default ${{ matrix.toolchain }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: Run pre-commit hooks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit-ci/lite-action@v1.0.2
+        if: always()

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+---
+MD013:
+  # Maximum number of characters
+  line_length: 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.38.0
+    hooks:
+      - id: markdownlint-fix
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier
+        types_or: [yaml, json]
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.13.0
+    hooks:
+      - id: pretty-format-toml
+        args: [--autofix, --indent, "4", --no-sort]
+      - id: pretty-format-rust
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: [--ignore-words, .codespell_ignore.txt]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["rust-lang.rust-analyzer"]
+    "recommendations": ["rust-lang.rust-analyzer", "editorconfig.editorconfig"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-    "recommendations": ["rust-lang.rust-analyzer", "editorconfig.editorconfig"]
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "rust-lang.rust-analyzer",
         "editorconfig.editorconfig",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "davidanson.vscode-markdownlint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,19 @@
 {
     "[rust]": {
-        "editor.formatOnSave": true
+        "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[toml]": {
+        "editor.formatOnSave": false
+    },
+    "editor.formatOnSave": true,
     "editor.rulers": [100] // default max_width for rustfmt
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-ict-rse-team@imperial.ac.uk.
+<ict-rse-team@imperial.ac.uk>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ faster version of [the older MUSE tool].
 
 ## Getting started
 
+### Installing the Rust toolchain
+
 We recommend that developers use `rustup` to install the Rust toolchain. Follow the instructions on
 [the `rustup` website](https://rustup.rs/).
 
@@ -18,6 +20,8 @@ Once you have done so, select the `stable` toolchain (used by this project) as y
 ```sh
 rustup default stable
 ```
+
+### Working with the project
 
 To build the project, run:
 
@@ -38,6 +42,24 @@ cargo test
 ```
 
 More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
+
+### Installing `pre-commit` (optional)
+
+It is recommended that developers install the `pre-commit` tool in order to automatically run this
+repository's hooks when making a new Git commit. Follow [the instructions on the `pre-commit`
+website] in order to get started.
+
+Once you have installed `pre-commit`, you need to enable its use for this repository by installing
+the hooks, like so:
+
+```sh
+pre-commit install
+```
+
+Thereafter, a series of checks should be run every time you commit with Git. In addition, the
+`pre-commit` hooks are also run as part of the CI pipeline.
+
+[the instructions on the `pre-commit` website]: https://pre-commit.com/#installation
 
 ## Copyright
 


### PR DESCRIPTION
I took the hooks we use in our Poetry template as a starting point, removed the Python-specific ones and added a formatter for Rust.

I initially tried to set up this repo with [pre-commit.ci](https://pre-commit.ci), but unfortunately the Rust formatter requires the `rustfmt` tool to be installed and there doesn't appear to be a way to install extra arbitrary software into the pre-commit.ci containers. They do, however, provide a GitHub Action which automatically applies fixes from `pre-commit`, so we can replicate the functionality that way.

Closes #4.