### PR TITLE
Make PACs references to `Commodity`s

### DIFF
--- a/examples/simple/process_pacs.csv
+++ b/examples/simple/process_pacs.csv
@@ -1,4 +1,4 @@
-process_id,pac
+process_id,commodity_id
 GASDRV,GASPRD
 GASPRC,GASNAT
 WNDFRM,ELCTRI

--- a/src/model.rs
+++ b/src/model.rs
@@ -91,6 +91,7 @@ impl Model {
         );
         let processes = read_processes(
             model_dir.as_ref(),
+            &commodities,
             &region_ids,
             &time_slice_info,
             &year_range,

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,7 +17,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 pub struct Model {
     pub milestone_years: Vec<u32>,
     pub agents: HashMap<Rc<str>, Agent>,
-    pub commodities: HashMap<Rc<str>, Commodity>,
+    pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,

--- a/src/process.rs
+++ b/src/process.rs
@@ -262,6 +262,7 @@ fn read_process_parameters(
 ///
 /// # Arguments
 ///
+/// * `iter` - An iterator of `ProcessPAC`s
 /// * `process_ids` - All possible process IDs
 /// * `commodities` - Commodities for the model
 ///

--- a/src/process.rs
+++ b/src/process.rs
@@ -85,7 +85,7 @@ where
 #[derive(PartialEq, Clone, Eq, Hash, Debug, Deserialize)]
 struct ProcessPAC {
     process_id: String,
-    pac: String,
+    commodity_id: String,
 }
 define_process_id_getter! {ProcessPAC}
 
@@ -282,10 +282,10 @@ where
 
     iter.map(|pac| {
         let process_id = process_ids.get_id(&pac.process_id)?;
-        let commodity = commodities.get(pac.pac.as_str());
+        let commodity = commodities.get(pac.commodity_id.as_str());
 
         match commodity {
-            None => Err(format!("{} is not a valid commodity ID", &pac.pac))?,
+            None => Err(format!("{} is not a valid commodity ID", &pac.commodity_id))?,
             Some(commodity) => {
                 if !pacs.insert(pac) {
                     Err("Duplicate PACs found")?;
@@ -649,7 +649,7 @@ mod tests {
         // duplicate PAC
         let pac = ProcessPAC {
             process_id: "id1".into(),
-            pac: "commodity1".into(),
+            commodity_id: "commodity1".into(),
         };
         let pacs = [pac.clone(), pac];
         assert!(read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities).is_err());
@@ -657,7 +657,7 @@ mod tests {
         // invalid commodity ID
         let bad_pac = ProcessPAC {
             process_id: "id1".into(),
-            pac: "other_commodity".into(),
+            commodity_id: "other_commodity".into(),
         };
         assert!(
             read_process_pacs_from_iter([bad_pac].into_iter(), &process_ids, &commodities).is_err()
@@ -666,15 +666,15 @@ mod tests {
         let pacs = [
             ProcessPAC {
                 process_id: "id1".into(),
-                pac: "commodity1".into(),
+                commodity_id: "commodity1".into(),
             },
             ProcessPAC {
                 process_id: "id1".into(),
-                pac: "commodity2".into(),
+                commodity_id: "commodity2".into(),
             },
             ProcessPAC {
                 process_id: "id2".into(),
-                pac: "commodity1".into(),
+                commodity_id: "commodity1".into(),
             },
         ];
         let expected = [


### PR DESCRIPTION
# Description

Now that we have merged the commodity-related code, we can use these data structures elsewhere.

As PACs are commodities, it makes sense to represent them as references to commodity types, which is what I've done here. There are currently no tests, but we can add these later.

Edit: PACs are "Primary Activity Commodities": From the glossary:

> "**Primary Activity Commodity (PAC):** The PACs specify which output/s are linked to the process
capacity. The combined output of all PACs cannot exceed the *Asset’s* capacity. A user can define
which output/s are PACs."

Closes #164.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
