### PR TITLE
Validate region IDs for processes

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -18,7 +18,7 @@ pub struct Model {
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slices: Vec<TimeSlice>,
     pub demand_data: Vec<Demand>,
-    pub regions: Vec<Region>,
+    pub regions: HashMap<Rc<str>, Region>,
 }
 
 /// Represents the contents of the entire model file.

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use crate::region::{read_regions, Region};
 use crate::time_slice::{read_time_slices, TimeSlice};
 use log::warn;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -91,9 +91,12 @@ impl Model {
             Some(time_slices) => time_slices,
         };
 
+        let regions = read_regions(model_dir.as_ref());
+        let region_ids = HashSet::from_iter(regions.keys().cloned());
         let years = &model_file.milestone_years.years;
         let processes = read_processes(
             model_dir.as_ref(),
+            &region_ids,
             *years.first().unwrap()..=*years.last().unwrap(),
         );
 
@@ -102,7 +105,7 @@ impl Model {
             processes,
             time_slices,
             demand_data: read_demand_data(model_dir.as_ref()),
-            regions: read_regions(model_dir.as_ref()),
+            regions,
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -162,25 +162,26 @@ define_id_getter! {Process}
 
 /// Read process parameters from the specified CSV file
 fn read_process_parameters(
-    file_path: &Path,
+    model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
     year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, ProcessParameter> {
+    let file_path = model_dir.join(PROCESS_PARAMETERS_FILE_NAME);
     let mut params = HashMap::new();
-    for param in read_csv::<ProcessParameterRaw>(file_path) {
-        let param = param.into_parameter(file_path, year_range);
-        let id = process_ids.get_id_checked(file_path, &param.process_id);
+    for param in read_csv::<ProcessParameterRaw>(&file_path) {
+        let param = param.into_parameter(&file_path, year_range);
+        let id = process_ids.get_id_checked(&file_path, &param.process_id);
 
         if params.insert(Rc::clone(&id), param).is_some() {
             input_panic(
-                file_path,
+                &file_path,
                 &format!("More than one parameter provided for process {id}"),
             );
         }
     }
 
     if params.len() < process_ids.len() {
-        input_panic(file_path, "Each process must have an associated parameter");
+        input_panic(&file_path, "Each process must have an associated parameter");
     }
 
     params
@@ -210,8 +211,7 @@ pub fn read_processes(
     let mut flows = read_csv_grouped_by_id(&file_path, &process_ids);
     let file_path = model_dir.join(PROCESS_PACS_FILE_NAME);
     let mut pacs = read_csv_grouped_by_id(&file_path, &process_ids);
-    let file_path = model_dir.join(PROCESS_PARAMETERS_FILE_NAME);
-    let mut parameters = read_process_parameters(&file_path, &process_ids, &year_range);
+    let mut parameters = read_process_parameters(model_dir, &process_ids, &year_range);
     let file_path = model_dir.join(PROCESS_REGIONS_FILE_NAME);
     let mut regions = read_csv_grouped_by_id(&file_path, &process_ids);
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -160,8 +160,8 @@ pub struct Process {
 }
 define_id_getter! {Process}
 
-/// Read process parameter from the specified CSV file
-fn read_process_parameter(
+/// Read process parameters from the specified CSV file
+fn read_process_parameters(
     file_path: &Path,
     process_ids: &HashSet<Rc<str>>,
     year_range: &RangeInclusive<u32>,
@@ -211,7 +211,7 @@ pub fn read_processes(
     let file_path = model_dir.join(PROCESS_PACS_FILE_NAME);
     let mut pacs = read_csv_grouped_by_id(&file_path, &process_ids);
     let file_path = model_dir.join(PROCESS_PARAMETERS_FILE_NAME);
-    let mut parameters = read_process_parameter(&file_path, &process_ids, &year_range);
+    let mut parameters = read_process_parameters(&file_path, &process_ids, &year_range);
     let file_path = model_dir.join(PROCESS_REGIONS_FILE_NAME);
     let mut regions = read_csv_grouped_by_id(&file_path, &process_ids);
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -141,7 +141,7 @@ struct ProcessRegion {
     region_id: String,
 }
 define_process_id_getter! {ProcessRegion}
-define_region_id_getter! { ProcessRegion}
+define_region_id_getter! {ProcessRegion}
 
 #[derive(PartialEq, Debug, Deserialize)]
 struct ProcessDescription {

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,6 +1,7 @@
-use crate::input::{define_id_getter, read_csv_id_file, HasID};
+use crate::input::*;
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -14,6 +15,21 @@ pub struct Region {
 }
 define_id_getter! {Region}
 
+#[derive(PartialEq, Debug)]
+pub enum RegionSelection {
+    All,
+    Some(HashSet<Rc<str>>),
+}
+
+impl RegionSelection {
+    pub fn contains(&self, region_id: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Some(regions) => regions.contains(region_id),
+        }
+    }
+}
+
 /// Reads regions from a CSV file.
 ///
 /// # Arguments
@@ -26,6 +42,88 @@ define_id_getter! {Region}
 /// region IDs.
 pub fn read_regions(model_dir: &Path) -> HashMap<Rc<str>, Region> {
     read_csv_id_file(&model_dir.join(REGIONS_FILE_NAME))
+}
+
+pub trait HasRegionID {
+    fn get_region_id(&self) -> &str;
+}
+
+macro_rules! define_region_id_getter {
+    ($t:ty) => {
+        impl HasRegionID for $t {
+            fn get_region_id(&self) -> &str {
+                &self.region_id
+            }
+        }
+    };
+}
+
+pub(crate) use define_region_id_getter;
+
+/// Try to insert a region ID into the specified map
+#[must_use]
+fn try_insert_region(
+    file_path: &Path,
+    key: Rc<str>,
+    region_id: &str,
+    region_ids: &HashSet<Rc<str>>,
+    entity_regions: &mut HashMap<Rc<str>, RegionSelection>,
+) -> bool {
+    if region_id.eq_ignore_ascii_case("all") {
+        // Valid for all regions
+        return entity_regions.insert(key, RegionSelection::All).is_none();
+    }
+
+    // Validate region_id
+    let region_id = region_ids.get_id_checked(file_path, region_id);
+
+    // Add or create entry in entity_regions
+    let selection = entity_regions
+        .entry(key)
+        .or_insert_with(|| RegionSelection::Some(HashSet::with_capacity(1)));
+
+    match selection {
+        RegionSelection::All => false,
+        RegionSelection::Some(ref mut set) => set.insert(region_id),
+    }
+}
+
+/// Read region IDs associated with a particular entity.
+///
+/// # Arguments
+///
+/// `file_path` - Path to CSV file
+/// `entity_ids` - All possible valid IDs for the entity type
+/// `region_ids` - All possible valid region IDs
+pub fn read_regions_for_entity<T>(
+    file_path: &Path,
+    entity_ids: &HashSet<Rc<str>>,
+    region_ids: &HashSet<Rc<str>>,
+) -> HashMap<Rc<str>, RegionSelection>
+where
+    T: HasID + HasRegionID + DeserializeOwned,
+{
+    let mut entity_regions = HashMap::new();
+    for record in read_csv::<T>(file_path) {
+        let key = entity_ids.get_id_checked(file_path, record.get_id());
+        let region_id = record.get_region_id();
+
+        let succeeded =
+            try_insert_region(file_path, key, region_id, region_ids, &mut entity_regions);
+
+        if !succeeded {
+            input_panic(file_path, "Invalid regions specified for entity. Must specify either unique region IDs or \"all\".")
+        }
+    }
+
+    if entity_regions.len() < entity_ids.len() {
+        input_panic(
+            file_path,
+            "At least one region must be specified per entity",
+        );
+    }
+
+    entity_regions
 }
 
 #[cfg(test)]

--- a/src/region.rs
+++ b/src/region.rs
@@ -98,7 +98,7 @@ fn read_regions_for_entity_from_iter<I, T>(
 ) -> HashMap<Rc<str>, RegionSelection>
 where
     I: Iterator<Item = T>,
-    T: HasID + HasRegionID + DeserializeOwned,
+    T: HasID + HasRegionID,
 {
     let mut entity_regions = HashMap::new();
     for entity in entity_iter {

--- a/src/region.rs
+++ b/src/region.rs
@@ -114,7 +114,11 @@ where
         );
 
         if !succeeded {
-            input_panic(file_path, "Invalid regions specified for entity. Must specify either unique region IDs or \"all\".")
+            input_panic(
+                file_path,
+                "Invalid regions specified for entity. \
+                 Must specify either unique region IDs or \"all\".",
+            )
         }
     }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,17 +1,20 @@
-use crate::input::read_csv_as_vec;
+use crate::input::{define_id_getter, read_csv_id_file, HasID};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::Path;
+use std::rc::Rc;
 
 const REGIONS_FILE_NAME: &str = "regions.csv";
 
 /// Represents a region with an ID and a longer description.
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Region {
-    pub id: String,
+    pub id: Rc<str>,
     pub description: String,
 }
+define_id_getter! {Region}
 
-/// Reads regions data from a CSV file.
+/// Reads regions from a CSV file.
 ///
 /// # Arguments
 ///
@@ -19,9 +22,10 @@ pub struct Region {
 ///
 /// # Returns
 ///
-/// This function returns a `Vec<Region>` with the parsed regions data
-pub fn read_regions(model_dir: &Path) -> Vec<Region> {
-    read_csv_as_vec(&model_dir.join(REGIONS_FILE_NAME))
+/// This function returns a `HashMap<Rc<str>, Region>` with the parsed regions data. The keys are
+/// region IDs.
+pub fn read_regions(model_dir: &Path) -> HashMap<Rc<str>, Region> {
+    read_csv_id_file(&model_dir.join(REGIONS_FILE_NAME))
 }
 
 #[cfg(test)]
@@ -53,20 +57,29 @@ AP,Asia Pacific"
         let regions = read_regions(dir.path());
         assert_eq!(
             regions,
-            vec![
-                Region {
-                    id: "NA".to_string(),
-                    description: "North America".to_string(),
-                },
-                Region {
-                    id: "EU".to_string(),
-                    description: "Europe".to_string(),
-                },
-                Region {
-                    id: "AP".to_string(),
-                    description: "Asia Pacific".to_string(),
-                },
-            ]
+            HashMap::from([
+                (
+                    "NA".into(),
+                    Region {
+                        id: "NA".into(),
+                        description: "North America".to_string(),
+                    }
+                ),
+                (
+                    "EU".into(),
+                    Region {
+                        id: "EU".into(),
+                        description: "Europe".to_string(),
+                    }
+                ),
+                (
+                    "AP".into(),
+                    Region {
+                        id: "AP".into(),
+                        description: "Asia Pacific".to_string(),
+                    }
+                ),
+            ])
         )
     }
 }


### PR DESCRIPTION
# Description

This PR adds validation for the regions associated with processes. I've written the code in a generic way so that it can be reused (in particular for reading in commodities). It allows for entering `"all"` as a region ID, which means that the process is active in every region. There is thorough error checking and I've written lots of tests for this -- so while the diff looks rather large, it is mostly because of these tests! I also added some tests that were missing for `process.rs`.

Closes #138. Closes #141.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
