### PR TITLE
Disallow empty CSV files

### DIFF
--- a/src/demand.rs
+++ b/src/demand.rs
@@ -33,13 +33,6 @@ pub struct Demand {
 pub fn read_demand_data(file_path: &Path) -> Result<Vec<Demand>, InputError> {
     let demand_data = read_vec_from_csv(file_path)?;
 
-    if demand_data.is_empty() {
-        Err(InputError::new(
-            file_path,
-            "Demand data file cannot be empty",
-        ))?;
-    }
-
     // **TODO**: add validation checks here? e.g. check not negative, apply interpolation and
     // extrapolation rules?
     Ok(demand_data)

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,6 +19,10 @@ pub fn read_vec_from_csv<T: DeserializeOwned>(csv_file_path: &Path) -> Result<Ve
         vec.push(d)
     }
 
+    if vec.is_empty() {
+        Err(InputError::new(csv_file_path, "CSV file cannot be empty"))?;
+    }
+
     Ok(vec)
 }
 

--- a/src/time_slices.rs
+++ b/src/time_slices.rs
@@ -22,15 +22,9 @@ pub struct TimeSlice {
 pub fn read_time_slices(file_path: &Path) -> Result<Vec<TimeSlice>, InputError> {
     let time_slices = read_vec_from_csv(file_path)?;
 
-    if time_slices.is_empty() {
-        Err(InputError::new(
-            file_path,
-            "Time slices file cannot be empty",
-        ))?;
-    }
-
     check_time_slice_fractions_in_range(file_path, &time_slices)?;
     check_time_slice_fractions_sum_to_one(file_path, &time_slices)?;
+
     Ok(time_slices)
 }
 


### PR DESCRIPTION
# Description

Currently, both the `read_time_slices()` and `read_demand_data()` functions return an error if there are no entries in the CSV files. Instead of doing this for every CSV reader, we can just implement this check in the generic `read_vec_from_csv()` function, which is what I've done here.

This of course makes it a general policy across all CSV files (though we could gate the check with an argument, if we wanted). I'm just wondering if we want this policy? For time slices, we disallow empty CSV files, but users can omit the `time_slices_path` option in `settings.toml` to get the default value (albeit we issue a warning). I guess for other files that are optional we want to do something similar, i.e. disallow empty CSV files but let users omit the relevant option in `settings.toml`.

Thoughts? @ahawkes @tsmbland 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
