### PR TITLE
Add program logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["science", "simulation", "command-line-utilities"]
 
 [dependencies]
 csv = "1.3.0"
+env_logger = "0.11.3"
 float-cmp = "0.9.0"
+log = "0.4.22"
 serde = {version = "1.0.202", features = ["derive"]}
 tempfile = "3.10.1"
 toml = "0.8.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ csv = "1.3.0"
 env_logger = "0.11.3"
 float-cmp = "0.9.0"
 log = "0.4.22"
+log-panics = "2.1.0"
 serde = {version = "1.0.202", features = ["derive"]}
 tempfile = "3.10.1"
 toml = "0.8.13"

--- a/examples/simple/settings.toml
+++ b/examples/simple/settings.toml
@@ -1,3 +1,6 @@
+[global]
+log_level = "info"
+
 [input_files]
 agents_file_path = "agents.csv"
 agent_objectives_file_path = "agent_objectives.csv"

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,10 +1,12 @@
 use env_logger::Env;
 
+pub(crate) const DEFAULT_LOG_LEVEL: &str = "info";
+
 /// Initialise the program logger.
 ///
-/// The user can specify their preferred logging level via the `settings.toml` file or with the
-/// `MUSE2_LOG_LEVEL` environment variable. If both are provided, the environment variable takes
-/// precedence. If neither is supplied, the default log level is `info`.
+/// The user can specify their preferred logging level via the `settings.toml` file (defaulting to
+/// `info` if not present) or with the `MUSE2_LOG_LEVEL` environment variable. If both are provided,
+/// the environment variable takes precedence.
 ///
 /// Possible options are:
 ///
@@ -22,10 +24,9 @@ use env_logger::Env;
 /// # Arguments
 ///
 /// * `log_level_from_settings`: The log level specified in `settings.toml`
-pub fn init(log_level_from_settings: Option<&str>) {
-    let fallback_log_level = log_level_from_settings.unwrap_or("info");
+pub fn init(log_level_from_settings: &str) {
     let env = Env::new()
-        .filter_or("MUSE2_LOG_LEVEL", fallback_log_level)
+        .filter_or("MUSE2_LOG_LEVEL", log_level_from_settings)
         .write_style("MUSE2_LOG_STYLE");
 
     // Initialise logger

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,12 +1,12 @@
-use std::env;
+use env_logger::Env;
 
 /// Initialise the program logger
 pub fn init() {
     // Log at the info level by default, unless the user has specified otherwise
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "info")
-    }
+    let env = Env::new()
+        .filter_or("MUSE2_LOG_LEVEL", "info")
+        .write_style("MUSE2_LOG_STYLE");
 
     // Initialise logger
-    env_logger::init();
+    env_logger::init_from_env(env);
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+/// Initialise the program logger
+pub fn init() {
+    // Log at the info level by default, unless the user has specified otherwise
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "info")
+    }
+
+    // Initialise logger
+    env_logger::init();
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,10 +1,31 @@
 use env_logger::Env;
 
-/// Initialise the program logger
-pub fn init() {
-    // Log at the info level by default, unless the user has specified otherwise
+/// Initialise the program logger.
+///
+/// The user can specify their preferred logging level via the `settings.toml` file or with the
+/// `MUSE2_LOG_LEVEL` environment variable. If both are provided, the environment variable takes
+/// precedence. If neither is supplied, the default log level is `info`.
+///
+/// Possible options are:
+///
+/// * `error`
+/// * `warn`
+/// * `info`
+/// * `debug`
+/// * `trace`
+///
+/// To choose whether or not to colourise the log output, the `MUSE2_LOG_STYLE` environment
+/// variable can be used. See [the `env_logger`
+/// documentation](https://docs.rs/env_logger/latest/env_logger/index.html#disabling-colors) for
+/// details.
+///
+/// # Arguments
+///
+/// * `log_level_from_settings`: The log level specified in `settings.toml`
+pub fn init(log_level_from_settings: Option<&str>) {
+    let fallback_log_level = log_level_from_settings.unwrap_or("info");
     let env = Env::new()
-        .filter_or("MUSE2_LOG_LEVEL", "info")
+        .filter_or("MUSE2_LOG_LEVEL", fallback_log_level)
         .write_style("MUSE2_LOG_STYLE");
 
     // Initialise logger

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! Provides the main entry point to the program.
 
 mod input;
+mod log;
 mod settings;
 mod simulation;
 mod time_slices;
@@ -10,13 +11,8 @@ use std::path::Path;
 
 /// The main entry point to the program
 fn main() {
-    // Log at the info level by default, unless the user has specified otherwise
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "info")
-    }
-
-    // Initialise logger
-    env_logger::init();
+    // Initialise program logger
+    log::init();
 
     // Parse command-line arguments
     let args: Vec<String> = env::args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,20 @@ use std::path::Path;
 
 /// The main entry point to the program
 fn main() {
+    // Log at the info level by default, unless the user has specified otherwise
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "info")
+    }
+
+    // Initialise logger
+    env_logger::init();
+
+    // Parse command-line arguments
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         panic!("Must provide path to model configuration TOML file.");
     }
 
+    // Run simulation
     simulation::run(Path::new(&args[1]))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Load settings from CSV files and verify
     let settings = reader
-        .try_into()
+        .into_settings()
         .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
 
     info!("Settings loaded successfully.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,9 @@ mod settings;
 mod simulation;
 mod time_slices;
 
+use crate::settings::SettingsReader;
+use ::log::info;
 use std::env;
-use std::path::Path;
 
 /// The main entry point to the program
 fn main() {
@@ -17,6 +18,20 @@ fn main() {
         panic!("Must provide path to model configuration TOML file.");
     }
 
+    // Read settings TOML file
+    let reader = SettingsReader::from_path(&args[1])
+        .unwrap_or_else(|err| panic!("Failed to parse TOML file: {}", err));
+
+    // Set the program log level
+    log::init(reader.log_level());
+
+    // Load settings from CSV files and verify
+    let settings = reader
+        .try_into()
+        .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
+
+    info!("Settings loaded successfully.");
+
     // Run simulation
-    simulation::run(Path::new(&args[1]))
+    simulation::run(&settings)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,6 @@ use std::path::Path;
 
 /// The main entry point to the program
 fn main() {
-    // Initialise program logger
-    log::init();
-
     // Parse command-line arguments
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
 
     // Set the program log level
     log::init(reader.log_level());
+    log_panics::init(); // Write panic info to logger rather than stderr
 
     // Load settings from CSV files and verify
     let settings = reader

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::time_slices::{read_time_slices, TimeSlice};
+use log::warn;
 use serde::Deserialize;
 use std::error::Error;
 use std::fs;
@@ -121,7 +122,7 @@ pub fn read_settings(settings_file_path: &Path) -> Result<Settings, Box<dyn Erro
         None => {
             // If there is no time slice file provided, use a default time slice which covers the
             // whole year and the whole day
-            eprintln!("WARNING: No time slices CSV file provided; using a single time slice");
+            warn!("No time slices CSV file provided; using a single time slice");
 
             vec![TimeSlice {
                 season: "all-year".to_string(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,9 +15,9 @@ pub struct Settings {
 /// Represents the contents of the entire settings file.
 #[derive(Debug, Deserialize, PartialEq)]
 struct SettingsFile {
-    pub global: Global,
-    pub input_files: InputFiles,
-    pub milestone_years: MilestoneYears,
+    global: Global,
+    input_files: InputFiles,
+    milestone_years: MilestoneYears,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -34,25 +34,25 @@ fn default_log_level() -> String {
 /// Represents the "input_files" section of the settings file.
 #[derive(Debug, Deserialize, PartialEq)]
 struct InputFiles {
-    pub agents_file_path: PathBuf,
-    pub agent_objectives_file_path: PathBuf,
-    pub agent_regions_file_path: PathBuf,
-    pub assets_file_path: PathBuf,
-    pub commodities_file_path: PathBuf,
-    pub commodity_constraints_file_path: PathBuf,
-    pub commodity_costs_file_path: PathBuf,
-    pub demand_file_path: PathBuf,
-    pub demand_slicing_file_path: PathBuf,
-    pub processes_file_path: PathBuf,
-    pub process_availabilities_file_path: PathBuf,
-    pub process_flow_share_constraints_file_path: PathBuf,
-    pub process_flows_file_path: PathBuf,
-    pub process_investment_constraints_file_path: PathBuf,
-    pub process_pacs_file_path: PathBuf,
-    pub process_parameters_file_path: PathBuf,
-    pub process_regions_file_path: PathBuf,
-    pub regions_file_path: PathBuf,
-    pub time_slices_path: Option<PathBuf>,
+    agents_file_path: PathBuf,
+    agent_objectives_file_path: PathBuf,
+    agent_regions_file_path: PathBuf,
+    assets_file_path: PathBuf,
+    commodities_file_path: PathBuf,
+    commodity_constraints_file_path: PathBuf,
+    commodity_costs_file_path: PathBuf,
+    demand_file_path: PathBuf,
+    demand_slicing_file_path: PathBuf,
+    processes_file_path: PathBuf,
+    process_availabilities_file_path: PathBuf,
+    process_flow_share_constraints_file_path: PathBuf,
+    process_flows_file_path: PathBuf,
+    process_investment_constraints_file_path: PathBuf,
+    process_pacs_file_path: PathBuf,
+    process_parameters_file_path: PathBuf,
+    process_regions_file_path: PathBuf,
+    regions_file_path: PathBuf,
+    time_slices_path: Option<PathBuf>,
 }
 
 /// Represents the "milestone_years" section of the settings file.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,7 +134,7 @@ impl SettingsReader {
         Ok(reader)
     }
 
-    fn to_settings_raw(self) -> Result<Settings, Box<dyn Error>> {
+    pub fn into_settings(self) -> Result<Settings, Box<dyn Error>> {
         let time_slices = match self.input_files.time_slices_path {
             None => {
                 // If there is no time slice file provided, use a default time slice which covers the
@@ -155,20 +155,6 @@ impl SettingsReader {
             time_slices,
             milestone_years: self.milestone_years.years,
         })
-    }
-}
-
-impl TryInto<Settings> for SettingsReader {
-    type Error = SettingsError;
-
-    /// Convert into a Settings struct.
-    fn try_into(self) -> Result<Settings, Self::Error> {
-        match self.to_settings_raw() {
-            Ok(settings) => Ok(settings),
-            Err(err) => Err(Self::Error {
-                msg: err.to_string(),
-            }),
-        }
     }
 }
 
@@ -250,9 +236,8 @@ mod tests {
 
     #[test]
     fn test_read_settings() {
-        let reader = get_settings_reader();
-        let _: Settings = reader
-            .try_into()
+        get_settings_reader()
+            .into_settings()
             .unwrap_or_else(|err| panic!("Failed to read example settings file: {:?}", err));
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -93,7 +93,6 @@ impl SettingsReader {
     /// * `path`: The path to the settings TOML file (which includes paths to other configuration
     ///           files)
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<SettingsReader, SettingsError> {
-        // let path: &Path = path;
         let mut reader = Self::from_path_raw(path.as_ref()).map_err(|err| SettingsError {
             msg: err.to_string(),
         })?;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,5 +1,6 @@
 //! High level functionality for launching a simulation.
 use crate::settings::read_settings;
+use log::info;
 use std::path::Path;
 
 /// Run the simulation
@@ -8,7 +9,7 @@ use std::path::Path;
 ///
 /// * `settings_file_path`: The path to the TOML file containing the model's configuration
 pub fn run(settings_file_path: &Path) {
-    println!("Loading settings from {:?}", settings_file_path);
+    info!("Loading settings from {:?}", settings_file_path);
 
     // Read and process the settings file
     let settings = read_settings(settings_file_path)

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,20 +1,12 @@
 //! High level functionality for launching a simulation.
-use crate::settings::read_settings;
-use log::info;
-use std::path::Path;
+use crate::settings::Settings;
 
 /// Run the simulation
 ///
 /// # Arguments:
 ///
-/// * `settings_file_path`: The path to the TOML file containing the model's configuration
-pub fn run(settings_file_path: &Path) {
-    // Read and process the settings file
-    let settings = read_settings(settings_file_path)
-        .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
-
-    info!("Settings loaded successfully.");
-
+/// * `settings`: The model settings
+pub fn run(settings: &Settings) {
     // Print the contents of settings
     // TODO: Remove this once we're actually doing something with the settings
     println!("Time slices: {:?}", settings.time_slices);

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,5 +1,6 @@
 //! High level functionality for launching a simulation.
 use crate::settings::read_settings;
+use log::info;
 use std::path::Path;
 
 /// Run the simulation
@@ -11,6 +12,8 @@ pub fn run(settings_file_path: &Path) {
     // Read and process the settings file
     let settings = read_settings(settings_file_path)
         .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
+
+    info!("Settings loaded successfully.");
 
     // Print the contents of settings
     // TODO: Remove this once we're actually doing something with the settings

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,6 +1,5 @@
 //! High level functionality for launching a simulation.
 use crate::settings::read_settings;
-use log::info;
 use std::path::Path;
 
 /// Run the simulation
@@ -9,8 +8,6 @@ use std::path::Path;
 ///
 /// * `settings_file_path`: The path to the TOML file containing the model's configuration
 pub fn run(settings_file_path: &Path) {
-    info!("Loading settings from {:?}", settings_file_path);
-
     // Read and process the settings file
     let settings = read_settings(settings_file_path)
         .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));


### PR DESCRIPTION
# Description

For various reasons, it's better to use a proper logging library rather than having print statements dotted throughout the code.

I've added `env_logger` as a dependency (it seems to be a conservative choice) and used it in a few places in the code. The default output will look something like this:

```
[2024-07-02T15:21:11Z INFO  muse2::simulation] Loading settings from "examples/simple/settings.toml"
```

We can always configure it later if we want it to look different.

Closes #91.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
