### PR TITLE
Read in commodities-related CSV files

### DIFF
--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -16,7 +16,7 @@ pub struct Commodity {
     pub id: Rc<str>,
     pub description: String,
     #[serde(rename = "type")] // NB: we can't name a field type as it's a reserved keyword
-    pub commodity_type: CommodityType,
+    pub kind: CommodityType,
     pub time_slice_level: TimeSliceLevel,
 
     #[serde(skip)]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,19 +1,57 @@
-use crate::input::read_csv_as_vec;
+use crate::input::*;
 use crate::time_slice::TimeSliceLevel;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::rc::Rc;
 
 const COMMODITY_FILE_NAME: &str = "commodities.csv";
+const COMMODITY_COSTS_FILE_NAME: &str = "commodity_costs.csv";
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Commodity {
-    pub id: String,
+    pub id: Rc<str>,
     pub description: String,
     #[serde(rename = "type")] // NB: we can't name a field type as it's a reserved keyword
     pub commodity_type: CommodityType,
     pub time_slice_level: TimeSliceLevel,
+
+    #[serde(skip)]
+    pub costs: Vec<CommodityCost>,
 }
+define_id_getter! {Commodity}
+
+macro_rules! define_commodity_id_getter {
+    ($t:ty) => {
+        impl HasID for $t {
+            fn get_id(&self) -> &str {
+                &self.commodity_id
+            }
+        }
+    };
+}
+
+#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+pub enum BalanceType {
+    #[string = "net"]
+    Net,
+    #[string = "cons"]
+    Consumption,
+    #[string = "prod"]
+    Production,
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub struct CommodityCost {
+    pub commodity_id: String,
+    pub region_id: String,
+    pub balance_type: BalanceType,
+    pub year: u32,
+    pub time_slice: String,
+    pub value: f64,
+}
+define_commodity_id_getter! {CommodityCost}
 
 /// Commodity balance type
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
@@ -29,6 +67,17 @@ pub enum CommodityType {
 }
 
 /// Read commodity data from the specified model directory.
-pub fn read_commodities(model_dir: &Path) -> Vec<Commodity> {
-    read_csv_as_vec(&model_dir.join(COMMODITY_FILE_NAME))
+pub fn read_commodities(model_dir: &Path) -> HashMap<Rc<str>, Commodity> {
+    let mut commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME));
+    let commodity_ids = HashSet::from_iter(commodities.keys().cloned());
+    let mut costs =
+        read_csv_grouped_by_id(&model_dir.join(COMMODITY_COSTS_FILE_NAME), &commodity_ids);
+
+    for (id, commodity) in commodities.iter_mut() {
+        if let Some(costs) = costs.remove(id) {
+            commodity.costs = costs;
+        }
+    }
+
+    commodities
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -3,6 +3,7 @@ use crate::time_slice::TimeSliceLevel;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
+use std::ops::RangeInclusive;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -46,7 +47,7 @@ pub enum BalanceType {
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct CommodityCost {
     pub commodity_id: String,
-    pub region_id: Rc<str>,
+    pub region_id: String,
     pub balance_type: BalanceType,
     pub year: u32,
     pub time_slice: String,
@@ -67,20 +68,39 @@ pub enum CommodityType {
     OutputCommodity,
 }
 
+fn check_commodity_costs<'a, I>(
+    costs: I,
+    region_ids: &HashSet<Rc<str>>,
+    year_range: &RangeInclusive<u32>,
+) -> Result<(), String>
+where
+    I: Iterator<Item = &'a CommodityCost>,
+{
+    for cost in costs {
+        // Check region ID is valid
+        if !region_ids.contains(cost.region_id.as_str()) {
+            Err(format!("Region ID {} is invalid", cost.region_id))?;
+        }
+
+        // Check year is in range
+        if !year_range.contains(&cost.year) {
+            Err(format!("Year {} is out of range", cost.year))?;
+        }
+    }
+
+    Ok(())
+}
+
 fn read_commodity_costs(
     model_dir: &Path,
     commodity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
+    year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, Vec<CommodityCost>> {
     let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
-    let mut costs = read_csv_grouped_by_id::<CommodityCost>(&file_path, commodity_ids);
-
-    // Check region IDs
-    for cost in costs.values_mut().flatten() {
-        cost.region_id = region_ids
-            .get_id(&cost.region_id)
-            .unwrap_input_err(&file_path);
-    }
+    let costs = read_csv_grouped_by_id::<CommodityCost>(&file_path, commodity_ids);
+    check_commodity_costs(costs.values().flatten(), region_ids, year_range)
+        .unwrap_input_err(&file_path);
 
     costs
 }
@@ -89,10 +109,11 @@ fn read_commodity_costs(
 pub fn read_commodities(
     model_dir: &Path,
     region_ids: &HashSet<Rc<str>>,
+    year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, Commodity> {
     let mut commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME));
     let commodity_ids = commodities.keys().cloned().collect();
-    let mut costs = read_commodity_costs(model_dir, &commodity_ids, region_ids);
+    let mut costs = read_commodity_costs(model_dir, &commodity_ids, region_ids, year_range);
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {
@@ -102,4 +123,48 @@ pub fn read_commodities(
     }
 
     commodities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_commodity_costs() {
+        let region_ids = ["GBR".into(), "FRA".into()].into_iter().collect();
+        let year_range = 2010..=2020;
+
+        // Valid
+        let cost = CommodityCost {
+            commodity_id: "commodity".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Consumption,
+            year: 2010,
+            time_slice: "winter.day".into(),
+            value: 5.0,
+        };
+        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_ok());
+
+        // Bad region
+        let cost = CommodityCost {
+            commodity_id: "commodity".into(),
+            region_id: "USA".into(),
+            balance_type: BalanceType::Consumption,
+            year: 2010,
+            time_slice: "winter.day".into(),
+            value: 5.0,
+        };
+        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_err());
+
+        // Bad year
+        let cost = CommodityCost {
+            commodity_id: "commodity".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Consumption,
+            year: 1999,
+            time_slice: "winter.day".into(),
+            value: 5.0,
+        };
+        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_err());
+    }
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,8 +1,10 @@
 use crate::input::*;
-use crate::time_slice::TimeSliceLevel;
+use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
+use itertools::Itertools;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::rc::Rc;
@@ -47,12 +49,52 @@ pub enum BalanceType {
 
 /// Cost parameters for each commodity
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct CommodityCost {
+struct CommodityCostRaw {
     pub commodity_id: String,
     pub region_id: String,
     pub balance_type: BalanceType,
     pub year: u32,
     pub time_slice: String,
+    pub value: f64,
+}
+
+impl CommodityCostRaw {
+    /// Convert the raw record type into a validated `CommodityCost` type
+    fn try_into_commodity_cost(
+        self,
+        commodity_ids: &HashSet<Rc<str>>,
+        region_ids: &HashSet<Rc<str>>,
+        time_slice_info: &TimeSliceInfo,
+        year_range: &RangeInclusive<u32>,
+    ) -> Result<CommodityCost, Box<dyn Error>> {
+        let commodity_id = commodity_ids.get_id(&self.commodity_id)?;
+        let region_id = region_ids.get_id(&self.region_id)?;
+        let time_slice = time_slice_info.get_selection(&self.time_slice)?;
+
+        // Check year is in range
+        if !year_range.contains(&self.year) {
+            Err(format!("Year {} is out of range", self.year))?;
+        }
+
+        Ok(CommodityCost {
+            commodity_id,
+            region_id,
+            balance_type: self.balance_type,
+            year: self.year,
+            time_slice,
+            value: self.value,
+        })
+    }
+}
+
+/// Cost parameters for each commodity
+#[derive(PartialEq, Debug)]
+pub struct CommodityCost {
+    pub commodity_id: Rc<str>,
+    pub region_id: Rc<str>,
+    pub balance_type: BalanceType,
+    pub year: u32,
+    pub time_slice: TimeSliceSelection,
     pub value: f64,
 }
 define_commodity_id_getter! {CommodityCost}
@@ -70,28 +112,22 @@ pub enum CommodityType {
     OutputCommodity,
 }
 
-/// Check that commodity costs are all valid
-fn check_commodity_costs<'a, I>(
-    costs: I,
+fn read_commodity_costs_iter<I>(
+    iter: I,
+    commodity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
+    time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
-) -> Result<(), String>
+) -> Result<HashMap<Rc<str>, Vec<CommodityCost>>, Box<dyn Error>>
 where
-    I: Iterator<Item = &'a CommodityCost>,
+    I: Iterator<Item = CommodityCostRaw>,
 {
-    for cost in costs {
-        // Check region ID is valid
-        if !region_ids.contains(cost.region_id.as_str()) {
-            Err(format!("Region ID {} is invalid", cost.region_id))?;
-        }
-
-        // Check year is in range
-        if !year_range.contains(&cost.year) {
-            Err(format!("Year {} is out of range", cost.year))?;
-        }
-    }
-
-    Ok(())
+    Ok(iter
+        .map(|cost| {
+            cost.try_into_commodity_cost(commodity_ids, region_ids, time_slice_info, year_range)
+        })
+        .process_results(|iter| iter.into_id_map(commodity_ids))?
+        .unwrap()) // Commodity IDs have already been validated
 }
 
 /// Read costs associated with each commodity from commodity costs CSV file.
@@ -99,7 +135,9 @@ where
 /// # Arguments
 ///
 /// * `model_dir` - Folder containing model configuration files
+/// * `commodity_ids` - All possible commodity IDs
 /// * `region_ids` - All possible region IDs
+/// * `time_slice_info` - Information about time slices
 /// * `year_range` - The possible range of milestone years
 ///
 /// # Returns
@@ -109,14 +147,18 @@ fn read_commodity_costs(
     model_dir: &Path,
     commodity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
+    time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, Vec<CommodityCost>> {
     let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
-    let costs = read_csv_grouped_by_id::<CommodityCost>(&file_path, commodity_ids);
-    check_commodity_costs(costs.values().flatten(), region_ids, year_range)
-        .unwrap_input_err(&file_path);
-
-    costs
+    read_commodity_costs_iter(
+        read_csv::<CommodityCostRaw>(&file_path),
+        commodity_ids,
+        region_ids,
+        time_slice_info,
+        year_range,
+    )
+    .unwrap_input_err(&file_path)
 }
 
 /// Read commodity data from the specified model directory.
@@ -125,6 +167,7 @@ fn read_commodity_costs(
 ///
 /// * `model_dir` - Folder containing model configuration files
 /// * `region_ids` - All possible region IDs
+/// * `time_slice_info` - Information about time slices
 /// * `year_range` - The possible range of milestone years
 ///
 /// # Returns
@@ -133,11 +176,18 @@ fn read_commodity_costs(
 pub fn read_commodities(
     model_dir: &Path,
     region_ids: &HashSet<Rc<str>>,
+    time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, Commodity> {
     let mut commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME));
     let commodity_ids = commodities.keys().cloned().collect();
-    let mut costs = read_commodity_costs(model_dir, &commodity_ids, region_ids, year_range);
+    let mut costs = read_commodity_costs(
+        model_dir,
+        &commodity_ids,
+        region_ids,
+        time_slice_info,
+        year_range,
+    );
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {
@@ -154,41 +204,75 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_check_commodity_costs() {
+    fn test_try_into_commodity_cost() {
+        let commodity_ids = ["commodity".into()].into_iter().collect();
         let region_ids = ["GBR".into(), "FRA".into()].into_iter().collect();
+        let time_slice_info = TimeSliceInfo::default();
         let year_range = 2010..=2020;
 
         // Valid
-        let cost = CommodityCost {
+        let cost = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "GBR".into(),
             balance_type: BalanceType::Consumption,
             year: 2010,
-            time_slice: "winter.day".into(),
+            time_slice: "".into(),
             value: 5.0,
         };
-        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_ok());
+        assert!(cost
+            .try_into_commodity_cost(&commodity_ids, &region_ids, &time_slice_info, &year_range)
+            .is_ok());
+
+        // Bad commodity
+        let cost = CommodityCostRaw {
+            commodity_id: "commodity2".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Consumption,
+            year: 2010,
+            time_slice: "".into(),
+            value: 5.0,
+        };
+        assert!(cost
+            .try_into_commodity_cost(&commodity_ids, &region_ids, &time_slice_info, &year_range)
+            .is_err());
 
         // Bad region
-        let cost = CommodityCost {
+        let cost = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "USA".into(),
             balance_type: BalanceType::Consumption,
             year: 2010,
-            time_slice: "winter.day".into(),
+            time_slice: "".into(),
             value: 5.0,
         };
-        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_err());
+        assert!(cost
+            .try_into_commodity_cost(&commodity_ids, &region_ids, &time_slice_info, &year_range)
+            .is_err());
+
+        // Bad time slice selection
+        let cost = CommodityCostRaw {
+            commodity_id: "commodity".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Consumption,
+            year: 2010,
+            time_slice: "spring".into(),
+            value: 5.0,
+        };
+        assert!(cost
+            .try_into_commodity_cost(&commodity_ids, &region_ids, &time_slice_info, &year_range)
+            .is_err());
 
         // Bad year
-        let cost = CommodityCost {
+        let cost = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "GBR".into(),
             balance_type: BalanceType::Consumption,
             year: 1999,
-            time_slice: "winter.day".into(),
+            time_slice: "".into(),
             value: 5.0,
         };
-        assert!(check_commodity_costs([cost].iter(), &region_ids, &year_range).is_err());
+        assert!(cost
+            .try_into_commodity_cost(&commodity_ids, &region_ids, &time_slice_info, &year_range)
+            .is_err());
     }
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 const COMMODITY_FILE_NAME: &str = "commodities.csv";
 const COMMODITY_COSTS_FILE_NAME: &str = "commodity_costs.csv";
 
+/// A commodity within the simulation
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Commodity {
     pub id: Rc<str>,
@@ -33,6 +34,7 @@ macro_rules! define_commodity_id_getter {
     };
 }
 
+/// Type of balance for application of cost
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
 pub enum BalanceType {
     #[string = "net"]
@@ -68,6 +70,7 @@ pub enum CommodityType {
     OutputCommodity,
 }
 
+/// Check that commodity costs are all valid
 fn check_commodity_costs<'a, I>(
     costs: I,
     region_ids: &HashSet<Rc<str>>,
@@ -91,6 +94,17 @@ where
     Ok(())
 }
 
+/// Read costs associated with each commodity from commodity costs CSV file.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `region_ids` - All possible region IDs
+/// * `year_range` - The possible range of milestone years
+///
+/// # Returns
+///
+/// A map containing commodity costs, grouped by commodity ID.
 fn read_commodity_costs(
     model_dir: &Path,
     commodity_ids: &HashSet<Rc<str>>,
@@ -106,6 +120,16 @@ fn read_commodity_costs(
 }
 
 /// Read commodity data from the specified model directory.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `region_ids` - All possible region IDs
+/// * `year_range` - The possible range of milestone years
+///
+/// # Returns
+///
+/// A map containing commodities, grouped by commodity ID.
 pub fn read_commodities(
     model_dir: &Path,
     region_ids: &HashSet<Rc<str>>,

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,0 +1,34 @@
+use crate::input::read_csv_as_vec;
+use crate::time_slice::TimeSliceLevel;
+use serde::Deserialize;
+use serde_string_enum::DeserializeLabeledStringEnum;
+use std::path::Path;
+
+const COMMODITY_FILE_NAME: &str = "commodities.csv";
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub struct Commodity {
+    pub id: String,
+    pub description: String,
+    #[serde(rename = "type")] // NB: we can't name a field type as it's a reserved keyword
+    pub commodity_type: CommodityType,
+    pub time_slice_level: TimeSliceLevel,
+}
+
+/// Commodity balance type
+#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+pub enum CommodityType {
+    #[string = "sed"]
+    SupplyEqualsDemand,
+    #[string = "svd"]
+    ServiceDemand,
+    #[string = "inc"]
+    InputCommodity,
+    #[string = "ouc"]
+    OutputCommodity,
+}
+
+/// Read commodity data from the specified model directory.
+pub fn read_commodities(model_dir: &Path) -> Vec<Commodity> {
+    read_csv_as_vec(&model_dir.join(COMMODITY_FILE_NAME))
+}

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -122,12 +122,11 @@ fn read_commodity_costs_iter<I>(
 where
     I: Iterator<Item = CommodityCostRaw>,
 {
-    Ok(iter
-        .map(|cost| {
-            cost.try_into_commodity_cost(commodity_ids, region_ids, time_slice_info, year_range)
-        })
-        .process_results(|iter| iter.into_id_map(commodity_ids))?
-        .unwrap()) // Commodity IDs have already been validated
+    iter.map(|cost| {
+        cost.try_into_commodity_cost(commodity_ids, region_ids, time_slice_info, year_range)
+    })
+    // Commodity IDs have already been validated
+    .process_results(|iter| iter.into_id_map(commodity_ids).unwrap())
 }
 
 /// Read costs associated with each commodity from commodity costs CSV file.

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -42,10 +42,11 @@ pub enum BalanceType {
     Production,
 }
 
+/// Cost parameters for each commodity
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct CommodityCost {
     pub commodity_id: String,
-    pub region_id: String,
+    pub region_id: Rc<str>,
     pub balance_type: BalanceType,
     pub year: u32,
     pub time_slice: String,
@@ -66,13 +67,34 @@ pub enum CommodityType {
     OutputCommodity,
 }
 
-/// Read commodity data from the specified model directory.
-pub fn read_commodities(model_dir: &Path) -> HashMap<Rc<str>, Commodity> {
-    let mut commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME));
-    let commodity_ids = HashSet::from_iter(commodities.keys().cloned());
-    let mut costs =
-        read_csv_grouped_by_id(&model_dir.join(COMMODITY_COSTS_FILE_NAME), &commodity_ids);
+fn read_commodity_costs(
+    model_dir: &Path,
+    commodity_ids: &HashSet<Rc<str>>,
+    region_ids: &HashSet<Rc<str>>,
+) -> HashMap<Rc<str>, Vec<CommodityCost>> {
+    let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
+    let mut costs = read_csv_grouped_by_id::<CommodityCost>(&file_path, commodity_ids);
 
+    // Check region IDs
+    for cost in costs.values_mut().flatten() {
+        cost.region_id = region_ids
+            .get_id(&cost.region_id)
+            .unwrap_input_err(&file_path);
+    }
+
+    costs
+}
+
+/// Read commodity data from the specified model directory.
+pub fn read_commodities(
+    model_dir: &Path,
+    region_ids: &HashSet<Rc<str>>,
+) -> HashMap<Rc<str>, Commodity> {
+    let mut commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME));
+    let commodity_ids = commodities.keys().cloned().collect();
+    let mut costs = read_commodity_costs(model_dir, &commodity_ids, region_ids);
+
+    // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {
         if let Some(costs) = costs.remove(id) {
             commodity.costs = costs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod log;
 pub mod model;
 pub mod settings;
 
+mod commodity;
 mod demand;
 mod input;
 mod process;
@@ -18,6 +19,7 @@ use crate::model::Model;
 /// * `model` - The model to run
 pub fn run(model: &Model) {
     // TODO: Remove this once we're actually doing something with these values
+    println!("Commodities: {:?}", model.commodities);
     println!("Regions: {:?}", model.regions);
     println!("Demand data: {:?}", model.demand_data);
     println!("Processes: {:?}", model.processes);

--- a/src/model.rs
+++ b/src/model.rs
@@ -79,6 +79,8 @@ impl Model {
         let regions = read_regions(model_dir.as_ref());
         let region_ids = HashSet::from_iter(regions.keys().cloned());
         let years = &model_file.milestone_years.years;
+
+        let commodities = read_commodities(model_dir.as_ref(), &region_ids);
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
@@ -88,7 +90,7 @@ impl Model {
 
         Model {
             milestone_years: model_file.milestone_years.years,
-            commodities: read_commodities(model_dir.as_ref()),
+            commodities,
             processes,
             time_slice_info,
             demand_data: read_demand_data(model_dir.as_ref()),

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,7 +15,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 /// Model definition
 pub struct Model {
     pub milestone_years: Vec<u32>,
-    pub commodities: Vec<Commodity>,
+    pub commodities: HashMap<Rc<str>, Commodity>,
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -79,13 +79,14 @@ impl Model {
         let regions = read_regions(model_dir.as_ref());
         let region_ids = HashSet::from_iter(regions.keys().cloned());
         let years = &model_file.milestone_years.years;
+        let year_range = *years.first().unwrap()..=*years.last().unwrap();
 
-        let commodities = read_commodities(model_dir.as_ref(), &region_ids);
+        let commodities = read_commodities(model_dir.as_ref(), &region_ids, &year_range);
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
             &time_slice_info,
-            *years.first().unwrap()..=*years.last().unwrap(),
+            &year_range,
         );
 
         Model {

--- a/src/model.rs
+++ b/src/model.rs
@@ -81,7 +81,12 @@ impl Model {
         let years = &model_file.milestone_years.years;
         let year_range = *years.first().unwrap()..=*years.last().unwrap();
 
-        let commodities = read_commodities(model_dir.as_ref(), &region_ids, &year_range);
+        let commodities = read_commodities(
+            model_dir.as_ref(),
+            &region_ids,
+            &time_slice_info,
+            &year_range,
+        );
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 //! Code for simulation models.
+use crate::commodity::{read_commodities, Commodity};
 use crate::demand::{read_demand_data, Demand};
 use crate::input::{read_toml, UnwrapInputError};
 use crate::process::{read_processes, Process};
@@ -14,6 +15,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 /// Model definition
 pub struct Model {
     pub milestone_years: Vec<u32>,
+    pub commodities: Vec<Commodity>,
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,
@@ -86,6 +88,7 @@ impl Model {
 
         Model {
             milestone_years: model_file.milestone_years.years,
+            commodities: read_commodities(model_dir.as_ref()),
             processes,
             time_slice_info,
             demand_data: read_demand_data(model_dir.as_ref()),

--- a/src/process.rs
+++ b/src/process.rs
@@ -183,9 +183,9 @@ where
         .map(|record| {
             let time_slice = match record.time_slice {
                 // Defaults to all time slices
-                None => TimeSliceSelection::All,
+                None => TimeSliceSelection::Annual,
                 // Get a TimeSliceID from a string of the form season.time_of_day
-                Some(time_slice) => TimeSliceSelection::Some(
+                Some(time_slice) => TimeSliceSelection::Single(
                     time_slice_info
                         .get_time_slice_id_from_str(&time_slice)
                         .unwrap_input_err(file_path),

--- a/src/process.rs
+++ b/src/process.rs
@@ -279,7 +279,7 @@ pub fn read_processes(
     model_dir: &Path,
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
-    year_range: RangeInclusive<u32>,
+    year_range: &RangeInclusive<u32>,
 ) -> HashMap<Rc<str>, Process> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path);
@@ -290,7 +290,7 @@ pub fn read_processes(
     let mut flows = read_csv_grouped_by_id(&file_path, &process_ids);
     let file_path = model_dir.join(PROCESS_PACS_FILE_NAME);
     let mut pacs = read_csv_grouped_by_id(&file_path, &process_ids);
-    let mut parameters = read_process_parameters(model_dir, &process_ids, &year_range);
+    let mut parameters = read_process_parameters(model_dir, &process_ids, year_range);
     let file_path = model_dir.join(PROCESS_REGIONS_FILE_NAME);
     let mut regions =
         read_regions_for_entity::<ProcessRegion>(&file_path, &process_ids, region_ids);

--- a/src/process.rs
+++ b/src/process.rs
@@ -31,7 +31,7 @@ macro_rules! define_process_id_getter {
 struct ProcessAvailabilityRaw {
     process_id: String,
     limit_type: LimitType,
-    time_slice: Option<String>,
+    time_slice: String,
     #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     value: f64,
 }
@@ -181,16 +181,9 @@ where
 {
     let availabilities = iter
         .map(|record| {
-            let time_slice = match record.time_slice {
-                // Defaults to all time slices
-                None => TimeSliceSelection::Annual,
-                // Get a TimeSliceID from a string of the form season.time_of_day
-                Some(time_slice) => TimeSliceSelection::Single(
-                    time_slice_info
-                        .get_time_slice_id_from_str(&time_slice)
-                        .unwrap_input_err(file_path),
-                ),
-            };
+            let time_slice = time_slice_info
+                .get_selection(&record.time_slice)
+                .unwrap_input_err(file_path);
 
             ProcessAvailability {
                 process_id: record.process_id,

--- a/src/process.rs
+++ b/src/process.rs
@@ -269,6 +269,7 @@ fn read_process_parameters(
 ///
 /// * `model_dir` - Folder containing model configuration files
 /// * `region_ids` - All possible region IDs
+/// * `time_slice_info` - Information about seasons and times of day
 /// * `year_range` - The possible range of milestone years
 ///
 /// # Returns

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -31,7 +31,11 @@ impl Display for TimeSliceID {
 /// Represents a time slice read from an input file, which can be all
 #[derive(PartialEq, Debug)]
 pub enum TimeSliceSelection {
+    /// All year and all day
     Annual,
+    /// Only applies to one season
+    Season(Rc<str>),
+    /// Only applies to a single time slice
     Single(TimeSliceID),
 }
 
@@ -98,9 +102,12 @@ impl TimeSliceInfo {
     pub fn get_selection(&self, time_slice: &str) -> Result<TimeSliceSelection, Box<dyn Error>> {
         if time_slice.is_empty() || time_slice.eq_ignore_ascii_case("annual") {
             Ok(TimeSliceSelection::Annual)
-        } else {
+        } else if time_slice.contains('.') {
             let time_slice = self.get_time_slice_id_from_str(time_slice)?;
             Ok(TimeSliceSelection::Single(time_slice))
+        } else {
+            let season = self.seasons.get_id(time_slice)?;
+            Ok(TimeSliceSelection::Season(season))
         }
     }
 }

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -91,6 +91,18 @@ impl TimeSliceInfo {
             time_of_day: Rc::clone(time_of_day),
         })
     }
+
+    /// Get a `TimeSliceSelection` from the specified string.
+    ///
+    /// If the string is empty, the default value is `TimeSliceSelection::Annual`.
+    pub fn get_selection(&self, time_slice: &str) -> Result<TimeSliceSelection, Box<dyn Error>> {
+        if time_slice.is_empty() || time_slice.eq_ignore_ascii_case("annual") {
+            Ok(TimeSliceSelection::Annual)
+        } else {
+            let time_slice = self.get_time_slice_id_from_str(time_slice)?;
+            Ok(TimeSliceSelection::Single(time_slice))
+        }
+    }
 }
 
 /// A time slice record retrieved from a CSV file

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -31,8 +31,8 @@ impl Display for TimeSliceID {
 /// Represents a time slice read from an input file, which can be all
 #[derive(PartialEq, Debug)]
 pub enum TimeSliceSelection {
-    All,
-    Some(TimeSliceID),
+    Annual,
+    Single(TimeSliceID),
 }
 
 /// Information about the time slices in the simulation, including names and fractions

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -6,6 +6,7 @@ use crate::input::*;
 use float_cmp::approx_eq;
 use itertools::Itertools;
 use serde::Deserialize;
+use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Display;
@@ -143,6 +144,17 @@ where
         times_of_day,
         fractions,
     })
+}
+
+/// Refers to a particular aspect of a time slice
+#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+pub enum TimeSliceLevel {
+    #[string = "annual"]
+    Annual,
+    #[string = "season"]
+    Season,
+    #[string = "daynight"]
+    DayNight,
 }
 
 /// Read time slices from a CSV file.


### PR DESCRIPTION
# Description

The latest installment of the input layer work. This one is minimally invasive; it just adds support for two commodity-related CSV files (`commodities.csv` and `commodity_costs.csv`).

The commodity constraints file (which is currently empty in the example) is not read in by this code, but I've opened an issue to tackle it in future: #149.

Closes #62.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
