### PR TITLE
Add support for reading (most) process-related CSV files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,7 @@ float-cmp = "0.9.0"
 log = "0.4.22"
 log-panics = "2.1.0"
 serde = {version = "1.0.202", features = ["derive"]}
+serde_string_enum = "0.2.1"
 tempfile = "3.10.1"
 toml = "0.8.13"
+unicase = "2.7.0"

--- a/examples/simple/commodities.csv
+++ b/examples/simple/commodities.csv
@@ -1,4 +1,4 @@
-id,description,type,timeslice_level
+id,description,type,time_slice_level
 GASPRD,Gas produced,SED,SEASON
 GASNAT,Natural gas,SED,SEASON
 ELCTRI,Electricity,SED,DAYNIGHT

--- a/examples/simple/commodity_constraints.csv
+++ b/examples/simple/commodity_constraints.csv
@@ -1,1 +1,1 @@
-commodity_constraint,commodity_id,region_id,limit_type,balance_type,year,timeslice,value
+commodity_constraint,commodity_id,region_id,limit_type,balance_type,year,time_slice,value

--- a/examples/simple/commodity_costs.csv
+++ b/examples/simple/commodity_costs.csv
@@ -1,2 +1,2 @@
-commodity_id,region_id,balance_type,year,timeslice,value
+commodity_id,region_id,balance_type,year,time_slice,value
 CO2EMT,GBR,net,2020,ANNUAL,0.04

--- a/examples/simple/demand_slicing.csv
+++ b/examples/simple/demand_slicing.csv
@@ -1,4 +1,4 @@
-commodity_id,region_id,timeslice,fraction
+commodity_id,region_id,time_slice,fraction
 RSHEAT,GBR,winter.night,0.065498087
 RSHEAT,GBR,winter.day,0.226148097
 RSHEAT,GBR,winter.peak,0.111199678

--- a/examples/simple/process_availabilities.csv
+++ b/examples/simple/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,limit_type,timeslice,value
+process_id,limit_type,time_slice,value
 GASDRV,UP,,0.9
 GASPRC,UP,,0.9
 GASCGT,UP,,0.9

--- a/examples/simple/process_flow_share_constraints.csv
+++ b/examples/simple/process_flow_share_constraints.csv
@@ -1,1 +1,1 @@
-process_id,commodity_id,limit_type,timeslice,value
+process_id,commodity_id,limit_type,time_slice,value

--- a/examples/simple/processes.csv
+++ b/examples/simple/processes.csv
@@ -1,4 +1,4 @@
-process_id,description
+id,description
 GASDRV,Dry gas extraction
 GASPRC,Gas processing
 WNDFRM,Wind farm

--- a/examples/simple/settings.toml
+++ b/examples/simple/settings.toml
@@ -23,4 +23,4 @@ regions_file_path = "regions.csv"
 time_slices_path = "time_slices.csv"
 
 [milestone_years]
-years = [2020]
+years = [2020, 2100]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! Common routines for handling input data.
-use serde::de::DeserializeOwned;
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
 use std::error::Error;
 use std::fmt;
@@ -25,6 +25,19 @@ pub fn read_vec_from_csv<T: DeserializeOwned>(csv_file_path: &Path) -> Result<Ve
     }
 
     Ok(vec)
+}
+
+/// Read an f64, checking that it is between 0 and 1
+pub fn deserialise_proportion<'de, D>(deserialiser: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Deserialize::deserialize(deserialiser)?;
+    if !(0.0..=1.0).contains(&value) {
+        Err(serde::de::Error::custom("Value is not between 0 and 1"))?
+    }
+
+    Ok(value)
 }
 
 #[derive(PartialEq, Debug, SerializeLabeledStringEnum, DeserializeLabeledStringEnum)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 //! Common routines for handling input data.
 use serde::de::DeserializeOwned;
+use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
 use std::error::Error;
 use std::fmt;
 use std::path::Path;
@@ -24,6 +25,16 @@ pub fn read_vec_from_csv<T: DeserializeOwned>(csv_file_path: &Path) -> Result<Ve
     }
 
     Ok(vec)
+}
+
+#[derive(PartialEq, Debug, SerializeLabeledStringEnum, DeserializeLabeledStringEnum)]
+pub enum LimitType {
+    #[string = "lo"]
+    LowerBound,
+    #[string = "up"]
+    UpperBound,
+    #[string = "fx"]
+    Equality,
 }
 
 /// Indicates that an error occurred while loading a settings file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod demand;
 mod input;
 mod log;
+mod process;
 mod settings;
 mod simulation;
 mod time_slices;

--- a/src/process.rs
+++ b/src/process.rs
@@ -22,7 +22,7 @@ macro_rules! define_id_getter {
 pub struct ProcessAvailability {
     pub process_id: String,
     pub limit_type: String,
-    pub timeslice: Option<String>,
+    pub time_slice: Option<String>,
     pub value: f64,
 }
 define_id_getter! {ProcessAvailability}

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,175 @@
+use crate::input::{read_vec_from_csv, InputError};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+trait HasProcessID {
+    fn get_process_id(&self) -> &str;
+}
+
+macro_rules! define_id_getter {
+    ($t:ty) => {
+        impl HasProcessID for $t {
+            fn get_process_id(&self) -> &str {
+                &self.process_id
+            }
+        }
+    };
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub struct ProcessAvailability {
+    pub process_id: String,
+    pub limit_type: String,
+    pub timeslice: Option<String>,
+    pub value: f64,
+}
+define_id_getter! {ProcessAvailability}
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub struct ProcessFlow {
+    pub process_id: String,
+    pub commodity_id: String,
+    pub flow: f64,
+    pub flow_type: String,
+    #[serde(deserialize_with = "deserialise_flow_cost")]
+    pub flow_cost: f64,
+}
+define_id_getter! {ProcessFlow}
+
+/// Custom deserialiser for flow cost - treat empty fields as 0.0
+fn deserialise_flow_cost<'de, D>(deserialiser: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &str = Deserialize::deserialize(deserialiser)?;
+    if s.is_empty() {
+        return Ok(0.0);
+    }
+
+    let value: f64 = s.parse().map_err(serde::de::Error::custom)?;
+    Ok(value)
+}
+
+/// Primary Activity Commodity
+#[derive(PartialEq, Debug, Deserialize)]
+struct ProcessPAC {
+    process_id: String,
+    pac: String,
+}
+define_id_getter! {ProcessPAC}
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub struct ProcessParameter {
+    pub process_id: String,
+    pub start_year: u32,
+    pub end_year: u32,
+    pub capital_cost: f64,
+    pub fixed_operating_cost: f64,
+    pub variable_operating_cost: f64,
+    pub lifetime: u32,
+    pub discount_rate: f64,
+    pub cap2act: f64,
+}
+define_id_getter! {ProcessParameter}
+
+#[derive(PartialEq, Debug, Deserialize)]
+struct ProcessRegion {
+    process_id: String,
+    region_id: String,
+}
+define_id_getter! {ProcessRegion}
+
+#[derive(PartialEq, Debug, Deserialize)]
+struct ProcessDescription {
+    id: String,
+    description: String,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Process {
+    pub id: String,
+    pub description: String,
+    pub availabilities: Vec<ProcessAvailability>,
+    pub flows: Vec<ProcessFlow>,
+    pub pacs: Vec<String>,
+    pub parameters: Vec<ProcessParameter>,
+    pub regions: Vec<String>,
+}
+
+/// Read a CSV file, grouping the entries by process ID
+fn read_csv_grouped_by_id<'a, T>(
+    file_path: &Path,
+    process_ids: &'a HashSet<String>,
+) -> Result<HashMap<&'a str, Vec<T>>, InputError>
+where
+    T: HasProcessID + DeserializeOwned,
+{
+    let vec: Vec<T> = read_vec_from_csv(file_path)?;
+    let mut map = HashMap::new();
+    for elem in vec.into_iter() {
+        let elem_id = elem.get_process_id();
+        let id = match process_ids.get(elem_id) {
+            None => Err(InputError::new(
+                file_path,
+                &format!("Process ID {} not present in processes CSV file", elem_id),
+            ))?,
+            Some(id) => id.as_str(),
+        };
+
+        match map.get_mut(&id) {
+            None => {
+                map.insert(id, vec![elem]);
+            }
+            Some(vec) => vec.push(elem),
+        }
+    }
+
+    Ok(map)
+}
+
+/// Read process information from the specified CSV files
+pub fn read_processes(
+    processes_file_path: &Path,
+    process_availabilities_file_path: &Path,
+    process_flows_file_path: &Path,
+    process_pacs_file_path: &Path,
+    process_parameters_file_path: &Path,
+    process_regions_file_path: &Path,
+) -> Result<Vec<Process>, InputError> {
+    let descriptions: Vec<ProcessDescription> = read_vec_from_csv(processes_file_path)?;
+    let process_ids: HashSet<String> =
+        HashSet::from_iter(descriptions.iter().map(|desc| desc.id.clone()));
+    let mut availabilities =
+        read_csv_grouped_by_id(process_availabilities_file_path, &process_ids)?;
+    let mut flows = read_csv_grouped_by_id(process_flows_file_path, &process_ids)?;
+    let mut pacs = read_csv_grouped_by_id(process_pacs_file_path, &process_ids)?;
+    let mut parameters = read_csv_grouped_by_id(process_parameters_file_path, &process_ids)?;
+    let mut regions = read_csv_grouped_by_id(process_regions_file_path, &process_ids)?;
+
+    let processes = descriptions
+        .into_iter()
+        .map(|desc| Process {
+            id: desc.id.clone(),
+            description: desc.description,
+            availabilities: availabilities.remove(desc.id.as_str()).unwrap_or_default(),
+            flows: flows.remove(desc.id.as_str()).unwrap_or_default(),
+            pacs: pacs
+                .remove(desc.id.as_str())
+                .unwrap_or_default()
+                .into_iter()
+                .map(|pacs: ProcessPAC| pacs.pac)
+                .collect(),
+            parameters: parameters.remove(desc.id.as_str()).unwrap_or_default(),
+            regions: regions
+                .remove(desc.id.as_str())
+                .unwrap_or_default()
+                .into_iter()
+                .map(|region: ProcessRegion| region.region_id)
+                .collect(),
+        })
+        .collect();
+
+    Ok(processes)
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,4 @@
-use crate::input::{read_vec_from_csv, InputError};
+use crate::input::{read_vec_from_csv, InputError, LimitType};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
@@ -22,7 +22,7 @@ macro_rules! define_id_getter {
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct ProcessAvailability {
     pub process_id: String,
-    pub limit_type: String,
+    pub limit_type: LimitType,
     pub time_slice: Option<String>,
     pub value: f64,
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -274,7 +274,7 @@ pub fn read_processes(
                     .remove(id.as_str())
                     .unwrap_or_default()
                     .into_iter()
-                    .map(|pacs: ProcessPAC| pacs.pac)
+                    .map(|p: ProcessPAC| p.pac)
                     .collect(),
                 parameters: parameters.remove(id.as_str()).unwrap_or_default(),
                 regions: regions

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,7 @@
 use crate::input::{read_vec_from_csv, InputError};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
+use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -27,16 +28,29 @@ pub struct ProcessAvailability {
 }
 define_id_getter! {ProcessAvailability}
 
+#[derive(PartialEq, Debug, SerializeLabeledStringEnum, DeserializeLabeledStringEnum)]
+pub enum FlowType {
+    #[string = "fixed"]
+    Fixed,
+    #[string = "flexible"]
+    Flexible,
+}
+
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct ProcessFlow {
     pub process_id: String,
     pub commodity_id: String,
     pub flow: f64,
-    pub flow_type: String,
+    #[serde(default = "default_flow_type")]
+    pub flow_type: FlowType,
     #[serde(deserialize_with = "deserialise_flow_cost")]
     pub flow_cost: f64,
 }
 define_id_getter! {ProcessFlow}
+
+fn default_flow_type() -> FlowType {
+    FlowType::Fixed
+}
 
 /// Custom deserialiser for flow cost - treat empty fields as 0.0
 fn deserialise_flow_cost<'de, D>(deserialiser: D) -> Result<f64, D::Error>

--- a/src/process.rs
+++ b/src/process.rs
@@ -58,13 +58,11 @@ fn deserialise_flow_cost<'de, D>(deserialiser: D) -> Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: &str = Deserialize::deserialize(deserialiser)?;
-    if s.is_empty() {
-        return Ok(0.0);
+    let value: Option<f64> = Deserialize::deserialize(deserialiser)?;
+    match value {
+        None => Ok(0.0),
+        Some(value) => Ok(value),
     }
-
-    let value: f64 = s.parse().map_err(serde::de::Error::custom)?;
-    Ok(value)
 }
 
 /// Primary Activity Commodity

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,4 @@
-use crate::input::{read_vec_from_csv, InputError, LimitType};
+use crate::input::{deserialise_proportion, read_vec_from_csv, InputError, LimitType};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
@@ -24,6 +24,7 @@ pub struct ProcessAvailability {
     pub process_id: String,
     pub limit_type: LimitType,
     pub time_slice: Option<String>,
+    #[serde(deserialize_with = "deserialise_proportion")]
     pub value: f64,
 }
 define_id_getter! {ProcessAvailability}

--- a/src/process.rs
+++ b/src/process.rs
@@ -76,14 +76,14 @@ define_id_getter! {ProcessPAC}
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct ProcessParameter {
     pub process_id: String,
-    pub start_year: u32,
-    pub end_year: u32,
+    pub start_year: Option<u32>,
+    pub end_year: Option<u32>,
     pub capital_cost: f64,
     pub fixed_operating_cost: f64,
     pub variable_operating_cost: f64,
     pub lifetime: u32,
-    pub discount_rate: f64,
-    pub cap2act: f64,
+    pub discount_rate: Option<f64>,
+    pub cap2act: Option<f64>,
 }
 define_id_getter! {ProcessParameter}
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -166,6 +166,19 @@ pub struct Process {
 }
 
 /// Read a CSV file, grouping the entries by process ID, applying a filter to each element
+///
+/// # Arguments
+///
+/// * `file_path`: Path to CSV file
+/// * `process_ids`: All possible process IDs
+/// * `filter`: Function to convert the deserialised CSV row into another data structure
+///
+/// `filter` must be a function which takes a file path and a deserialised CSV row as arguments,
+/// returning either another data structure or an error.
+///
+/// # Returns
+///
+/// A HashMap with process ID as a key and a vector of filtered CSV data as a value.
 fn read_csv_grouped_by_id_with_filter<'a, T, U, F>(
     file_path: &Path,
     process_ids: &'a HashSet<String>,
@@ -200,6 +213,15 @@ where
 }
 
 /// Read a CSV file, grouping the entries by process ID
+///
+/// # Arguments
+///
+/// * `file_path`: Path to CSV file
+/// * `process_ids`: All possible process IDs
+///
+/// # Returns
+///
+/// A HashMap with process ID as a key and a vector of CSV data as a value.
 fn read_csv_grouped_by_id<'a, T>(
     file_path: &Path,
     process_ids: &'a HashSet<String>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -229,7 +229,9 @@ mod tests {
                     regions_file_path: PathBuf::from_str("regions.csv").unwrap(),
                     time_slices_path: Some(PathBuf::from_str("time_slices.csv").unwrap()),
                 },
-                milestone_years: MilestoneYears { years: vec![2020] }
+                milestone_years: MilestoneYears {
+                    years: vec![2020, 2100]
+                }
             }
         )
     }
@@ -237,7 +239,7 @@ mod tests {
     #[test]
     fn test_settings_reader_from_path() {
         let reader = get_settings_reader();
-        assert_eq!(reader.milestone_years.years, vec![2020]);
+        assert_eq!(reader.milestone_years.years, vec![2020, 2100]);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,6 +87,10 @@ impl SettingsReader {
         let mut reader = Self::from_path_raw(path.as_ref())
             .map_err(|err| InputError::new(path.as_ref(), &err.to_string()))?;
 
+        if reader.milestone_years.years.is_empty() {
+            Err(InputError::new(path.as_ref(), "milestone_years is empty"))?;
+        }
+
         // For paths to other files listed in the settings file, if they're relative, we treat them as
         // relative to the folder the settings file is in.
         let settings_dir = path.as_ref().parent().unwrap(); // will never fail

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -145,6 +145,8 @@ impl SettingsReader {
 
             Some(ref path) => read_time_slices(path)?,
         };
+
+        let years = &self.milestone_years.years;
         let processes = read_processes(
             &paths.processes_file_path,
             &paths.process_availabilities_file_path,
@@ -152,6 +154,7 @@ impl SettingsReader {
             &paths.process_pacs_file_path,
             &paths.process_parameters_file_path,
             &paths.process_regions_file_path,
+            *years.first().unwrap()..=*years.last().unwrap(),
         )?;
         let demand_data = read_demand_data(&paths.demand_file_path)?;
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -10,6 +10,7 @@ pub fn run(settings: &Settings) {
     // Print the contents of settings
     // TODO: Remove this once we're actually doing something with the settings
     println!("Demand data: {:?}", settings.demand_data);
+    println!("Processes: {:?}", settings.processes);
     println!("Time slices: {:?}", settings.time_slices);
     println!("Milestone years: {:?}", settings.milestone_years);
 }


### PR DESCRIPTION
# Description

This is a rough draft of code to read in most of the process-related CSV files. I generated the data structures with a Python script to guess the column types, then edited the results. Most of my effort was spent on integrating the data structures together, which isn't something we've done elsewhere in the codebase so far. The result is that we have a `read_processes()` function, which returns a `Vec<Process>`. Each `Process` struct also contains vectors representing its associated availabilities, flows, PACs, parameters and regions. I omitted code for reading the flow share and investment constraints files following @ahawkes' suggestion (the example files are currently also empty), but I'll open separate issues to solve these.

I also noticed that the first column in `processes.csv` is called `process_id`, whereas it should be `id`, so I've fixed that.

Questions:

* Is this way of representing the processes sensible, in terms of how we'll be using this data? While one could extract e.g. the availabilities for all processes from this data structure, it's not ideal, so if we will be accessing these vectors outside of the context of the process to which they relate, then we might want to consider alternatives.
* The `flow_cost` column in `process_flows.csv` is currently empty. I've currently assumed that that means they should all be treated as zero, but if the empty field means something else, then we should probably represent it as `None`. If we *do* want it to be zero, I'd suggest being explicit and filling the column with zeroes.

Not implemented yet:

* Unit tests
* Check for duplicate `id` values in `processes.csv`

Closes #64.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
