### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ More information is available in [the official `cargo` book](https://doc.rust-la
 
 Developers must install the `pre-commit` tool in order to automatically run this
 repository's hooks when making a new Git commit. Follow [the instructions on the `pre-commit`
-website] in order to get started.
+website](https://pre-commit.com/#install) in order to get started.
 
 Once you have installed `pre-commit`, you need to enable its use for this repository by installing
 the hooks, like so:


### PR DESCRIPTION
Setting correct hyperlink to point a developer to installing `pre-commit` on their machine.

# Description

Setting link to `pre-commit` guide as intended in the `CONTRIBUTING.md` file.

Fixes #176.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
