### PR TITLE
Make process code generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ float-cmp = "0.9.0"
 itertools = "0.13.0"
 log = "0.4.22"
 log-panics = "2.1.0"
-serde = {version = "1.0.202", features = ["derive"]}
+serde = {version = "1.0.202", features = ["derive", "rc"]}
 serde_string_enum = "0.2.1"
 tempfile = "3.10.1"
 toml = "0.8.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["science", "simulation", "command-line-utilities"]
 csv = "1.3.0"
 env_logger = "0.11.3"
 float-cmp = "0.9.0"
+itertools = "0.13.0"
 log = "0.4.22"
 log-panics = "2.1.0"
 serde = {version = "1.0.202", features = ["derive"]}

--- a/src/input.rs
+++ b/src/input.rs
@@ -111,7 +111,6 @@ pub trait HasID {
 }
 
 /// Implement the `HasID` trait for the given type, assuming it has a field called `id`
-#[macro_export]
 macro_rules! define_id_getter {
     ($t:ty) => {
         impl HasID for $t {
@@ -121,6 +120,8 @@ macro_rules! define_id_getter {
         }
     };
 }
+
+pub(crate) use define_id_getter;
 
 pub trait IDCollection {
     /// Get the ID after checking that it exists this collection. Returns a copy of the `Rc<str>` in

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,3 @@
-use crate::define_id_getter;
 use crate::input::*;
 use serde::{Deserialize, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};


### PR DESCRIPTION
# Description

This PR moves various bits of code out of `process.rs` and makes them more generic so that they can be used by other modules (e.g. it will be useful for the commodities code).

I've introduced a couple of changes to how things were implemented too:

1. I'm now using `Rc<str>` (reference counted strings) for ID values in many places. We end up using a lot of strings as the various process-related input files are read into `HashMap`s with IDs as strings and we want to avoid copying them as much as possible. An alternative is to use references with appropriate lifetimes but this is a bit more finnicky and doesn't always work (e.g. you can't have a key that refers to a field in the value of the same map).
2. I changed various functions for reading in and processing CSV data to work with iterators rather than directly with containers (e.g. `Vec`), which makes the code cleaner and more composable. Some of this has involved writing traits, which seemed odd to me at first, but I think the result is much nicer.

I also fixed #137 while I was at it.

Fixes #137.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
