### PR TITLE
Add clippy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
       - id: pretty-format-toml
         args: [--autofix, --indent, "4", --no-sort]
       - id: pretty-format-rust
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: clippy
+        args: [--fix, --allow-dirty, --allow-staged]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,8 @@ repos:
     rev: v1.0
     hooks:
       - id: clippy
-        args: [--fix, --allow-dirty, --allow-staged, --, -D, clippy::all]
+        # Warnings can be suppressed by adding "-A clippy::some_warning" to args
+        args: [--fix, --allow-dirty, --allow-staged, --, -D, clippy::all, -A, clippy::precedence]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v1.0
     hooks:
       - id: clippy
-        args: [--fix, --allow-dirty, --allow-staged]
+        args: [--fix, --allow-dirty, --allow-staged, --, -D, clippy::all]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
Clippy is a static analyser to catch common stylistic problems. It is bundled with Rust's default tools. More information is available here: https://doc.rust-lang.org/stable/clippy/index.html

This PR adds a `pre-commit` hook for automatically checking code with clippy. I was in two minds about whether a running a static analyser with every commit might make things irritatingly slow, but the code base is tiny for now, so the overhead is minimal, and if it does ever become a pain, we can always disable it and just run clippy as a GitHub Action instead. For Rust learners (like me) it probably is quite helpful to have these stylistic issues flagged up interactively anyway.

Closes #22.