### PR TITLE
Add workflow to deploy API docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Build and publish docs
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Setup pages
+        uses: actions/configure-pages@v4
+      - name: Build docs
+        run: cargo doc --no-deps
+      - name: Add redirect
+        run: echo '<meta http-equiv="refresh" content="0;url=muse2/index.html">' > target/doc/index.html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 MUSE 2.0 is a tool for running simulations of energy systems, written in Rust. It is a slimmer and
 faster version of [the older MUSE tool].
 
+Documentation is available on our [GitHub Pages site].
+
 :construction: Note that this repository is under heavy development and not suitable for end users!
 :construction:
 
 [the older MUSE tool]: https://github.com/EnergySystemsModellingLab/MUSE_OS
+[GitHub Pages site]: https://energysystemsmodellinglab.github.io/MUSE_2.0
 
 ## Getting started
 

--- a/src/muse2/settings.rs
+++ b/src/muse2/settings.rs
@@ -14,7 +14,7 @@ struct Settings {
     input_files: InputFiles,
 }
 
-/// Represents the [input_files] section of the settings file.
+/// Represents the "input_files" section of the settings file.
 #[derive(Debug, Deserialize, PartialEq)]
 struct InputFiles {
     /// Path to CSV file containing variable definitions


### PR DESCRIPTION
For now, I'm just publishing the API docs to GitHub Pages. We do also want to publish a manual (#36) but I'll do this in a separate PR.

I temporarily bypassed the environment protection rules to deploy from this branch so I could check that it worked. The result is here: https://energysystemsmodellinglab.github.io/MUSE_2.0/muse2/index.html

Closes #15.