### PR TITLE
Separate model and program settings

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
           apt install -y cmake libclang-dev
 
       - name: Check docs
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --document-private-items
 
       - run: cargo build --verbose
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           mdbook build
       - name: Build API docs
         run: |
-          cargo doc --no-deps
+          cargo doc --no-deps --document-private-items
 
           # Put API documentation in with book
           rm -r book/api/*

--- a/examples/simple/model.toml
+++ b/examples/simple/model.toml
@@ -1,0 +1,2 @@
+[milestone_years]
+years = [2020, 2100]

--- a/examples/simple/settings.toml
+++ b/examples/simple/settings.toml
@@ -1,5 +1,2 @@
-[global]
-log_level = "info"
-
-[milestone_years]
-years = [2020, 2100]
+# Modify this file if you want to change your program settings
+# log_level = "info"

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -1,4 +1,4 @@
-use crate::input::{read_vec_from_csv, InputError};
+use crate::input::{read_vec_from_csv, InputResult};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -32,7 +32,7 @@ pub struct Demand {
 ///
 /// This function will return an error if the file cannot be opened or read, or if the CSV data
 /// cannot be parsed.
-pub fn read_demand_data(model_dir: &Path) -> Result<Vec<Demand>, InputError> {
+pub fn read_demand_data(model_dir: &Path) -> InputResult<Vec<Demand>> {
     let demand_data = read_vec_from_csv(&model_dir.join(DEMAND_FILE_NAME))?;
 
     // **TODO**: add validation checks here? e.g. check not negative, apply interpolation and

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,12 +12,11 @@ use std::path::Path;
 ///
 /// * `file_path` - Path to the CSV file
 pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> Result<Vec<T>, InputError> {
-    let mut reader = csv::Reader::from_path(file_path)
-        .map_err(|err| InputError::new(file_path, &err.to_string()))?;
+    let mut reader = csv::Reader::from_path(file_path).map_input_err(file_path)?;
 
     let mut vec = Vec::new();
     for result in reader.deserialize() {
-        let d: T = result.map_err(|err| InputError::new(file_path, &err.to_string()))?;
+        let d: T = result.map_input_err(file_path)?;
         vec.push(d)
     }
 
@@ -34,9 +33,8 @@ pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> Result<Vec<T>
 ///
 /// * `file_path` - Path to the TOML file
 pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> Result<T, InputError> {
-    let toml_str = fs::read_to_string(file_path)
-        .map_err(|err| InputError::new(file_path, &err.to_string()))?;
-    toml::from_str(&toml_str).map_err(|err| InputError::new(file_path, &err.to_string()))
+    let toml_str = fs::read_to_string(file_path).map_input_err(file_path)?;
+    toml::from_str(&toml_str).map_input_err(file_path)
 }
 
 /// Read an f64, checking that it is between 0 and 1
@@ -84,6 +82,18 @@ impl fmt::Display for InputError {
 
 /// This is needed so that InputError can be treated like standard errors are.
 impl Error for InputError {}
+
+/// A trait allowing us to add the map_input_err method to `Result`s
+pub trait MapInputError<T> {
+    /// Maps a `Result` with an arbitrary `Error` type to a `Result<T, InputError>`
+    fn map_input_err(self, file_path: &Path) -> Result<T, InputError>;
+}
+
+impl<T, E: Error> MapInputError<T> for Result<T, E> {
+    fn map_input_err(self, file_path: &Path) -> Result<T, InputError> {
+        self.map_err(|err| InputError::new(file_path, &err.to_string()))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,28 +3,40 @@ use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
 use std::error::Error;
 use std::fmt;
+use std::fs;
 use std::path::Path;
 
 /// Read a series of type `T`s from a CSV file into a `Vec<T>`.
 ///
 /// # Arguments
 ///
-/// * `csv_file_path` - Path to the CSV file
-pub fn read_vec_from_csv<T: DeserializeOwned>(csv_file_path: &Path) -> Result<Vec<T>, InputError> {
-    let mut reader = csv::Reader::from_path(csv_file_path)
-        .map_err(|err| InputError::new(csv_file_path, &err.to_string()))?;
+/// * `file_path` - Path to the CSV file
+pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> Result<Vec<T>, InputError> {
+    let mut reader = csv::Reader::from_path(file_path)
+        .map_err(|err| InputError::new(file_path, &err.to_string()))?;
 
     let mut vec = Vec::new();
     for result in reader.deserialize() {
-        let d: T = result.map_err(|err| InputError::new(csv_file_path, &err.to_string()))?;
+        let d: T = result.map_err(|err| InputError::new(file_path, &err.to_string()))?;
         vec.push(d)
     }
 
     if vec.is_empty() {
-        Err(InputError::new(csv_file_path, "CSV file cannot be empty"))?;
+        Err(InputError::new(file_path, "CSV file cannot be empty"))?;
     }
 
     Ok(vec)
+}
+
+/// Parse a TOML file at the specified path.
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the TOML file
+pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> Result<T, InputError> {
+    let toml_str = fs::read_to_string(file_path)
+        .map_err(|err| InputError::new(file_path, &err.to_string()))?;
+    toml::from_str(&toml_str).map_err(|err| InputError::new(file_path, &err.to_string()))
 }
 
 /// Read an f64, checking that it is between 0 and 1
@@ -125,6 +137,24 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = create_csv_file(dir.path(), "a,b\n");
         assert!(read_vec_from_csv::<Record>(&file_path).is_err());
+    }
+
+    #[test]
+    fn test_read_toml() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.toml");
+        {
+            let mut file = File::create(&file_path).unwrap();
+            writeln!(file, "a = 1\nb = \"hello\"").unwrap();
+        }
+
+        assert_eq!(
+            read_toml::<Record>(&file_path).unwrap(),
+            Record {
+                a: 1,
+                b: "hello".to_string()
+            }
+        );
     }
 
     /// Deserialise value with deserialise_proportion()

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 /// # Arguments
 ///
 /// * `file_path` - Path to the CSV file
-pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> Result<Vec<T>, InputError> {
+pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> InputResult<Vec<T>> {
     let mut reader = csv::Reader::from_path(file_path).map_input_err(file_path)?;
 
     let mut vec = Vec::new();
@@ -32,7 +32,7 @@ pub fn read_vec_from_csv<T: DeserializeOwned>(file_path: &Path) -> Result<Vec<T>
 /// # Arguments
 ///
 /// * `file_path` - Path to the TOML file
-pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> Result<T, InputError> {
+pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> InputResult<T> {
     let toml_str = fs::read_to_string(file_path).map_input_err(file_path)?;
     toml::from_str(&toml_str).map_input_err(file_path)
 }
@@ -83,14 +83,17 @@ impl fmt::Display for InputError {
 /// This is needed so that InputError can be treated like standard errors are.
 impl Error for InputError {}
 
+/// Type alias for the result of input-related functions
+pub type InputResult<T> = Result<T, InputError>;
+
 /// A trait allowing us to add the map_input_err method to `Result`s
 pub trait MapInputError<T> {
-    /// Maps a `Result` with an arbitrary `Error` type to a `Result<T, InputError>`
-    fn map_input_err(self, file_path: &Path) -> Result<T, InputError>;
+    /// Maps a `Result` with an arbitrary `Error` type to an `InputResult<T>`
+    fn map_input_err(self, file_path: &Path) -> InputResult<T>;
 }
 
 impl<T, E: Error> MapInputError<T> for Result<T, E> {
-    fn map_input_err(self, file_path: &Path) -> Result<T, InputError> {
+    fn map_input_err(self, file_path: &Path) -> InputResult<T> {
         self.map_err(|err| InputError::new(file_path, &err.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 //! High level functionality for launching the simulation.
-pub mod demand;
-pub mod input;
 pub mod log;
 pub mod model;
-pub mod process;
-pub mod region;
 pub mod settings;
-pub mod time_slice;
+
+mod demand;
+mod input;
+mod process;
+mod region;
+mod time_slice;
 
 use crate::model::Model;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,16 @@
-//! High level functionality for launching a simulation.
+//! High level functionality for launching the simulation.
+pub mod demand;
+pub mod input;
+pub mod log;
+pub mod model;
+pub mod process;
+pub mod region;
+pub mod settings;
+pub mod time_slice;
+
 use crate::model::Model;
 
-/// Run the simulation
+/// Run the simulation.
 ///
 /// # Arguments:
 ///

--- a/src/log.rs
+++ b/src/log.rs
@@ -24,9 +24,12 @@ pub(crate) const DEFAULT_LOG_LEVEL: &str = "info";
 /// # Arguments
 ///
 /// * `log_level_from_settings`: The log level specified in `settings.toml`
-pub fn init(log_level_from_settings: &str) {
+pub fn init(log_level_from_settings: Option<&str>) {
     let env = Env::new()
-        .filter_or("MUSE2_LOG_LEVEL", log_level_from_settings)
+        .filter_or(
+            "MUSE2_LOG_LEVEL",
+            log_level_from_settings.unwrap_or(DEFAULT_LOG_LEVEL),
+        )
         .write_style("MUSE2_LOG_STYLE");
 
     // Initialise logger

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,8 @@
 //! Provides the main entry point to the program.
-
-mod demand;
-mod input;
-mod log;
-mod model;
-mod process;
-mod region;
-mod settings;
-mod simulation;
-mod time_slice;
-
 use ::log::info;
-use model::Model;
-use settings::Settings;
+use muse2::log;
+use muse2::model::Model;
+use muse2::settings::Settings;
 use std::env;
 use std::path::PathBuf;
 
@@ -39,5 +29,5 @@ fn main() {
     info!("Model loaded successfully.");
 
     // Run simulation
-    simulation::run(&model)
+    muse2::run(&model)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,18 @@
 mod demand;
 mod input;
 mod log;
+mod model;
 mod process;
 mod region;
 mod settings;
 mod simulation;
 mod time_slice;
 
-use crate::settings::SettingsReader;
 use ::log::info;
+use model::Model;
+use settings::Settings;
 use std::env;
+use std::path::PathBuf;
 
 /// The main entry point to the program
 fn main() {
@@ -20,22 +23,21 @@ fn main() {
     if args.len() != 2 {
         panic!("Must provide path to model folder.");
     }
+    let model_dir = PathBuf::from(args[1].as_str());
 
-    // Read settings TOML file
-    let reader = SettingsReader::from_path(&args[1])
-        .unwrap_or_else(|err| panic!("Failed to parse TOML file: {}", err));
+    // Read program settings
+    let settings = Settings::from_path(&model_dir)
+        .unwrap_or_else(|err| panic!("Failed to load program settings: {}", err));
 
     // Set the program log level
-    log::init(reader.log_level());
+    log::init(settings.log_level.as_deref());
     log_panics::init(); // Write panic info to logger rather than stderr
 
-    // Load settings from CSV files and verify
-    let settings = reader
-        .into_settings()
-        .unwrap_or_else(|err| panic!("Failed to load settings: {}", err));
+    let model =
+        Model::from_path(&model_dir).unwrap_or_else(|err| panic!("Failed to load model: {}", err));
 
-    info!("Settings loaded successfully.");
+    info!("Model loaded successfully.");
 
     // Run simulation
-    simulation::run(&settings)
+    simulation::run(&model)
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,155 @@
+//! Code for simulation models.
+use crate::demand::{read_demand_data, Demand};
+use crate::input::{read_toml, InputError};
+use crate::process::{read_processes, Process};
+use crate::region::{read_regions_data, Region};
+use crate::time_slice::{read_time_slices, TimeSlice};
+use log::warn;
+use serde::Deserialize;
+use std::path::Path;
+
+const MODEL_FILE_NAME: &str = "model.toml";
+
+/// Model definition
+pub struct Model {
+    pub milestone_years: Vec<u32>,
+    pub processes: Vec<Process>,
+    pub time_slices: Vec<TimeSlice>,
+    pub demand_data: Vec<Demand>,
+    pub regions: Vec<Region>,
+}
+
+/// Represents the contents of the entire model file.
+#[derive(Debug, Deserialize, PartialEq)]
+struct ModelFile {
+    milestone_years: MilestoneYears,
+}
+
+/// Represents the "milestone_years" section of the model file.
+#[derive(Debug, Deserialize, PartialEq)]
+struct MilestoneYears {
+    pub years: Vec<u32>,
+}
+
+/// Check that the milestone years parameter is valid
+fn check_milestone_years(file_path: &Path, years: &[u32]) -> Result<(), InputError> {
+    if years.is_empty() {
+        Err(InputError::new(file_path, "milestone_years is empty"))?;
+    }
+
+    if !years[..years.len() - 1]
+        .iter()
+        .zip(years[1..].iter())
+        .all(|(y1, y2)| y1 < y2)
+    {
+        Err(InputError::new(
+            file_path,
+            "milestone_years must be composed of unique values in order",
+        ))?
+    }
+
+    Ok(())
+}
+
+impl ModelFile {
+    /// Read a model file from the specified directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `model_dir` - Folder containing model configuration files
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelFile, InputError> {
+        let file_path = model_dir.as_ref().join(MODEL_FILE_NAME);
+        let model_file: ModelFile = read_toml(&file_path)?;
+        check_milestone_years(&file_path, &model_file.milestone_years.years)?;
+
+        Ok(model_file)
+    }
+}
+
+impl Model {
+    /// Read a model from the specified directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `model_dir` - Folder containing model configuration files
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Model, InputError> {
+        let model_file = ModelFile::from_path(&model_dir)?;
+
+        let time_slices = match read_time_slices(model_dir.as_ref())? {
+            None => {
+                // If there is no time slice file provided, use a default time slice which covers the
+                // whole year and the whole day
+                warn!("No time slices CSV file provided; using a single time slice");
+
+                vec![TimeSlice {
+                    season: "all-year".to_string(),
+                    time_of_day: "all-day".to_string(),
+                    fraction: 1.0,
+                }]
+            }
+
+            Some(time_slices) => time_slices,
+        };
+
+        let years = &model_file.milestone_years.years;
+        let processes = read_processes(
+            model_dir.as_ref(),
+            *years.first().unwrap()..=*years.last().unwrap(),
+        )?;
+
+        Ok(Model {
+            milestone_years: model_file.milestone_years.years,
+            processes,
+            time_slices,
+            demand_data: read_demand_data(model_dir.as_ref())?,
+            regions: read_regions_data(model_dir.as_ref())?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_check_milestone_years() {
+        let p = PathBuf::new();
+        assert!(check_milestone_years(&p, &[]).is_err());
+        assert!(check_milestone_years(&p, &[1]).is_ok());
+        assert!(check_milestone_years(&p, &[1, 2]).is_ok());
+        assert!(check_milestone_years(&p, &[1, 1]).is_err());
+        assert!(check_milestone_years(&p, &[2, 1]).is_err());
+    }
+
+    #[test]
+    fn test_model_file_from_path() {
+        let dir = tempdir().unwrap();
+        {
+            let mut file = File::create(dir.path().join(MODEL_FILE_NAME)).unwrap();
+            writeln!(file, "[milestone_years]\nyears = [2020, 2100]").unwrap();
+        }
+
+        let model_file = ModelFile::from_path(dir.path()).unwrap();
+        assert_eq!(model_file.milestone_years.years, vec![2020, 2100]);
+    }
+
+    /// Get the path to the example model.
+    fn get_model_dir() -> PathBuf {
+        Path::new(file!())
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("examples")
+            .join("simple")
+    }
+
+    #[test]
+    fn test_model_from_path() {
+        Model::from_path(get_model_dir()).unwrap();
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Code for simulation models.
 use crate::demand::{read_demand_data, Demand};
-use crate::input::{read_toml, InputError};
+use crate::input::{read_toml, InputError, InputResult};
 use crate::process::{read_processes, Process};
 use crate::region::{read_regions_data, Region};
 use crate::time_slice::{read_time_slices, TimeSlice};
@@ -32,7 +32,7 @@ struct MilestoneYears {
 }
 
 /// Check that the milestone years parameter is valid
-fn check_milestone_years(file_path: &Path, years: &[u32]) -> Result<(), InputError> {
+fn check_milestone_years(file_path: &Path, years: &[u32]) -> InputResult<()> {
     if years.is_empty() {
         Err(InputError::new(file_path, "milestone_years is empty"))?;
     }
@@ -57,7 +57,7 @@ impl ModelFile {
     /// # Arguments
     ///
     /// * `model_dir` - Folder containing model configuration files
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelFile, InputError> {
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> InputResult<ModelFile> {
         let file_path = model_dir.as_ref().join(MODEL_FILE_NAME);
         let model_file: ModelFile = read_toml(&file_path)?;
         check_milestone_years(&file_path, &model_file.milestone_years.years)?;
@@ -72,7 +72,7 @@ impl Model {
     /// # Arguments
     ///
     /// * `model_dir` - Folder containing model configuration files
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Model, InputError> {
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> InputResult<Model> {
         let model_file = ModelFile::from_path(&model_dir)?;
 
         let time_slices = match read_time_slices(model_dir.as_ref())? {

--- a/src/model.rs
+++ b/src/model.rs
@@ -136,20 +136,4 @@ mod tests {
         let model_file = ModelFile::from_path(dir.path()).unwrap();
         assert_eq!(model_file.milestone_years.years, vec![2020, 2100]);
     }
-
-    /// Get the path to the example model.
-    fn get_model_dir() -> PathBuf {
-        Path::new(file!())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("examples")
-            .join("simple")
-    }
-
-    #[test]
-    fn test_model_from_path() {
-        Model::from_path(get_model_dir()).unwrap();
-    }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,5 @@
 use crate::input::{
-    deserialise_proportion, read_vec_from_csv, InputError, LimitType, MapInputError,
+    deserialise_proportion, read_vec_from_csv, InputError, InputResult, LimitType, MapInputError,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
@@ -99,7 +99,7 @@ impl ProcessParameterRaw {
         self,
         file_path: &Path,
         year_range: &RangeInclusive<u32>,
-    ) -> Result<ProcessParameter, InputError> {
+    ) -> InputResult<ProcessParameter> {
         let start_year = match self.start_year {
             None => *year_range.start(),
             Some(year) => {
@@ -189,10 +189,10 @@ fn read_csv_grouped_by_id_with_filter<'a, T, U, F>(
     file_path: &Path,
     process_ids: &'a HashSet<String>,
     filter: F,
-) -> Result<HashMap<&'a str, Vec<T>>, InputError>
+) -> InputResult<HashMap<&'a str, Vec<T>>>
 where
     U: HasProcessID + DeserializeOwned,
-    F: Fn(&Path, U) -> Result<T, InputError>,
+    F: Fn(&Path, U) -> InputResult<T>,
 {
     let vec: Vec<U> = read_vec_from_csv(file_path)?;
     let mut map = HashMap::new();
@@ -231,7 +231,7 @@ where
 fn read_csv_grouped_by_id<'a, T>(
     file_path: &Path,
     process_ids: &'a HashSet<String>,
-) -> Result<HashMap<&'a str, Vec<T>>, InputError>
+) -> InputResult<HashMap<&'a str, Vec<T>>>
 where
     T: HasProcessID + DeserializeOwned,
 {
@@ -241,7 +241,7 @@ where
 /// Read processes CSV file, which contains IDs and descriptions.
 ///
 /// Returns a map of IDs to descriptions.
-fn read_processes_file(model_dir: &Path) -> Result<HashMap<String, String>, InputError> {
+fn read_processes_file(model_dir: &Path) -> InputResult<HashMap<String, String>> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let mut reader = csv::Reader::from_path(&file_path).map_input_err(&file_path)?;
 
@@ -280,7 +280,7 @@ fn read_processes_file(model_dir: &Path) -> Result<HashMap<String, String>, Inpu
 pub fn read_processes(
     model_dir: &Path,
     year_range: RangeInclusive<u32>,
-) -> Result<Vec<Process>, InputError> {
+) -> InputResult<Vec<Process>> {
     let mut descriptions = read_processes_file(model_dir)?;
 
     // Clone the IDs into a separate set. We need to copy them as the other maps will contain

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,6 @@
-use crate::input::{deserialise_proportion, read_vec_from_csv, InputError, LimitType};
+use crate::input::{
+    deserialise_proportion, read_vec_from_csv, InputError, LimitType, MapInputError,
+};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
@@ -241,13 +243,11 @@ where
 /// Returns a map of IDs to descriptions.
 fn read_processes_file(model_dir: &Path) -> Result<HashMap<String, String>, InputError> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
-    let mut reader = csv::Reader::from_path(&file_path)
-        .map_err(|err| InputError::new(&file_path, &err.to_string()))?;
+    let mut reader = csv::Reader::from_path(&file_path).map_input_err(&file_path)?;
 
     let mut descriptions = HashMap::new();
     for result in reader.deserialize() {
-        let desc: ProcessDescription =
-            result.map_err(|err| InputError::new(&file_path, &err.to_string()))?;
+        let desc: ProcessDescription = result.map_input_err(&file_path)?;
         if descriptions.contains_key(&desc.id) {
             Err(InputError::new(
                 &file_path,

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,4 +1,4 @@
-use crate::input::{read_vec_from_csv, InputError};
+use crate::input::{read_vec_from_csv, InputResult};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -26,7 +26,7 @@ pub struct Region {
 ///
 /// This function will return an error if the file cannot be opened or read, or if the CSV data
 /// cannot be parsed.
-pub fn read_regions_data(model_dir: &Path) -> Result<Vec<Region>, InputError> {
+pub fn read_regions_data(model_dir: &Path) -> InputResult<Vec<Region>> {
     let file_path = model_dir.join(REGIONS_FILE_NAME);
     let regions_data = read_vec_from_csv(&file_path)?;
     Ok(regions_data)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 //! Code for loading program settings.
-use crate::input::{read_toml, InputError};
+use crate::input::{read_toml, InputResult};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -19,7 +19,7 @@ impl Settings {
     /// # Arguments
     ///
     /// * `model_dir` - Folder containing model configuration files
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Settings, InputError> {
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> InputResult<Settings> {
         let file_path = model_dir.as_ref().join(SETTINGS_FILE_NAME);
         if !file_path.is_file() {
             return Ok(Settings::default());

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,17 +1,16 @@
 //! High level functionality for launching a simulation.
-use crate::settings::Settings;
+use crate::model::Model;
 
 /// Run the simulation
 ///
 /// # Arguments:
 ///
-/// * `settings` - The model settings
-pub fn run(settings: &Settings) {
-    // Print the contents of settings
-    // TODO: Remove this once we're actually doing something with the settings
-    println!("Regions: {:?}", settings.regions);
-    println!("Demand data: {:?}", settings.demand_data);
-    println!("Processes: {:?}", settings.processes);
-    println!("Time slices: {:?}", settings.time_slices);
-    println!("Milestone years: {:?}", settings.milestone_years);
+/// * `model` - The model to run
+pub fn run(model: &Model) {
+    // TODO: Remove this once we're actually doing something with these values
+    println!("Regions: {:?}", model.regions);
+    println!("Demand data: {:?}", model.demand_data);
+    println!("Processes: {:?}", model.processes);
+    println!("Time slices: {:?}", model.time_slices);
+    println!("Milestone years: {:?}", model.milestone_years);
 }

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,7 +2,7 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
-use crate::input::{deserialise_proportion, read_vec_from_csv, InputError};
+use crate::input::{deserialise_proportion, read_vec_from_csv, InputError, InputResult};
 use float_cmp::approx_eq;
 use serde::Deserialize;
 use std::path::Path;
@@ -37,7 +37,7 @@ pub struct TimeSlice {
 ///
 /// This function will return an error if the file cannot be opened or read, or if the CSV data
 /// cannot be parsed.
-pub fn read_time_slices(model_dir: &Path) -> Result<Option<Vec<TimeSlice>>, InputError> {
+pub fn read_time_slices(model_dir: &Path) -> InputResult<Option<Vec<TimeSlice>>> {
     let file_path = model_dir.join(TIME_SLICES_FILE_NAME);
     if !file_path.exists() {
         return Ok(None);
@@ -53,7 +53,7 @@ pub fn read_time_slices(model_dir: &Path) -> Result<Option<Vec<TimeSlice>>, Inpu
 fn check_time_slice_fractions_sum_to_one(
     file_path: &Path,
     time_slices: &[TimeSlice],
-) -> Result<(), InputError> {
+) -> InputResult<()> {
     let sum = time_slices.iter().map(|ts| ts.fraction).sum();
     if approx_eq!(f64, sum, 1.0, epsilon = 1e-5) {
         Ok(())

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,0 +1,19 @@
+use muse2::model::Model;
+use std::path::{Path, PathBuf};
+
+/// Get the path to the example model.
+fn get_model_dir() -> PathBuf {
+    Path::new(file!())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("examples")
+        .join("simple")
+}
+
+/// An integration test which attempts to load the example model
+#[test]
+fn test_model_from_path() {
+    Model::from_path(get_model_dir()).unwrap();
+}


### PR DESCRIPTION
# Description

We want to keep the program and model configuration separate, because:

- It will the config files clearer for end users
- It makes it easier to have a proper separation of concerns in the code
- It makes it easier to share models (without having to remove user-specific preferences from your colleagues' files)

I've split up the old `settings.toml` into `settings.toml` (for program settings) and `model.toml` (for model parameters), which are processed by separate corresponding Rust modules (`settings.rs` and `model.rs`). While I was refactoring, I did some misc tidying, including adding a validity check for the milestone years (#113) and moving the one integration test we have to the a separate `tests` folder, which is apparantly best practice. In order to do the latter, I had to add a `lib.rs` file to `src`, which makes the crate both a library and a binary crate (there's no way to have external tests for a purely binary crate), following the recommendation in the Rust book: https://doc.rust-lang.org/stable/book/ch12-03-improving-error-handling-and-modularity.html#separation-of-concerns-for-binary-projects

@dalonsoa @tsmbland I know you're both busy with one thing or another, so no pressure to review this. I can work on other things in the meantime.

Closes #122. Closes #113.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
