### PR TITLE
Make input-file errors more informative

### DIFF
--- a/src/demand.rs
+++ b/src/demand.rs
@@ -1,6 +1,5 @@
-use crate::input::read_vec_from_csv;
+use crate::input::{read_vec_from_csv, InputError};
 use serde::Deserialize;
-use std::error::Error;
 use std::path::Path;
 
 /// Represents a single demand entry in the dataset.
@@ -31,14 +30,18 @@ pub struct Demand {
 ///
 /// This function will return an error if the file cannot be opened or read, or if the CSV data
 /// cannot be parsed.
-pub fn read_demand_data(file_path: &Path) -> Result<Vec<Demand>, Box<dyn Error>> {
+pub fn read_demand_data(file_path: &Path) -> Result<Vec<Demand>, InputError> {
     let demand_data = read_vec_from_csv(file_path)?;
 
     if demand_data.is_empty() {
-        Err("Demand data file cannot be empty")?;
+        Err(InputError::new(
+            file_path,
+            "Demand data file cannot be empty",
+        ))?;
     }
 
-    // TBD add validation checks here? e.g. check not negative, apply interpolation and extrapolation rules?
+    // **TODO**: add validation checks here? e.g. check not negative, apply interpolation and
+    // extrapolation rules?
     Ok(demand_data)
 }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -24,14 +24,14 @@ pub struct Demand {
 ///
 /// # Returns
 ///
-/// This function returns a `Result` containing either a `Vec<Demand>` with the
-/// parsed demand data or a `Box<dyn Error>` if an error occurred.
+/// This function returns a `Result` containing either a `Vec<Demand>` with the parsed demand data
+/// or a `Box<dyn Error>` if an error occurred.
 ///
 /// # Errors
 ///
-/// This function will return an error if the file cannot be opened or read, or if
-/// the CSV data cannot be parsed.
-pub fn read_demand_from_csv(file_path: &Path) -> Result<Vec<Demand>, Box<dyn Error>> {
+/// This function will return an error if the file cannot be opened or read, or if the CSV data
+/// cannot be parsed.
+pub fn read_demand_data(file_path: &Path) -> Result<Vec<Demand>, Box<dyn Error>> {
     let demand_data = read_vec_from_csv(file_path)?;
 
     if demand_data.is_empty() {
@@ -70,9 +70,9 @@ COM1,West,2023,13"
     fn test_read_demand_from_csv() {
         let dir = tempdir().unwrap();
         let file_path = create_demand_file(dir.path());
-        let demands = read_demand_from_csv(&file_path).unwrap();
+        let demand_data = read_demand_data(&file_path).unwrap();
         assert_eq!(
-            demands,
+            demand_data,
             vec![
                 Demand {
                     year: 2023,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,7 @@
 //! Common routines for handling input data.
 use serde::de::DeserializeOwned;
 use std::error::Error;
+use std::fmt;
 use std::path::Path;
 
 /// Read a series of type Ts from a CSV file into a Vec<T>.
@@ -8,15 +9,38 @@ use std::path::Path;
 /// # Arguments
 ///
 /// * `csv_file_path`: Path to the CSV file
-pub fn read_vec_from_csv<T: DeserializeOwned>(
-    csv_file_path: &Path,
-) -> Result<Vec<T>, Box<dyn Error>> {
-    let mut reader = csv::Reader::from_path(csv_file_path)?;
+pub fn read_vec_from_csv<T: DeserializeOwned>(csv_file_path: &Path) -> Result<Vec<T>, InputError> {
+    let mut reader = csv::Reader::from_path(csv_file_path)
+        .map_err(|err| InputError::new(csv_file_path, &err.to_string()))?;
+
     let mut vec = Vec::new();
     for result in reader.deserialize() {
-        let d: T = result?;
+        let d: T = result.map_err(|err| InputError::new(csv_file_path, &err.to_string()))?;
         vec.push(d)
     }
 
     Ok(vec)
 }
+
+/// Indicates that an error occurred while loading a settings file.
+#[derive(Debug, Clone)]
+pub struct InputError {
+    message: String,
+}
+
+impl InputError {
+    pub fn new(file_path: &Path, message: &str) -> InputError {
+        InputError {
+            message: format!("Error reading {}: {}", file_path.to_string_lossy(), message),
+        }
+    }
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// This is needed so that InputError can be treated like standard errors are.
+impl Error for InputError {}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::demand::{read_demand_from_csv, Demand};
+use crate::demand::{read_demand_data, Demand};
 use crate::log::DEFAULT_LOG_LEVEL;
 use crate::time_slices::{read_time_slices, TimeSlice};
 use log::warn;
@@ -156,7 +156,7 @@ impl SettingsReader {
         Ok(Settings {
             time_slices,
             milestone_years: self.milestone_years.years,
-            demand_data: read_demand_from_csv(&self.input_files.demand_file_path)?,
+            demand_data: read_demand_data(&self.input_files.demand_file_path)?,
         })
     }
 }


### PR DESCRIPTION
# Description

While working on #64, it's become apparant to me that the error messages we're outputting are not as informative as they could be. Specifically, we don't indicate to the user which input files the errors relate to, which makes tracking down problems rather difficult.

In this PR, I've introduced a error type, `InputError`, which takes a file path as well as a message as an argument, so that we can notify users about this. I've updated all the input-related functions to use this as an error type.

Unrelated: I also renamed a few things in `demand.rs` for consistency.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
