### PR TITLE
Add metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "muse2"
 version = "0.1.0"
+authors = ["Hawkes Research Group @ Chemical Engineering, Imperial College London <a.hawkes@imperial.ac.uk>", "Imperial College London RSE Team <ict-rse-team@imperial.ac.uk>"]
 edition = "2021"
+description = "A tool for running simulations of energy systems"
+documentation = "https://energysystemsmodellinglab.github.io/MUSE_2.0"
+readme = "README.md"
+repository = "https://github.com/EnergySystemsModellingLab/MUSE_2.0"
+license = "GPL-3.0-only"
+keywords = ["energy", "modelling"]
+categories = ["science", "simulation", "command-line-utilities"]
 
 [dependencies]
 csv = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse2"
-version = "0.1.0"
+version = "2.0.0-dev1"
 authors = ["Hawkes Research Group @ Chemical Engineering, Imperial College London <a.hawkes@imperial.ac.uk>", "Imperial College London RSE Team <ict-rse-team@imperial.ac.uk>"]
 edition = "2021"
 description = "A tool for running simulations of energy systems"


### PR DESCRIPTION
# Description

This PR adds some additional metadata to `Cargo.toml`. This information is used to describe Rust packages on https://crates.io/ where we will probably want to publish MUSE 2.0 at some point.

Some of the information was lifted from MUSE v1's manifest.

@ahawkes Would you mind checking that you're happy with the description etc.?

Closes #9.