### PR TITLE
Document how to use the logging library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,29 +242,3 @@ pre-commit install
 
 Thereafter, a series of checks should be run every time you commit with Git. In addition, the
 `pre-commit` hooks are also run as part of the CI pipeline.
-
-### Setting the log level
-
-MUSE uses the [`env_logger`] crate for logging. The default log level is `info`, though this can be
-configured either via the `log_level` option in [`settings.toml`] or by setting the
-`MUSE2_LOG_LEVEL` environment variable. (If both are used, the environment variable takes
-precedence.)
-
-The possible options are:
-
-- `error`
-- `warn`
-- `info`
-- `debug`
-- `trace`
-- `off`
-
-By default, MUSE will colourise the log output if this is available (i.e. it is outputting to a
-terminal rather than a file), but this can be overridden by modifying the `MUSE2_LOG_STYLE`
-environment variable.
-
-For more information, please consult [the `env_logger` documentation].
-
-[`env_logger`]: https://crates.io/crates/env_logger
-[`settings.toml`]: examples/simple/settings.toml
-[the `env_logger` documentation]: https://docs.rs/env_logger/latest/env_logger

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,3 +242,29 @@ pre-commit install
 
 Thereafter, a series of checks should be run every time you commit with Git. In addition, the
 `pre-commit` hooks are also run as part of the CI pipeline.
+
+### Setting the log level
+
+MUSE uses the [`env_logger`] crate for logging. The default log level is `info`, though this can be
+configured either via the `log_level` option in [`settings.toml`] or by setting the
+`MUSE2_LOG_LEVEL` environment variable. (If both are used, the environment variable takes
+precedence.)
+
+The possible options are:
+
+- `error`
+- `warn`
+- `info`
+- `debug`
+- `trace`
+- `off`
+
+By default, MUSE will colourise the log output if this is available (i.e. it is outputting to a
+terminal rather than a file), but this can be overridden by modifying the `MUSE2_LOG_STYLE`
+environment variable.
+
+For more information, please consult [the `env_logger` documentation].
+
+[`env_logger`]: https://crates.io/crates/env_logger
+[`settings.toml`]: examples/simple/settings.toml
+[the `env_logger` documentation]: https://docs.rs/env_logger/latest/env_logger

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,4 +2,4 @@
 
 [Introduction](./introduction.md)
 
-- [Chapter 1](./chapter_1.md)
+- [User Guide](./user_guide.md)

--- a/docs/chapter_1.md
+++ b/docs/chapter_1.md
@@ -1,3 +1,0 @@
-# Chapter 1
-
-[Insert content here.]

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,7 +3,10 @@
 MUSE 2.0 is a tool for running simulations of energy systems, written in Rust. It is a slimmer and
 faster version of [the older MUSE tool].
 
+To get started, please look at the [user guide].
+
 The [API docs are available here].
 
 [the older MUSE tool]: https://github.com/EnergySystemsModellingLab/MUSE_OS
+[user guide]: ./user_guide.md
 [API docs are available here]: ./api/muse2

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,27 @@
+# User Guide
+
+## Setting the log level
+
+MUSE uses the [`env_logger`] crate for logging. The default log level is `info`, though this can be
+configured either via the `log_level` option in [`settings.toml`] or by setting the
+`MUSE2_LOG_LEVEL` environment variable. (If both are used, the environment variable takes
+precedence.)
+
+The possible options are:
+
+- `error`
+- `warn`
+- `info`
+- `debug`
+- `trace`
+- `off`
+
+By default, MUSE will colourise the log output if this is available (i.e. it is outputting to a
+terminal rather than a file), but this can be overridden by modifying the `MUSE2_LOG_STYLE`
+environment variable.
+
+For more information, please consult [the `env_logger` documentation].
+
+[`env_logger`]: https://crates.io/crates/env_logger
+[`settings.toml`]: ../examples/simple/settings.toml
+[the `env_logger` documentation]: https://docs.rs/env_logger/latest/env_logger

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,10 @@
+{
+    "httpHeaders": [
+        {
+            "urls": ["https://crates.io/"],
+            "headers": {
+                "Accept": "text/html"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Description

As suggested by @ahawkes, this PR documents how to configure the program logger. I've put it in `CONTRIBUTING.md` for now. At some point, we should probably move developer/user documentation to the `docs` folder so it will appear on our GitHub Pages, but that's a job for another day.

Note that there isn't currently a way to tell MUSE itself to write the log to a file (see discussion in #110).

Closes #111.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
