### PR TITLE
Tidy settings error handling

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -40,11 +41,10 @@ pub struct MilestoneYears {
 }
 
 /// Read a settings file from the given path.
-fn read_settings_file(path: &Path) -> Settings {
-    let config_str = fs::read_to_string(path)
-        .unwrap_or_else(|err| panic!("Failed to read file {:?}: {:?}", path, err));
-    toml::from_str(&config_str)
-        .unwrap_or_else(|err| panic!("Could not parse settings file: {:?}", err))
+fn read_settings_file(path: &Path) -> Result<Settings, Box<dyn Error>> {
+    let config_str = fs::read_to_string(path)?;
+    let settings: Settings = toml::from_str(&config_str)?;
+    Ok(settings)
 }
 
 /// Read settings from disk and update paths.
@@ -53,8 +53,8 @@ fn read_settings_file(path: &Path) -> Settings {
 ///
 /// * `settings_file_path`: The path to the settings TOML file (which includes paths to other
 ///                         configuration files)
-pub fn read_settings(settings_file_path: &Path) -> Settings {
-    let mut config = read_settings_file(settings_file_path);
+pub fn read_settings(settings_file_path: &Path) -> Result<Settings, Box<dyn Error>> {
+    let mut config = read_settings_file(settings_file_path)?;
 
     // For paths to other files listed in the settings file, if they're relative, we treat them as
     // relative to the folder the settings file is in.
@@ -87,7 +87,7 @@ pub fn read_settings(settings_file_path: &Path) -> Settings {
     update_path!(config.input_files.regions_file_path);
     update_path!(config.input_files.time_slices_path);
 
-    config
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -109,7 +109,8 @@ mod tests {
 
     #[test]
     fn test_read_settings_file() {
-        let settings = read_settings_file(&get_settings_file_path());
+        let settings = read_settings_file(&get_settings_file_path())
+            .expect("Failed to read read example settings file");
 
         assert_eq!(
             settings,
@@ -153,10 +154,9 @@ mod tests {
 
     #[test]
     fn test_read_settings() {
-        let settings = read_settings(&get_settings_file_path());
+        let settings =
+            read_settings(&get_settings_file_path()).expect("Failed to read example settings file");
 
         assert_eq!(settings.milestone_years.years, vec![2020]);
-
-        // Additional assertions can be added to test the absolute paths
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -42,8 +42,8 @@ pub struct MilestoneYears {
 
 /// Read a settings file from the given path.
 fn read_settings_file(path: &Path) -> Result<Settings, Box<dyn Error>> {
-    let config_str = fs::read_to_string(path)?;
-    let settings: Settings = toml::from_str(&config_str)?;
+    let settings_str = fs::read_to_string(path)?;
+    let settings: Settings = toml::from_str(&settings_str)?;
     Ok(settings)
 }
 
@@ -54,40 +54,48 @@ fn read_settings_file(path: &Path) -> Result<Settings, Box<dyn Error>> {
 /// * `settings_file_path`: The path to the settings TOML file (which includes paths to other
 ///                         configuration files)
 pub fn read_settings(settings_file_path: &Path) -> Result<Settings, Box<dyn Error>> {
-    let mut config = read_settings_file(settings_file_path)?;
+    let mut settings = read_settings_file(settings_file_path)?;
 
     // For paths to other files listed in the settings file, if they're relative, we treat them as
     // relative to the folder the settings file is in.
     let settings_dir = settings_file_path.parent().unwrap(); // will never fail
 
-    // Update the file paths in the config to be absolute paths
+    // Update the file paths in settings to be absolute paths
     macro_rules! update_path {
         ($path:expr) => {
             $path = settings_dir.join(&$path);
         };
     }
 
-    update_path!(config.input_files.agents_file_path);
-    update_path!(config.input_files.agent_objectives_file_path);
-    update_path!(config.input_files.agent_regions_file_path);
-    update_path!(config.input_files.assets_file_path);
-    update_path!(config.input_files.commodities_file_path);
-    update_path!(config.input_files.commodity_constraints_file_path);
-    update_path!(config.input_files.commodity_costs_file_path);
-    update_path!(config.input_files.demand_file_path);
-    update_path!(config.input_files.demand_slicing_file_path);
-    update_path!(config.input_files.processes_file_path);
-    update_path!(config.input_files.process_availabilities_file_path);
-    update_path!(config.input_files.process_flow_share_constraints_file_path);
-    update_path!(config.input_files.process_flows_file_path);
-    update_path!(config.input_files.process_investment_constraints_file_path);
-    update_path!(config.input_files.process_pacs_file_path);
-    update_path!(config.input_files.process_parameters_file_path);
-    update_path!(config.input_files.process_regions_file_path);
-    update_path!(config.input_files.regions_file_path);
-    update_path!(config.input_files.time_slices_path);
+    update_path!(settings.input_files.agents_file_path);
+    update_path!(settings.input_files.agent_objectives_file_path);
+    update_path!(settings.input_files.agent_regions_file_path);
+    update_path!(settings.input_files.assets_file_path);
+    update_path!(settings.input_files.commodities_file_path);
+    update_path!(settings.input_files.commodity_constraints_file_path);
+    update_path!(settings.input_files.commodity_costs_file_path);
+    update_path!(settings.input_files.demand_file_path);
+    update_path!(settings.input_files.demand_slicing_file_path);
+    update_path!(settings.input_files.processes_file_path);
+    update_path!(settings.input_files.process_availabilities_file_path);
+    update_path!(
+        settings
+            .input_files
+            .process_flow_share_constraints_file_path
+    );
+    update_path!(settings.input_files.process_flows_file_path);
+    update_path!(
+        settings
+            .input_files
+            .process_investment_constraints_file_path
+    );
+    update_path!(settings.input_files.process_pacs_file_path);
+    update_path!(settings.input_files.process_parameters_file_path);
+    update_path!(settings.input_files.process_regions_file_path);
+    update_path!(settings.input_files.regions_file_path);
+    update_path!(settings.input_files.time_slices_path);
 
-    Ok(config)
+    Ok(settings)
 }
 
 #[cfg(test)]

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 pub fn run(settings_file_path: &Path) {
     // Read and process the settings file
-    let settings = read_settings(settings_file_path);
+    let settings = read_settings(settings_file_path)
+        .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
 
     // Example usage: Accessing the milestone years
     println!("Milestone Years: {:?}", settings.milestone_years.years);


### PR DESCRIPTION
# Description

I'm currently merging the changes from #80 into my PR and I think the error-handling could be a bit tidier. No offence @Ashmit8583! This is exactly how I did things in my example code, but I've learned a bit more about error handling in Rust since then. While errors due to reading settings files should result in a panic, I think it's cleaner to pass the errors back up the callstack a bit and let the errors be dealt with in a common place in `simulation::run()`. That way we can print `"Something went wrong while loading settings: {thing that went wrong}"` rather than having `panic!`s dotted about the input reading code.

I also renamed a couple of variables for consistency.

@Ashmit8583 I've tagged you as a reviewer because this is your code so it would be good if you could take a look.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
