### PR TITLE
Add validation for time slices (without sorting)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,6 @@ pub fn run(model: &Model) {
     println!("Regions: {:?}", model.regions);
     println!("Demand data: {:?}", model.demand_data);
     println!("Processes: {:?}", model.processes);
-    println!("Time slices: {:?}", model.time_slices);
+    println!("Time slices: {:?}", model.time_slice_info);
     println!("Milestone years: {:?}", model.milestone_years);
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -80,6 +80,7 @@ impl Model {
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
+            &time_slice_info,
             *years.first().unwrap()..=*years.last().unwrap(),
         );
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,7 @@ use crate::demand::{read_demand_data, Demand};
 use crate::input::{read_toml, UnwrapInputError};
 use crate::process::{read_processes, Process};
 use crate::region::{read_regions, Region};
-use crate::time_slice::{read_time_slices, TimeSlice};
-use log::warn;
+use crate::time_slice::{read_time_slice_info, TimeSliceInfo};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -16,7 +15,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 pub struct Model {
     pub milestone_years: Vec<u32>,
     pub processes: HashMap<Rc<str>, Process>,
-    pub time_slices: Vec<TimeSlice>,
+    pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,
     pub regions: HashMap<Rc<str>, Region>,
 }
@@ -74,22 +73,7 @@ impl Model {
     pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Model {
         let model_file = ModelFile::from_path(&model_dir);
 
-        let time_slices = match read_time_slices(model_dir.as_ref()) {
-            None => {
-                // If there is no time slice file provided, use a default time slice which covers the
-                // whole year and the whole day
-                warn!("No time slices CSV file provided; using a single time slice");
-
-                vec![TimeSlice {
-                    season: "all-year".to_string(),
-                    time_of_day: "all-day".to_string(),
-                    fraction: 1.0,
-                }]
-            }
-
-            Some(time_slices) => time_slices,
-        };
-
+        let time_slice_info = read_time_slice_info(model_dir.as_ref());
         let regions = read_regions(model_dir.as_ref());
         let region_ids = HashSet::from_iter(regions.keys().cloned());
         let years = &model_file.milestone_years.years;
@@ -102,7 +86,7 @@ impl Model {
         Model {
             milestone_years: model_file.milestone_years.years,
             processes,
-            time_slices,
+            time_slice_info,
             demand_data: read_demand_data(model_dir.as_ref()),
             regions,
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -30,7 +30,7 @@ pub struct ProcessAvailability {
     pub process_id: String,
     pub limit_type: LimitType,
     pub time_slice: Option<String>,
-    #[serde(deserialize_with = "deserialise_proportion")]
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     pub value: f64,
 }
 define_process_id_getter! {ProcessAvailability}

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,23 +2,109 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
-use crate::input::{deserialise_proportion_nonzero, input_panic, read_csv_as_vec};
+use crate::input::*;
 use float_cmp::approx_eq;
 use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt::Display;
 use std::path::Path;
+use std::rc::Rc;
 
 const TIME_SLICES_FILE_NAME: &str = "time_slices.csv";
 
-/// Represents a single time slice in the simulation
-#[derive(PartialEq, Debug, Deserialize)]
-pub struct TimeSlice {
-    /// Which season (in the year)
-    pub season: String,
-    /// Time of day, as a category (e.g. night, day etc.)
-    pub time_of_day: String,
+/// An ID describing season and time of day
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub struct TimeSliceID {
+    pub season: Rc<str>,
+    pub time_of_day: Rc<str>,
+}
+
+impl Display for TimeSliceID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.season, self.time_of_day)
+    }
+}
+
+/// Information about the time slices in the simulation, including names and fractions
+#[derive(PartialEq, Debug)]
+pub struct TimeSliceInfo {
+    /// Names of seasons
+    pub seasons: HashSet<Rc<str>>,
+    /// Names of times of day (e.g. "evening")
+    pub times_of_day: HashSet<Rc<str>>,
     /// The fraction of the year that this combination of season and time of day occupies
+    pub fractions: HashMap<TimeSliceID, f64>,
+}
+
+impl Default for TimeSliceInfo {
+    /// The default `TimeSliceInfo` is a single time slice covering the whole year
+    fn default() -> Self {
+        let id = TimeSliceID {
+            season: "all-year".into(),
+            time_of_day: "all-day".into(),
+        };
+        let fractions = [(id.clone(), 1.0)].into_iter().collect();
+
+        Self {
+            seasons: [id.season].into_iter().collect(),
+            times_of_day: [id.time_of_day].into_iter().collect(),
+            fractions,
+        }
+    }
+}
+
+/// A time slice record retrieved from a CSV file
+#[derive(PartialEq, Debug, Deserialize)]
+struct TimeSliceRaw {
+    season: String,
+    time_of_day: String,
     #[serde(deserialize_with = "deserialise_proportion_nonzero")]
-    pub fraction: f64,
+    fraction: f64,
+}
+
+/// Get the specified `String` from `set` or insert if it doesn't exist
+fn get_or_insert(value: String, set: &mut HashSet<Rc<str>>) -> Rc<str> {
+    // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
+    match set.get(value.as_str()) {
+        Some(value) => Rc::clone(value),
+        None => {
+            let value = Rc::from(value);
+            set.insert(Rc::clone(&value));
+            value
+        }
+    }
+}
+
+/// Read time slice information from an iterator of raw time slice records
+fn read_time_slice_info_from_iter<I>(iter: I) -> Result<TimeSliceInfo, Box<dyn Error>>
+where
+    I: Iterator<Item = TimeSliceRaw>,
+{
+    let mut seasons: HashSet<Rc<str>> = HashSet::new();
+    let mut times_of_day = HashSet::new();
+    let mut fractions = HashMap::new();
+    for time_slice in iter {
+        let season = get_or_insert(time_slice.season, &mut seasons);
+        let time_of_day = get_or_insert(time_slice.time_of_day, &mut times_of_day);
+        let id = TimeSliceID {
+            season,
+            time_of_day,
+        };
+
+        if fractions.insert(id.clone(), time_slice.fraction).is_some() {
+            Err(format!("Duplicate time slice entry for {}", id))?;
+        }
+    }
+
+    // Validate data
+    check_time_slice_fractions_sum_to_one(fractions.values().cloned())?;
+
+    Ok(TimeSliceInfo {
+        seasons,
+        times_of_day,
+        fractions,
+    })
 }
 
 /// Read time slices from a CSV file.
@@ -29,32 +115,31 @@ pub struct TimeSlice {
 ///
 /// # Returns
 ///
-/// This function returns either `Some(Vec<TimeSlice>)` with the parsed time slices or, if the time
-/// slice CSV file does not exist, `None` will be returned.
-pub fn read_time_slices(model_dir: &Path) -> Option<Vec<TimeSlice>> {
+/// This function returns a `TimeSliceInfo` struct or, if the file doesn't exist, a single time
+/// slice covering the whole year (see `TimeSliceInfo::default()`).
+pub fn read_time_slice_info(model_dir: &Path) -> TimeSliceInfo {
     let file_path = model_dir.join(TIME_SLICES_FILE_NAME);
     if !file_path.exists() {
-        return None;
+        return TimeSliceInfo::default();
     }
 
-    let time_slices = read_csv_as_vec(&file_path);
-    check_time_slice_fractions_sum_to_one(&file_path, &time_slices);
-
-    Some(time_slices)
+    read_time_slice_info_from_iter(read_csv(&file_path)).unwrap_input_err(&file_path)
 }
 
 /// Check that time slice fractions sum to (approximately) one
-fn check_time_slice_fractions_sum_to_one(file_path: &Path, time_slices: &[TimeSlice]) {
-    let sum = time_slices.iter().map(|ts| ts.fraction).sum();
+fn check_time_slice_fractions_sum_to_one<I>(fractions: I) -> Result<(), Box<dyn Error>>
+where
+    I: Iterator<Item = f64>,
+{
+    let sum = fractions.sum();
     if !approx_eq!(f64, sum, 1.0, epsilon = 1e-5) {
-        input_panic(
-            file_path,
-            &format!(
-                "Sum of time slice fractions does not equal one (actual: {})",
-                sum
-            ),
-        )
+        Err(format!(
+            "Sum of time slice fractions does not equal one (actual: {})",
+            sum
+        ))?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -62,19 +147,8 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Write;
-    use std::panic::catch_unwind;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use tempfile::tempdir;
-
-    macro_rules! ts {
-        ($fraction:expr) => {
-            TimeSlice {
-                season: "summer".to_string(),
-                time_of_day: "day".to_string(),
-                fraction: $fraction,
-            }
-        };
-    }
 
     /// Create an example time slices file in dir_path
     fn create_time_slices_file(dir_path: &Path) {
@@ -92,79 +166,88 @@ autumn,evening,0.25"
     }
 
     #[test]
-    fn test_read_time_slices() {
+    fn test_read_time_slice_info() {
         let dir = tempdir().unwrap();
         create_time_slices_file(dir.path());
-        let time_slices = read_time_slices(dir.path()).unwrap();
+
+        let info = read_time_slice_info(dir.path());
         assert_eq!(
-            time_slices,
-            &[
-                TimeSlice {
-                    season: "winter".to_string(),
-                    time_of_day: "day".to_string(),
-                    fraction: 0.25
-                },
-                TimeSlice {
-                    season: "peak".to_string(),
-                    time_of_day: "night".to_string(),
-                    fraction: 0.25
-                },
-                TimeSlice {
-                    season: "summer".to_string(),
-                    time_of_day: "peak".to_string(),
-                    fraction: 0.25
-                },
-                TimeSlice {
-                    season: "autumn".to_string(),
-                    time_of_day: "evening".to_string(),
-                    fraction: 0.25
-                }
-            ]
-        )
+            info,
+            TimeSliceInfo {
+                seasons: [
+                    "winter".into(),
+                    "peak".into(),
+                    "summer".into(),
+                    "autumn".into()
+                ]
+                .into_iter()
+                .collect(),
+                times_of_day: [
+                    "day".into(),
+                    "night".into(),
+                    "peak".into(),
+                    "evening".into()
+                ]
+                .into_iter()
+                .collect(),
+                fractions: [
+                    (
+                        TimeSliceID {
+                            season: "winter".into(),
+                            time_of_day: "day".into(),
+                        },
+                        0.25,
+                    ),
+                    (
+                        TimeSliceID {
+                            season: "peak".into(),
+                            time_of_day: "night".into(),
+                        },
+                        0.25,
+                    ),
+                    (
+                        TimeSliceID {
+                            season: "summer".into(),
+                            time_of_day: "peak".into(),
+                        },
+                        0.25,
+                    ),
+                    (
+                        TimeSliceID {
+                            season: "autumn".into(),
+                            time_of_day: "evening".into(),
+                        },
+                        0.25,
+                    ),
+                ]
+                .into_iter()
+                .collect()
+            }
+        );
     }
 
     #[test]
-    #[should_panic]
-    fn test_read_time_slices_empty() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("time_slices.csv");
-        {
-            let mut file = File::create(file_path).unwrap();
-            writeln!(file, "season,time_of_day,fraction").unwrap();
-        }
-
-        read_time_slices(dir.path());
+    fn test_read_time_slice_info_non_existent() {
+        let actual = read_time_slice_info(tempdir().unwrap().path());
+        assert_eq!(actual, TimeSliceInfo::default());
     }
 
     #[test]
-    fn test_check_time_slice_fractions_sum_to_one_ok() {
-        let p = PathBuf::new();
-
+    fn test_check_time_slice_fractions_sum_to_one() {
         // Single input, valid
-        check_time_slice_fractions_sum_to_one(&p, &[ts!(1.0)]);
+        assert!(check_time_slice_fractions_sum_to_one([1.0].into_iter()).is_ok());
 
         // Multiple inputs, valid
-        check_time_slice_fractions_sum_to_one(&p, &[ts!(0.4), ts!(0.6)]);
-    }
-
-    #[test]
-    fn test_check_time_slice_fractions_sum_to_one_err() {
-        let p = PathBuf::new();
-
-        macro_rules! check_panic {
-            ($ts:expr) => {
-                assert!(catch_unwind(|| check_time_slice_fractions_sum_to_one(&p, $ts)).is_err())
-            };
-        }
+        assert!(check_time_slice_fractions_sum_to_one([0.4, 0.6].into_iter()).is_ok());
 
         // Single input, invalid
-        check_panic!(&[ts!(0.5)]);
+        assert!(check_time_slice_fractions_sum_to_one([0.5].into_iter()).is_err());
 
         // Multiple inputs, invalid
-        check_panic!(&[ts!(0.4), ts!(0.3)]);
+        assert!(check_time_slice_fractions_sum_to_one([0.4, 0.3].into_iter()).is_err());
 
         // Edge cases
-        check_panic!(&[ts!(f64::INFINITY)]);
-        check_panic!(&[ts!(f64::NAN)]);
+        assert!(check_time_slice_fractions_sum_to_one([f64::INFINITY].into_iter()).is_err());
+        assert!(check_time_slice_fractions_sum_to_one([f64::NAN].into_iter()).is_err());
     }
 }


### PR DESCRIPTION
# Description

This PR adds code to validate the time slices as they are loaded and provides some new types (`TimeSliceID`, `TimeSliceSelection`) to work with time slices safely. It adds time slice validation to the process-related code.

Following feedback for #146, I've changed things so we don't read the time slices from `model.toml`. Instead, they are just extracted from `time_slices.csv`, as before.

Closes #109.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
