### PR TITLE
Add Tom to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Ensure that all PRs must be approved by at least one of the below
-* @alexdewar @dalonsoa
+* @alexdewar @dalonsoa @tsmbland


### PR DESCRIPTION
Given that @tsmbland will be reviewing things while @dalonsoa is away, let's just add him to the `CODEOWNERS` file now.

If/when @dalonsoa and I stop being involved in PR reviews, we can take ourselves out of the file.

Everyone happy with this?