### PR TITLE
CI tweaks and add caching for cargo

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -28,6 +28,8 @@ jobs:
           apt update
           apt install -y cmake libclang-dev
 
+      - run: cargo build --verbose
+
       - name: Generate code coverage
         run: |
           cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   coverage:
-    name: test with coverage
+    name: Build and test with coverage
     runs-on: ubuntu-latest
     env:
       # **HACK**: Explicitly link against zlib to avoid linking failure
@@ -38,7 +38,7 @@ jobs:
           fail_ci_if_error: true
 
   build_and_test:
-    name: MUSE 2.0
+    name: Build and test
     runs-on: ${{ matrix.os }}
     env:
       # Make warnings fatal

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -13,8 +13,9 @@ jobs:
     name: Build and test with coverage
     runs-on: ubuntu-latest
     env:
+      # Make warnings fatal
       # **HACK**: Explicitly link against zlib to avoid linking failure
-      RUSTFLAGS: -lz
+      RUSTFLAGS: -D warnings -lz
     container:
       image: xd009642/tarpaulin:develop-nightly
       options: --security-opt seccomp=unconfined

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -58,6 +58,7 @@ jobs:
       # Make warnings fatal
       RUSTFLAGS: -D warnings
     strategy:
+      fail-fast: false
       matrix:
         ## macOS runner is currently failing: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/43
         # os: [windows-latest, macos-latest]

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -23,6 +23,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cargo Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ubuntu-latest-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ubuntu-latest-cargo-${{ hashFiles('Cargo.toml') }}
+            ubuntu-latest-cargo
+
       - name: Install dependencies
         run: |
           apt update
@@ -55,6 +66,16 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v4
+      - name: Cargo Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ matrix.os }}-cargo
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}


### PR DESCRIPTION
This PR enables caching for cargo artifacts on GitHub Actions, which should drastically speed things up (currently we're building some very big libraries from source every time the CI runs).

Commit summary:

- **CI: Use better names for actions**
- **CI: Also make warnings fatal for Ubuntu runner**
- **CI: Also test-build application on Ubuntu runner**
- **CI: Enable caching of cargo artifacts**

Closes #41.

Tagging @cc-a in case you're interested!