### PR TITLE
Read in agents-related files

### DIFF
--- a/examples/simple/agent_objectives.csv
+++ b/examples/simple/agent_objectives.csv
@@ -1,4 +1,4 @@
-agent_id,objective,decision_weight,decision_lexico_tolerance
+agent_id,objective_type,decision_weight,decision_lexico_tolerance
 A0_GEX,lcox,,
 A0_GPR,lcox,,
 A0_ELC,lcox,,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -11,6 +11,7 @@ const AGENT_FILE_NAME: &str = "agents.csv";
 const AGENT_REGIONS_FILE_NAME: &str = "agent_regions.csv";
 const AGENT_OBJECTIVES_FILE_NAME: &str = "agent_objectives.csv";
 
+/// Which processes apply to this agent
 #[derive(Debug, Clone, PartialEq)]
 pub enum SearchSpace {
     AllProcesses,
@@ -33,6 +34,7 @@ impl<'de> Deserialize<'de> for SearchSpace {
     }
 }
 
+/// The decision rule for a particular objective
 #[derive(Debug, Clone, PartialEq, DeserializeLabeledStringEnum)]
 pub enum DecisionRule {
     #[string = "single"]
@@ -43,6 +45,7 @@ pub enum DecisionRule {
     Lexicographical,
 }
 
+/// An agent in the simulation
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct Agent {
     pub id: Rc<str>,
@@ -80,6 +83,8 @@ struct AgentRegion {
 define_agent_id_getter! {AgentRegion}
 define_region_id_getter! {AgentRegion}
 
+/// The type of objective for the agent
+///
 /// **TODO** Add more objective types
 #[derive(Debug, Clone, PartialEq, DeserializeLabeledStringEnum)]
 pub enum ObjectiveType {
@@ -89,6 +94,7 @@ pub enum ObjectiveType {
     EquivalentAnnualCost,
 }
 
+/// An objective for an agent with associated parameters
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct AgentObjective {
     agent_id: String,
@@ -172,6 +178,15 @@ where
     Ok(objectives)
 }
 
+/// Read agent objective info from the agent_objectives.csv file.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+///
+/// # Returns
+///
+/// A map of Agents, with the agent ID as the key
 fn read_agent_objectives(
     model_dir: &Path,
     agents: &HashMap<Rc<str>, Agent>,
@@ -207,7 +222,16 @@ where
     Ok(agents)
 }
 
-/// Read agents info from a CSV file.
+/// Read agents info from the agents.csv file.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `process_ids` - The possible valid process IDs
+///
+/// # Returns
+///
+/// A map of Agents, with the agent ID as the key
 pub fn read_agents_file(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
@@ -216,7 +240,17 @@ pub fn read_agents_file(
     read_agents_file_from_iter(read_csv(&file_path), process_ids).unwrap_input_err(&file_path)
 }
 
-/// Read agents info from CSV files.
+/// Read agents info from various CSV files.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `process_ids` - The possible valid process IDs
+/// * `region_ids` - The possible valid region IDs
+///
+/// # Returns
+///
+/// A map of Agents, with the agent ID as the key
 pub fn read_agents(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,76 @@
+use crate::input::{deserialise_proportion_nonzero, input_panic, read_csv};
+use serde::Deserialize;
+use serde_string_enum::DeserializeLabeledStringEnum;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::rc::Rc;
+
+const AGENT_FILE_NAME: &str = "agents.csv";
+
+#[derive(Debug, PartialEq)]
+pub enum SearchSpace {
+    AllProcesses,
+    Some(HashSet<String>),
+}
+
+impl<'de> Deserialize<'de> for SearchSpace {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Option::<&str>::deserialize(deserializer)?;
+        match value {
+            None => Ok(SearchSpace::AllProcesses),
+            Some(processes_str) => {
+                let processes = HashSet::from_iter(processes_str.split(';').map(String::from));
+                Ok(SearchSpace::Some(processes))
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, DeserializeLabeledStringEnum)]
+pub enum DecisionRule {
+    #[string = "single"]
+    Single,
+    #[string = "weighted"]
+    Weighted,
+    #[string = "lexico"]
+    Lexicographical,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Agent {
+    pub id: Rc<str>,
+    pub description: String,
+    pub commodity_id: String,
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
+    pub commodity_portion: f64,
+    pub search_space: SearchSpace,
+    pub decision_rule: DecisionRule,
+    pub capex_limit: Option<f64>,
+    pub annual_cost_limit: Option<f64>,
+}
+
+/// Read agents info from a CSV file.
+pub fn read_agents(model_dir: &Path, process_ids: &HashSet<Rc<str>>) -> HashMap<Rc<str>, Agent> {
+    let file_path = model_dir.join(AGENT_FILE_NAME);
+    let mut agents = HashMap::new();
+    for agent in read_csv::<Agent>(&file_path) {
+        if let SearchSpace::Some(ref search_space) = agent.search_space {
+            // Check process IDs are all valid
+            if !search_space
+                .iter()
+                .all(|id| process_ids.contains(id.as_str()))
+            {
+                input_panic(&file_path, "Invalid process ID");
+            }
+        }
+
+        if agents.insert(Rc::clone(&agent.id), agent).is_some() {
+            input_panic(&file_path, "Duplicate agent ID");
+        }
+    }
+
+    agents
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,12 +2,15 @@ use crate::input::*;
 use crate::region::*;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
+
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::path::Path;
 use std::rc::Rc;
 
 const AGENT_FILE_NAME: &str = "agents.csv";
 const AGENT_REGIONS_FILE_NAME: &str = "agent_regions.csv";
+const AGENT_OBJECTIVES_FILE_NAME: &str = "agent_objectives.csv";
 
 #[derive(Debug, PartialEq)]
 pub enum SearchSpace {
@@ -55,6 +58,8 @@ pub struct Agent {
 
     #[serde(skip)]
     pub regions: RegionSelection,
+    #[serde(skip)]
+    pub objectives: Vec<AgentObjective>,
 }
 
 macro_rules! define_agent_id_getter {
@@ -74,6 +79,99 @@ struct AgentRegion {
 }
 define_agent_id_getter! {AgentRegion}
 define_region_id_getter! {AgentRegion}
+
+/// **TODO** Add more objective types
+#[derive(Debug, PartialEq, DeserializeLabeledStringEnum)]
+pub enum ObjectiveType {
+    #[string = "lcox"]
+    LevellisedCostOfX,
+    #[string = "eac"]
+    EquivalentAnnualCost,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct AgentObjective {
+    agent_id: String,
+    objective_type: ObjectiveType,
+    decision_weight: Option<f64>,
+    decision_lexico_tolerance: Option<f64>,
+}
+define_agent_id_getter! {AgentObjective}
+
+/// Check that required parameters are present and others are absent
+fn check_objective_parameter(objective: &AgentObjective, agent: &Agent) -> Result<(), String> {
+    // Check that the user hasn't supplied a value for a field we're not using
+    macro_rules! check_field_none {
+        ($field:ident) => {
+            if objective.$field.is_some() {
+                Err(format!(
+                    "Field {} should be empty for this decision rule",
+                    stringify!($field)
+                ))?;
+            }
+        };
+    }
+
+    // Check that required fields are present
+    macro_rules! check_field_some {
+        ($field:ident) => {
+            if objective.$field.is_none() {
+                Err(format!("Required field {} is empty", stringify!($field)))?;
+            }
+        };
+    }
+
+    match &agent.decision_rule {
+        DecisionRule::Single => {
+            check_field_none!(decision_weight);
+            check_field_none!(decision_lexico_tolerance);
+        }
+        DecisionRule::Weighted => {
+            check_field_none!(decision_lexico_tolerance);
+            check_field_some!(decision_weight);
+        }
+        DecisionRule::Lexicographical => {
+            check_field_none!(decision_weight);
+            check_field_some!(decision_lexico_tolerance);
+        }
+    };
+
+    Ok(())
+}
+
+fn read_agent_objectives_from_iter<I>(
+    iter: I,
+    agents: &HashMap<Rc<str>, Agent>,
+    agent_ids: &HashSet<Rc<str>>,
+) -> Result<HashMap<Rc<str>, Vec<AgentObjective>>, Box<dyn Error>>
+where
+    I: Iterator<Item = AgentObjective>,
+{
+    let objectives = iter.into_id_map(agent_ids)?;
+    for objective in objectives.values().flatten() {
+        // We've already checked that agent IDs are valid
+        let agent = agents.get(objective.agent_id.as_str()).unwrap();
+
+        // Check that required parameters are present and others are absent
+        check_objective_parameter(objective, agent)?;
+    }
+
+    if objectives.len() < agent_ids.len() {
+        Err("All agents must have at least one objective")?;
+    }
+
+    Ok(objectives)
+}
+
+fn read_agent_objectives(
+    model_dir: &Path,
+    agents: &HashMap<Rc<str>, Agent>,
+    agent_ids: &HashSet<Rc<str>>,
+) -> HashMap<Rc<str>, Vec<AgentObjective>> {
+    let file_path = model_dir.join(AGENT_OBJECTIVES_FILE_NAME);
+    read_agent_objectives_from_iter(read_csv(&file_path), agents, agent_ids)
+        .unwrap_input_err(&file_path)
+}
 
 /// Read agents info from a CSV file.
 pub fn read_agents_file(
@@ -113,9 +211,11 @@ pub fn read_agents(
     let file_path = model_dir.join(AGENT_REGIONS_FILE_NAME);
     let mut agent_regions =
         read_regions_for_entity::<AgentRegion>(&file_path, &agent_ids, region_ids);
+    let mut objectives = read_agent_objectives(model_dir, &agents, &agent_ids);
 
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();
+        agent.objectives = objectives.remove(id).unwrap();
     }
 
     agents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod log;
 pub mod model;
 pub mod settings;
 
+mod agent;
 mod demand;
 mod input;
 mod process;

--- a/src/model.rs
+++ b/src/model.rs
@@ -86,7 +86,7 @@ impl Model {
             *years.first().unwrap()..=*years.last().unwrap(),
         );
         let process_ids = processes.keys().cloned().collect();
-        let agents = read_agents(model_dir.as_ref(), &process_ids);
+        let agents = read_agents(model_dir.as_ref(), &process_ids, &region_ids);
 
         Model {
             milestone_years: model_file.milestone_years.years,

--- a/src/region.rs
+++ b/src/region.rs
@@ -16,7 +16,7 @@ pub struct Region {
 }
 define_id_getter! {Region}
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum RegionSelection {
     All,
     Some(HashSet<Rc<str>>),

--- a/src/region.rs
+++ b/src/region.rs
@@ -22,6 +22,12 @@ pub enum RegionSelection {
     Some(HashSet<Rc<str>>),
 }
 
+impl Default for RegionSelection {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
 impl RegionSelection {
     pub fn contains(&self, region_id: &str) -> bool {
         match self {


### PR DESCRIPTION
# Description

This PR adds support for reading in the various agent-related CSV files, viz.: `agents.csv`, `agent_regions.csv` and `agent_objectives.csv`.

Closes #76. Closes #107. Closes #108.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
