### PR TITLE
Re-enable testing on macOS

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -60,9 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ## macOS runner is currently failing: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/43
-        # os: [windows-latest, macos-latest]
-        os: [windows-latest]
+        os: [windows-latest, macos-latest]
         toolchain:
           - stable
     steps:


### PR DESCRIPTION
I've noticed that @Ashmit8583 is using macOS, so given that we have at least one mac user, we probably need to be testing this platform too.

As this code isn't using the `highs` crate anymore, there won't be build failures (see https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/43). That said, it also seems like the HiGHS example code is also working with macOS again (I've opened a PR: https://github.com/EnergySystemsModellingLab/highs-example-rust/pull/3)!

I'm still unsure of what the problem was (no one has replied to me in the upstream repo: https://github.com/rust-or/highs/issues/17), but at least it's working now.