### PR TITLE
CI: Temporarily disable macOS runner

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -45,7 +45,9 @@ jobs:
       RUSTFLAGS: -D warnings
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        ## macOS runner is currently failing: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/43
+        # os: [windows-latest, macos-latest]
+        os: [windows-latest]
         toolchain:
           - stable
     steps:


### PR DESCRIPTION
The macOS runner is currently failing, for reasons unknown (#43).

It seems to be something to do with the `highs` crate and I've raised an issue upstream, but for now, let's just disable the macOS runner so it isn't a blocker.