### PR TITLE
Don't make `build_and_test` workflow depend on `coverage`

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -38,7 +38,6 @@ jobs:
           fail_ci_if_error: true
 
   build_and_test:
-    needs: coverage
     name: MUSE 2.0
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
These tasks can proceed in parallel. With this option in here, it means that the Windows and macOS tests will only be run after the Linux ones have completed (and successfully too).