### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ensure that all PRs must be approved by at least one of the below
+* @alexdewar @dalonsoa


### PR DESCRIPTION
The CODEOWNERS file ensures that certain users must have given approving reviews before PRs can be merged.

I have listed myself and @dalonsoa for now. Obviously we can add or remove people as needed.

@ahawkes I would have listed you too, but apparently if you're a "code owner" you're automatically flagged as a reviewer on every PR, which I didn't think you'd want.