### PR TITLE
Generic CSV reader and non-empty collections

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,22 @@
+//! Common routines for handling input data.
+use serde::de::DeserializeOwned;
+use std::error::Error;
+use std::path::Path;
+
+/// Read a series of type Ts from a CSV file into a Vec<T>.
+///
+/// # Arguments
+///
+/// * `csv_file_path`: Path to the CSV file
+pub fn read_vec_from_csv<T: DeserializeOwned>(
+    csv_file_path: &Path,
+) -> Result<Vec<T>, Box<dyn Error>> {
+    let mut reader = csv::Reader::from_path(csv_file_path)?;
+    let mut vec = Vec::new();
+    for result in reader.deserialize() {
+        let d: T = result?;
+        vec.push(d)
+    }
+
+    Ok(vec)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! Provides the main entry point to the program.
 
+mod input;
 mod settings;
 mod simulation;
 mod time_slices;

--- a/src/time_slices.rs
+++ b/src/time_slices.rs
@@ -2,6 +2,7 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
+use crate::input::read_vec_from_csv;
 use float_cmp::approx_eq;
 use serde::Deserialize;
 use std::error::Error;
@@ -20,12 +21,7 @@ pub struct TimeSlice {
 
 /// Read time slices from a CSV file
 pub fn read_time_slices(csv_file_path: &Path) -> Result<Vec<TimeSlice>, Box<dyn Error>> {
-    let mut reader = csv::Reader::from_path(csv_file_path)?;
-    let mut time_slices = Vec::new();
-    for result in reader.deserialize() {
-        let time_slice: TimeSlice = result?;
-        time_slices.push(time_slice)
-    }
+    let time_slices = read_vec_from_csv(csv_file_path)?;
 
     if time_slices.is_empty() {
         Err("Time slices file cannot be empty")?;


### PR DESCRIPTION
# Description

Following @dalonsoa's suggestion in #94, I've had a go at a generic `read_vec_from_csv` function, which should reduce the amount of boilerplate code for other CSV readers.

While I was at it, I thought I'd see how things looked if I used the `nonempty-collections` crate to statically enforce the non-emptiness of some containers -- I've written a `read_nevec_from_csv` function to use this and I've used it for the time slices code.

I'm happy-ish with how things look, but using `NESlice`s instead of native Rust slices has introduced a bit of ugliness in the tests. Maybe it's ok there though.

Thoughts and suggestions welcome!

Closes #94. Closes #96.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
