### PR TITLE
`time_slices.csv`: Put time of day in separate column

### DIFF
--- a/examples/simple/time_slices.csv
+++ b/examples/simple/time_slices.csv
@@ -1,5 +1,17 @@
-Season,Night,Day,Peak,Evening
-winter,0.072916667,0.104166667,0.03125,0.041666667
-peak,0.072916667,0.104166667,0.03125,0.041666667
-summer,0.072916667,0.104166667,0.03125,0.041666667
-autumn,0.072916667,0.104166667,0.03125,0.041666667
+Season,Time of Day,Value
+winter,night,0.072916667
+winter,day,0.104166667
+winter,peak,0.03125
+winter,evening,0.041666667
+peak,night,0.072916667
+peak,day,0.104166667
+peak,peak,0.03125
+peak,evening,0.041666667
+summer,night,0.072916667
+summer,day,0.104166667
+summer,peak,0.03125
+summer,evening,0.041666667
+autumn,night,0.072916667
+autumn,day,0.104166667
+autumn,peak,0.03125
+autumn,evening,0.041666667

--- a/examples/simple/time_slices.csv
+++ b/examples/simple/time_slices.csv
@@ -1,4 +1,4 @@
-Season,Time of Day,Value
+Season,Time of Day,Length
 winter,night,0.072916667
 winter,day,0.104166667
 winter,peak,0.03125


### PR DESCRIPTION
Currently it is assumed that the number of times of day will be the same for every season, but according to @ahawkes we may want more flexibility.

Accordingly, I've updated `time_slices.csv` to have three columns: season, time of day and value.

Fixes #65.

I used the following Python script to generate this file from the original settings.toml file:

```py
import pandas as pd
import tomllib

def main(file_path):
    print(f"loading {file_path}")
    with open(file_path, "rb") as f:
        data = tomllib.load(f)

    time_slices = data["time_slices"]

    rows_list = []
    for season, tod_dict in time_slices.items():
        for tod, value in tod_dict.items():
            rows_list.append([season, tod, value])

    df = pd.DataFrame(rows_list, columns=["Season", "Time of Day", "Value"])
    df.to_csv("time_slices.csv", index=False)

if __name__ == "__main__":
    import sys

    main(sys.argv[1])
```