### PR TITLE
Rename columns in CSV files to use "_id" suffix

### DIFF
--- a/examples/simple/agent_objectives.csv
+++ b/examples/simple/agent_objectives.csv
@@ -1,4 +1,4 @@
-agent,objective,decision_weight,decision_lexico_tolerance
+agent_id,objective,decision_weight,decision_lexico_tolerance
 A0_GEX,LCOX,,
 A0_GPR,LCOX,,
 A0_ELC,LCOX,,

--- a/examples/simple/agent_regions.csv
+++ b/examples/simple/agent_regions.csv
@@ -1,4 +1,4 @@
-agent,region
+agent_id,region_id
 A0_GEX,GBR
 A0_GPR,GBR
 A0_ELC,GBR

--- a/examples/simple/agents.csv
+++ b/examples/simple/agents.csv
@@ -1,4 +1,4 @@
-agent,description,commodity_name,commodity_portion,search_space,decision_rule,capex_limit,annual_cost_limit
+id,description,commodity_id,commodity_portion,search_space,decision_rule,capex_limit,annual_cost_limit
 A0_GEX,Gas extractors,GASPRD,1,,single,,
 A0_GPR,Gas processors,GASNAT,1,,single,,
 A0_ELC,Electricity generators,ELCTRI,1,,single,,

--- a/examples/simple/assets.csv
+++ b/examples/simple/assets.csv
@@ -1,4 +1,4 @@
-process_name,region,agent,capacity,commission_year
+process_id,region_id,agent_id,capacity,commission_year
 GASDRV,GBR,A0_GEX,4002.26,2020
 GASPRC,GBR,A0_GPR,3782.13,2020
 WNDFRM,GBR,A0_ELC,3.964844,2020

--- a/examples/simple/commodities.csv
+++ b/examples/simple/commodities.csv
@@ -1,4 +1,4 @@
-commodity_name,description,type,timeslice_level
+id,description,type,timeslice_level
 GASPRD,Gas produced,SED,SEASON
 GASNAT,Natural gas,SED,SEASON
 ELCTRI,Electricity,SED,DAYNIGHT

--- a/examples/simple/commodity_constraints.csv
+++ b/examples/simple/commodity_constraints.csv
@@ -1,1 +1,1 @@
-constraint_name,commodity_name,region,limit_type,balance_type,year,timeslice,value
+id,commodity_id,region_id,limit_type,balance_type,year,timeslice,value

--- a/examples/simple/commodity_constraints.csv
+++ b/examples/simple/commodity_constraints.csv
@@ -1,1 +1,1 @@
-id,commodity_id,region_id,limit_type,balance_type,year,timeslice,value
+commodity_constraint,commodity_id,region_id,limit_type,balance_type,year,timeslice,value

--- a/examples/simple/commodity_costs.csv
+++ b/examples/simple/commodity_costs.csv
@@ -1,2 +1,2 @@
-commodity_name,region,balance_type,year,timeslice,value
+commodity_id,region_id,balance_type,year,timeslice,value
 CO2EMT,GBR,net,2020,ANNUAL,0.04

--- a/examples/simple/demand.csv
+++ b/examples/simple/demand.csv
@@ -1,2 +1,2 @@
-commodity_name,region,year,demand
+commodity_id,region_id,year,demand
 RSHEAT,GBR,2020,927.38

--- a/examples/simple/demand_slicing.csv
+++ b/examples/simple/demand_slicing.csv
@@ -1,4 +1,4 @@
-commodity_name,region,timeslice,fraction
+commodity_id,region_id,timeslice,fraction
 RSHEAT,GBR,winter.night,0.065498087
 RSHEAT,GBR,winter.day,0.226148097
 RSHEAT,GBR,winter.peak,0.111199678

--- a/examples/simple/process_availabilities.csv
+++ b/examples/simple/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_name,limit_type,timeslice,value
+process_id,limit_type,timeslice,value
 GASDRV,UP,,0.9
 GASPRC,UP,,0.9
 GASCGT,UP,,0.9

--- a/examples/simple/process_flow_share_constraints.csv
+++ b/examples/simple/process_flow_share_constraints.csv
@@ -1,1 +1,1 @@
-process_name,commodity_name,limit_type,timeslice,value
+process_id,commodity_id,limit_type,timeslice,value

--- a/examples/simple/process_flows.csv
+++ b/examples/simple/process_flows.csv
@@ -1,4 +1,4 @@
-process_name,commodity_name,flow,flow_type,flow_cost
+process_id,commodity_id,flow,flow_type,flow_cost
 GASDRV,GASPRD,1.0,fixed,
 GASPRC,GASPRD,-1.05,fixed,
 GASPRC,GASNAT,1.0,fixed,

--- a/examples/simple/process_investment_constraints.csv
+++ b/examples/simple/process_investment_constraints.csv
@@ -1,1 +1,1 @@
-constraint_name,process_name,region,limit_type,constraint_type,year,growth_seed_value,value
+constraint_id,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value

--- a/examples/simple/process_investment_constraints.csv
+++ b/examples/simple/process_investment_constraints.csv
@@ -1,1 +1,1 @@
-constraint_id,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value
+commodity_constraint_id,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value

--- a/examples/simple/process_investment_constraints.csv
+++ b/examples/simple/process_investment_constraints.csv
@@ -1,1 +1,1 @@
-commodity_constraint_id,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value
+process_investment_constraint,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value

--- a/examples/simple/process_pacs.csv
+++ b/examples/simple/process_pacs.csv
@@ -1,4 +1,4 @@
-process_name,pac
+process_id,pac
 GASDRV,GASPRD
 GASPRC,GASNAT
 WNDFRM,ELCTRI

--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,4 +1,4 @@
-process_name,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,cap2act
+process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,cap2act
 GASDRV,2020,2100,10.0,0.3,2.0,25,0.1,1.0
 GASPRC,2020,2100,7.0,0.21,0.5,25,0.1,1.0
 WNDFRM,2020,2100,1000.0,30.0,0.4,25,0.1,31.54

--- a/examples/simple/process_regions.csv
+++ b/examples/simple/process_regions.csv
@@ -1,4 +1,4 @@
-process_name,region
+process_id,region_id
 GASDRV,GBR
 GASPRC,GBR
 WNDFRM,GBR

--- a/examples/simple/processes.csv
+++ b/examples/simple/processes.csv
@@ -1,4 +1,4 @@
-process_name,description
+process_id,description
 GASDRV,Dry gas extraction
 GASPRC,Gas processing
 WNDFRM,Wind farm

--- a/examples/simple/regions.csv
+++ b/examples/simple/regions.csv
@@ -1,2 +1,2 @@
-region,description
+id,description
 GBR,United Kingdom


### PR DESCRIPTION
There are many places in the CSV files where rows in one file are referred to in another, e.g. commodities defined in commodities.csv are referred to via a "commodity_name" column elsewhere. Agents and regions are the exception: they're referred to with "agent" and "region", respectively.

As "name" is a little ambiguous, I've used an "id" suffix instead. In files that provide a list of these IDs (e.g. agents.csv) the column is just "id" now, which is terser and more in keeping with what databases do.

I've changed the "constraint_name" column to "commodity_constraint_id" because I think that's clearer.

Closes #101.