### PR TITLE
pre-commit: Automatically reformat Rust files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: pretty-format-toml
         args: [--autofix, --indent, "4", --no-sort]
       - id: pretty-format-rust
+        args: [--autofix]
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:


### PR DESCRIPTION
Reported by @ahawkes.

Currently an error message is displayed if the formatting is not correct, but files are not automatically reformated. Let's fix that.

The reason I didn't notice sooner is because we have the VS Code settings for this project set to autoformat Rust files on save, but we shouldn't rely on this!