### PR TITLE
Add more validation for time slices

### DIFF
--- a/examples/simple/model.toml
+++ b/examples/simple/model.toml
@@ -1,2 +1,6 @@
+[time_slices]
+seasons = ["winter", "peak", "summer", "autumn"]
+times_of_day = ["night", "day", "peak", "evening"]
+
 [milestone_years]
 years = [2020, 2100]

--- a/src/input.rs
+++ b/src/input.rs
@@ -47,13 +47,13 @@ pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> T {
 }
 
 /// Read an f64, checking that it is between 0 and 1
-pub fn deserialise_proportion<'de, D>(deserialiser: D) -> Result<f64, D::Error>
+pub fn deserialise_proportion_nonzero<'de, D>(deserialiser: D) -> Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value = Deserialize::deserialize(deserialiser)?;
-    if !(0.0..=1.0).contains(&value) {
-        Err(serde::de::Error::custom("Value is not between 0 and 1"))?
+    if !(value > 0.0 && value <= 1.0) {
+        Err(serde::de::Error::custom("Value must be > 0 and <= 1"))?
     }
 
     Ok(value)
@@ -287,20 +287,21 @@ mod tests {
         );
     }
 
-    /// Deserialise value with deserialise_proportion()
+    /// Deserialise value with deserialise_proportion_nonzero()
     fn deserialise_f64(value: f64) -> Result<f64, ValueError> {
         let deserialiser: F64Deserializer<ValueError> = value.into_deserializer();
-        deserialise_proportion(deserialiser)
+        deserialise_proportion_nonzero(deserialiser)
     }
 
     #[test]
-    fn test_deserialise_proportion() {
+    fn test_deserialise_proportion_nonzero() {
         // Valid inputs
-        assert_eq!(deserialise_f64(0.0), Ok(0.0));
+        assert_eq!(deserialise_f64(0.01), Ok(0.01));
         assert_eq!(deserialise_f64(0.5), Ok(0.5));
         assert_eq!(deserialise_f64(1.0), Ok(1.0));
 
         // Invalid inputs
+        assert!(deserialise_f64(0.0).is_err());
         assert!(deserialise_f64(-1.0).is_err());
         assert!(deserialise_f64(2.0).is_err());
         assert!(deserialise_f64(f64::NAN).is_err());

--- a/src/model.rs
+++ b/src/model.rs
@@ -104,6 +104,7 @@ impl Model {
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
+            &model_file.time_slices,
             *years.first().unwrap()..=*years.last().unwrap(),
         );
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -30,7 +30,7 @@ struct ProcessAvailabilityRaw {
     process_id: String,
     limit_type: LimitType,
     time_slice: Option<String>,
-    #[serde(deserialize_with = "deserialise_proportion")]
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     value: f64,
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -20,6 +20,12 @@ pub struct TimeSliceID {
     pub time_of_day: Rc<str>,
 }
 
+#[derive(PartialEq, Debug)]
+pub enum TimeSliceSelection {
+    AllTimeSlices,
+    SingleTimeSlice(TimeSliceID),
+}
+
 /// Ordered list of seasons and times of day for time slices
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct TimeSliceDefinitions {
@@ -62,6 +68,17 @@ impl TimeSliceDefinitions {
             season: Rc::clone(season),
             time_of_day: Rc::clone(time_of_day),
         }
+    }
+
+    pub fn get_time_slice_id_from_str(&self, file_path: &Path, time_slice: &str) -> TimeSliceID {
+        let (season, time_of_day) = time_slice.split('.').collect_tuple().unwrap_or_else(|| {
+            input_panic(
+                file_path,
+                "time_slice must be in the form season.time_of_day",
+            )
+        });
+
+        self.get_time_slice_id(file_path, season, time_of_day)
     }
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,7 +2,7 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
-use crate::input::{deserialise_proportion, input_panic, read_csv};
+use crate::input::{deserialise_proportion_nonzero, input_panic, read_csv};
 use crate::model::MODEL_FILE_NAME;
 
 use float_cmp::approx_eq;
@@ -89,7 +89,7 @@ struct TimeSliceRaw {
     /// Time of day, as a category (e.g. night, day etc.)
     time_of_day: String,
     /// The fraction of the year that this combination of season and time of day occupies
-    #[serde(deserialize_with = "deserialise_proportion")]
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     fraction: f64,
 }
 


### PR DESCRIPTION
# Description

This PR introduces better typing for time slices and adds extra validation steps, both for when reading time slice input data and processes data (which is currently the only place where time slices are used).

I've changed things so that the possible seasons and times of day are now listed in `model.toml`, rather than just being implicit from the values that appear in `time_slices.csv`. The main reason for doing this is so that the ordering is explicit and obvious (we need to know which time slices occurs after which!). Not every combination of season and time of day needs to be present in `time_slices.csv` and it is possible to have input data where it is literally impossible to know what the user's intended ordering is. So now, the ordering is specified explicitly in `model.toml` and it doesn't matter what order the rows are in `time_slices.csv` as the data will be sorted after loading.

I've introduced a new type `TimeSliceID`, which represents the name of the season and time of day for a given time slice, which is intended to be used in all the places elsewhere in the code where we refer to time slices (e.g. for processes). The existing `TimeSlice` struct contains a `TimeSliceID` and also the fraction of the year for that time slice.

I also noticed that everywhere where we are reading in proportions from input values (using the `deserialise_proportion` function), it doesn't actually make sense to accept zeroes (e.g. a time slice with a `fraction` of `0.0` doesn't mean anything), so I changed this function to disallow zeroes.

Closes #109.

(I've tagged you as a reviewer for this @AdrianDAlessandro, but no pressure. Let me know if you've had your fill of Rust!)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
