### PR TITLE
Add draft dispatch formulation to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,6 @@ and improvements.
 
 [Developer Setup](#developer-setup)
 
-- [Installing the Rust toolchain](#installing-the-rust-toolchain)
-- [Working with the project](#working-with-the-project)
-- [Pre-Commit Hooks](#pre-commit-hooks)
-
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the [MUSE Code of Conduct](CODE_OF_CONDUCT.md).
@@ -194,51 +190,4 @@ on how to write the documentation.
 
 ## Developer Setup
 
-### Installing the Rust toolchain
-
-We recommend that developers use `rustup` to install the Rust toolchain. Follow the instructions on
-[the `rustup` website](https://rustup.rs/).
-
-Once you have done so, select the `stable` toolchain (used by this project) as your default with:
-
-```sh
-rustup default stable
-```
-
-### Working with the project
-
-To build the project, run:
-
-```sh
-cargo build
-```
-
-To run MUSE with the example input files, you can run:
-
-```sh
-cargo run examples/simple
-```
-
-Tests can be run with:
-
-```sh
-cargo test
-```
-
-More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
-
-### Pre-Commit hooks
-
-Developers must install the `pre-commit` tool in order to automatically run this
-repository's hooks when making a new Git commit. Follow [the instructions on the `pre-commit`
-website](https://pre-commit.com/#install) in order to get started.
-
-Once you have installed `pre-commit`, you need to enable its use for this repository by installing
-the hooks, like so:
-
-```sh
-pre-commit install
-```
-
-Thereafter, a series of checks should be run every time you commit with Git. In addition, the
-`pre-commit` hooks are also run as part of the CI pipeline.
+Please see the [developer guide](docs/developer_guide.md).

--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "docs"
 title = "MUSE 2.0"
+
+[output.html]
+mathjax-support = true

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,4 +3,5 @@
 [Introduction](./introduction.md)
 
 - [User Guide](./user_guide.md)
+- [Dispatch Optimisation](./dispatch_optimisation.md)
 - [Glossary](./glossary.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,5 +3,6 @@
 [Introduction](./introduction.md)
 
 - [User Guide](./user_guide.md)
+- [Developer Guide](./developer_guide.md)
 - [Dispatch Optimisation](./dispatch_optimisation.md)
 - [Glossary](./glossary.md)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -38,6 +38,25 @@ cargo test
 
 More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
 
+## Developing the documentation
+
+We use [mdBook](https://rust-lang.github.io/mdBook/) for generating technical documentation.
+
+If you are developing the documentation locally, you may want to check that your changes render
+correctly (especially if you are working with equations).
+
+To do this, you first need to install mdBook:
+
+```sh
+cargo install mdbook
+```
+
+You can then view the documentation in your browser like so:
+
+```sh
+mdbook serve -o
+```
+
 ## Pre-Commit hooks
 
 Developers must install the `pre-commit` tool in order to automatically run this

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,55 @@
+# Developer Guide
+
+This is a guide for those who wish to contribute to the MUSE 2.0 project or make local changes to
+the code.
+
+[The API documentation is available here.](./api/muse2)
+
+## Installing the Rust toolchain
+
+We recommend that developers use `rustup` to install the Rust toolchain. Follow the instructions on
+[the `rustup` website](https://rustup.rs/).
+
+Once you have done so, select the `stable` toolchain (used by this project) as your default with:
+
+```sh
+rustup default stable
+```
+
+## Working with the project
+
+To build the project, run:
+
+```sh
+cargo build
+```
+
+To run MUSE with the example input files, you can run:
+
+```sh
+cargo run examples/simple
+```
+
+Tests can be run with:
+
+```sh
+cargo test
+```
+
+More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
+
+## Pre-Commit hooks
+
+Developers must install the `pre-commit` tool in order to automatically run this
+repository's hooks when making a new Git commit. Follow [the instructions on the `pre-commit`
+website](https://pre-commit.com/#install) in order to get started.
+
+Once you have installed `pre-commit`, you need to enable its use for this repository by installing
+the hooks, like so:
+
+```sh
+pre-commit install
+```
+
+Thereafter, a series of checks should be run every time you commit with Git. In addition, the
+`pre-commit` hooks are also run as part of the CI pipeline.

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -127,7 +127,7 @@ $$\sum_{a,ts} q_{r,a,c,ts} = cr\\_ net\\_ fx$$
 
 Where *c* is a service demand commodity.
 
-**TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves.
+**TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves. \
 **TBD** – trade between regions.
 
 ### Asset-level commodity flow share constraints for flexible assets

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -4,8 +4,8 @@ Decision variables:
 
 \\( q_{r,a,c,ts} \\). Where *q* represents *c* commodity flow in region *r*, to/from asset *a*, in
 time slice *ts*.
--ve values are flow into the asset, +ve values are flows from the asset. Note that *q* is a quantity
-flow (e.g. energy) as opposed to an intensity (e.g. power).
+Negative values are flows into the asset and positive values are flows from the asset. Note that *q*
+is a quantity flow (e.g. energy) as opposed to an intensity (e.g. power).
 
 where
 
@@ -70,8 +70,8 @@ For each *r*, *a*, *c*, *ts*:
 
 (**TBD**)
 
-for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a -ve
-sign), and “out” refers to output flow commodities (i.e. with a +ve sign).
+for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a
+negative sign), and “out” refers to output flow commodities (i.e. with a positive sign).
 
 ### Asset-level capacity and availability constraints
 

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -44,134 +44,134 @@ Assets where ratio between output/s and input/s is strictly proportional. Energy
 inputs and outputs are proportional to first-listed primary activity commodity at a time slice level
 defined for each commodity. Input/output ratio is a fixed value.
 
-> For each *r*, *a*, *ts*, *c*:
->
-> $$ \frac{q_{r,a,c,ts}}{flow_{r,a,ts,c}} - \frac{q_{r,a,pac1,ts}}{flow_{r,a,ts,pac1}} = 0 $$
->
-> for all commodity flows that the process has (except *pac1*). Where *pac1* is the first listed
-> primary activity commodity for the asset (i.e. all input and output flows are made proportional to
-> *pac1* flow).
->
-> Note – need to handle cases where a flow is set to zero in the input data – should raise a
-> warning that the value has been ignored, specifying which region/asset/commodity.
->
-> **TBD** - cases where time slice level of the commodity is seasonal or annual.
+For each *r*, *a*, *ts*, *c*:
+
+$$ \frac{q_{r,a,c,ts}}{flow_{r,a,ts,c}} - \frac{q_{r,a,pac1,ts}}{flow_{r,a,ts,pac1}} = 0 $$
+
+for all commodity flows that the process has (except *pac1*). Where *pac1* is the first listed
+primary activity commodity for the asset (i.e. all input and output flows are made proportional to
+*pac1* flow).
+
+Note – need to handle cases where a flow is set to zero in the input data – should raise a
+warning that the value has been ignored, specifying which region/asset/commodity.
+
+**TBD** - cases where time slice level of the commodity is seasonal or annual.
 
 ### Commodity-flexible assets
 
 Assets where ratio of input/s to output/s can vary for selected commodities, subject to user-defined
 ratios between input and output.
 
-> Energy commodity asset inputs and outputs are constrained such that total inputs to total outputs
-> of selected commodities is limited to user-defined ratios. Furthermore, each commodity input or
-> output can be limited to be within a range, relative to other commodities.
->
-> For each *r*, *a*, *c*, *ts*:
->
-> **TBD**
->
-> for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a -ve
-> sign), and “out” refers to output flow commodities (i.e. with a +ve sign).*
+Energy commodity asset inputs and outputs are constrained such that total inputs to total outputs
+of selected commodities is limited to user-defined ratios. Furthermore, each commodity input or
+output can be limited to be within a range, relative to other commodities.
+
+For each *r*, *a*, *c*, *ts*:
+
+(**TBD**)
+
+for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a -ve
+sign), and “out” refers to output flow commodities (i.e. with a +ve sign).*
 
 ### Asset-level capacity and availability constraints
 
-> Primary activity commodity/ies output must not exceed asset capacity or any other limit as
-> defined by availability factor constraint user inputs.
->
-> For the capacity limits, for each *r*, *a*, *c*, *ts*. The sum of all PACs must be less than the
-> assets’ capacity:
->
-> $$
-> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}} \leq 1
-> $$
->
-> For the availability constraints, for each *r*, *a*, *c*, *ts*:
->
-> $$
-> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
-> \leq process.availability.value(up)_{r,a,ts}
-> $$
->
-> $$
-> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
-> \geq process.availability.value(lo)_{r,a,ts}
-> $$
->
-> $$
-> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
-> = process.availability.value(fx)_{r,a,ts}
-> $$
->
-> The sum of all PACs must be within the assets' availability bounds. Similar constraints also
-> limit output of PACs to respect the availability constraints at time slice, seasonal or annual
-> levels. With appropriate selection of *q* on the LHS to match RHS temporal granularity.
->
-> Note: Where availability is specified for a process at `DAYNIGHT` time slice level, it supersedes
-> the capacity limit constraint (i.e. you don’t need both).
+Primary activity commodity/ies output must not exceed asset capacity or any other limit as
+defined by availability factor constraint user inputs.
+
+For the capacity limits, for each *r*, *a*, *c*, *ts*. The sum of all PACs must be less than the
+assets’ capacity:
+
+$$
+\sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}} \leq 1
+$$
+
+For the availability constraints, for each *r*, *a*, *c*, *ts*:
+
+$$
+\sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+\leq process.availability.value(up)_{r,a,ts}
+$$
+
+$$
+\sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+\geq process.availability.value(lo)_{r,a,ts}
+$$
+
+$$
+\sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+= process.availability.value(fx)_{r,a,ts}
+$$
+
+The sum of all PACs must be within the assets' availability bounds. Similar constraints also
+limit output of PACs to respect the availability constraints at time slice, seasonal or annual
+levels. With appropriate selection of *q* on the LHS to match RHS temporal granularity.
+
+Note: Where availability is specified for a process at `DAYNIGHT` time slice level, it supersedes
+the capacity limit constraint (i.e. you don’t need both).
 
 ### Commodity balance constraints
 
-> Commodity supply-demand balance for a whole system (or for a single region or set of regions).
-> For each internal commodity that requires a strict balance (supply == demand, SED), it is an
-> equality constraint with just “1” for each relevant commodity and RHS equals 0. Note there is also
-> a special case where the commodity is a service demand (e.g. Mt steel produced), where net sum of
-> output must be equal to the demand.
->
-> For supply-demand balance commodities. For each *r* and each *c*:
->
-> $$\sum_{a,ts} q_{r,a,c,ts} = 0$$
->
-> For a service demand, for each *c*, within a single region:
->
-> $$\sum_{a,ts} q_{r,a,c,ts} = cr\\_ net\\_ fx$$
->
-> Where *c* is a service demand commodity.
->
-> **TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves.
-> **TBD** – trade between regions.
+Commodity supply-demand balance for a whole system (or for a single region or set of regions).
+For each internal commodity that requires a strict balance (supply == demand, SED), it is an
+equality constraint with just “1” for each relevant commodity and RHS equals 0. Note there is also
+a special case where the commodity is a service demand (e.g. Mt steel produced), where net sum of
+output must be equal to the demand.
+
+For supply-demand balance commodities. For each *r* and each *c*:
+
+$$\sum_{a,ts} q_{r,a,c,ts} = 0$$
+
+For a service demand, for each *c*, within a single region:
+
+$$\sum_{a,ts} q_{r,a,c,ts} = cr\\_ net\\_ fx$$
+
+Where *c* is a service demand commodity.
+
+**TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves.
+**TBD** – trade between regions.
 
 ### Asset-level commodity flow share constraints for flexible assets
 
-> Restricts share of flow amongst a set of specified flexible commodities. Constraints can be
-> constructed for input side of processes or output side of processes, or both.
->
-> $$
-> q_{r,a,c,ts} \leq process.commodity.constraint.value(up)\_{r,a,c,ts} *
-> \left( \sum_{flexible\ c} q\_{r,a,c,ts} \right)
-> $$
->
-> $$
-> q_{r,a,c,ts} \geq process.commodity.constraint.value(lo)\_{r,a,c,ts} *
-> \left( \sum\_{flexible\ c} q_{r,a,c,ts} \right)
-> $$
->
-> $$
-> q_{r,a,c,ts} = process.commodity.constraint.value(fx)\_{r,a,c,ts} *
-> \left( \sum\_{flexible\ c} q\_{r,a,c,ts} \right)
-> $$
->
-> Could be used to define flow limits on specific commodities in a flexible process. E.g. a
-> refinery that is flexible and can produce gasoline, diesel or jet fuel, but for a given crude oil
-> input only a limited amount of jet fuel can be produced and remainder of production must be either
-> diesel or gasoline (for example).
+Restricts share of flow amongst a set of specified flexible commodities. Constraints can be
+constructed for input side of processes or output side of processes, or both.
+
+$$
+q_{r,a,c,ts} \leq process.commodity.constraint.value(up)\_{r,a,c,ts} *
+\left( \sum_{flexible\ c} q\_{r,a,c,ts} \right)
+$$
+
+$$
+q_{r,a,c,ts} \geq process.commodity.constraint.value(lo)\_{r,a,c,ts} *
+\left( \sum\_{flexible\ c} q_{r,a,c,ts} \right)
+$$
+
+$$
+q_{r,a,c,ts} = process.commodity.constraint.value(fx)\_{r,a,c,ts} *
+\left( \sum\_{flexible\ c} q\_{r,a,c,ts} \right)
+$$
+
+Could be used to define flow limits on specific commodities in a flexible process. E.g. a
+refinery that is flexible and can produce gasoline, diesel or jet fuel, but for a given crude oil
+input only a limited amount of jet fuel can be produced and remainder of production must be either
+diesel or gasoline (for example).
 
 ### Other net and absolute commodity volume constraints
 
 <!-- markdownlint-disable-next-line MD033 -->
-> Net constraint: There might be a net CO<sub>2</sub> emissions limit of zero in 2050, or even a
-> negative value. Constraint applied on both outputs and inputs of the commodity, sum must less then
-> (or equal to or more than) a user-specified value. For system-wide net commodity production
-> constraint, for each *c*, sum over regions, assets, time slices.
->
-> $$\sum_{r,a,ts} q_{r,a,c,ts} \leq commodity.constraint.rhs\\_ value(up)$$
->
-> $$\sum_{r,a,ts} q_{r,a,c,ts} \geq commodity.constraint.rhs\\_ value(lo)$$
->
-> $$\sum_{r,a,ts} q_{r,a,c,ts} = commodity.constraint.rhs\\_ value(fx)$$
->
-> Similar constraints can be constructed for net commodity volume over specific regions or sets of
-> regions.
->
-> Production or consumption constraint: Likewise similar constraints can be constructed to limit
-> absolute production or absolute consumption. In these cases selective choice of *q* focused on
-> process inputs (consumption) or process outputs (production) can be applied.
+Net constraint: There might be a net CO<sub>2</sub> emissions limit of zero in 2050, or even a
+negative value. Constraint applied on both outputs and inputs of the commodity, sum must less then
+(or equal to or more than) a user-specified value. For system-wide net commodity production
+constraint, for each *c*, sum over regions, assets, time slices.
+
+$$\sum_{r,a,ts} q_{r,a,c,ts} \leq commodity.constraint.rhs\\_ value(up)$$
+
+$$\sum_{r,a,ts} q_{r,a,c,ts} \geq commodity.constraint.rhs\\_ value(lo)$$
+
+$$\sum_{r,a,ts} q_{r,a,c,ts} = commodity.constraint.rhs\\_ value(fx)$$
+
+Similar constraints can be constructed for net commodity volume over specific regions or sets of
+regions.
+
+Production or consumption constraint: Likewise similar constraints can be constructed to limit
+absolute production or absolute consumption. In these cases selective choice of *q* focused on
+process inputs (consumption) or process outputs (production) can be applied.

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -50,7 +50,7 @@ defined for each commodity. Input/output ratio is a fixed value.
 >
 > for all commodity flows that the process has (except *pac1*). Where *pac1* is the first listed
 > primary activity commodity for the asset (i.e. all input and output flows are made proportional to
-> *pac1* flow).*
+> *pac1* flow).
 >
 > Note – need to handle cases where a flow is set to zero in the input data – should raise a
 > warning that the value has been ignored, specifying which region/asset/commodity.

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -71,7 +71,7 @@ For each *r*, *a*, *c*, *ts*:
 (**TBD**)
 
 for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a -ve
-sign), and “out” refers to output flow commodities (i.e. with a +ve sign).*
+sign), and “out” refers to output flow commodities (i.e. with a +ve sign).
 
 ### Asset-level capacity and availability constraints
 

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -1,0 +1,177 @@
+# Dispatch Optimisation Formulation
+
+Decision variables:
+
+\\( q_{r,a,c,ts} \\). Where *q* represents *c* commodity flow in region *r*, to/from asset *a*, in
+time slice *ts*.
+-ve values are flow into the asset, +ve values are flows from the asset. Note that *q* is a quantity
+flow (e.g. energy) as opposed to an intensity (e.g. power).
+
+where
+
+*r* = regions
+
+*a* = assets
+
+*c* = commodities
+
+*ts* = time_slices
+
+Objective function:
+
+$$
+  min. \sum_{r}{\sum_{a}{\sum_{c}{\sum_{ts}}}} cost_{r,a,c,ts} * q_{r,a,c,ts}
+$$
+
+Where *cost* is a vector of cost coefficients representing the cost of
+each commodity flow.
+
+$$
+  cost_{r,a,c,ts} = var\\_ opex_{r,a,pacs,ts} + flow\\_ cost_{r,a,c,ts} + commodity.cost_{r,c,ts}
+$$
+
+Constraints.
+
+TBD – does it make sense for all assets of the same type that are in the
+same region are grouped together in constraints (to reduce the number of
+constraints).
+
+## Asset-level input-output commodity balances
+
+### Non-flexible assets
+
+Assets where ratio between output/s and input/s is strictly proportional. *Energy commodity asset
+inputs and outputs are proportional to first-listed primary activity commodity at a time slice level
+defined for each commodity. Input/output ratio is a fixed value.*
+
+> For each *r*, *a*, *ts*, *c*:
+>
+> $$ \frac{q_{r,a,c,ts}}{flow_{r,a,ts,c}} - \frac{q_{r,a,pac1,ts}}{flow_{r,a,ts,pac1}} = 0 $$
+>
+> for all commodity flows that the process has (except *pac1*). Where *pac1* is the first listed
+> primary activity commodity for the asset (i.e. all input and output flows are made proportional to
+> *pac1* flow).*
+>
+> Note – need to handle cases where a flow is set to zero in the input data – should raise a
+> warning that the value has been ignored, specifying which region/asset/commodity.
+>
+> **TBD** - cases where time slice level of the commodity is seasonal or annual.
+
+### Commodity-flexible assets
+
+Assets where ratio of input/s to output/s can vary for selected commodities, subject to user-defined
+ratios between input and output.
+
+> Energy commodity asset inputs and outputs are constrained such that total inputs to total outputs
+> of selected commodities is limited to user-defined ratios. Furthermore, each commodity input or
+> output can be limited to be within a range, relative to other commodities.
+>
+> For each *r*, *a*, *c*, *ts*:
+>
+> **TBD**
+>
+> for all *c* that are flexible commodities. “in” refers to input flow commodities (i.e. with a -ve
+> sign), and “out” refers to output flow commodities (i.e. with a +ve sign).*
+
+### Asset-level capacity and availability constraints
+
+> Primary activity commodity/ies output must not exceed asset capacity or any other limit as
+> defined by availability factor constraint user inputs.
+>
+> For the capacity limits, for each *r*, *a*, *c*, *ts*. The sum of all PACs must be less than the
+> assets’ capacity:
+>
+> $$
+> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}} \leq 1
+> $$
+>
+> For the availability constraints, for each *r*, *a*, *c*, *ts*:
+>
+> $$
+> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+> \leq process.availability.value(up)_{r,a,ts}
+> $$
+>
+> $$
+> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+> \geq process.availability.value(lo)_{r,a,ts}
+> $$
+>
+> $$
+> \sum_{pacs} \frac{q_{r,a,c,ts}}{capacity\\_ a_{a} * time\\_ slice\\_ length_{ts}}
+> = process.availability.value(fx)_{r,a,ts}
+> $$
+>
+> The sum of all PACs must be within the assets' availability bounds. Similar constraints also
+> limit output of PACs to respect the availability constraints at time slice, seasonal or annual
+> levels. With appropriate selection of *q* on the LHS to match RHS temporal granularity.
+>
+> Note: Where availability is specified for a process at `DAYNIGHT` time slice level, it supersedes
+> the capacity limit constraint (i.e. you don’t need both).
+
+### Commodity balance constraints
+
+> Commodity supply-demand balance for a whole system (or for a single region or set of regions).
+> For each internal commodity that requires a strict balance (supply == demand, SED), it is an
+> equality constraint with just “1” for each relevant commodity and RHS equals 0. Note there is also
+> a special case where the commodity is a service demand (e.g. Mt steel produced), where net sum of
+> output must be equal to the demand.
+>
+> For supply-demand balance commodities. For each *r* and each *c*:
+>
+> $$\sum_{a,ts} q_{r,a,c,ts} = 0$$
+>
+> For a service demand, for each *c*, within a single region:
+>
+> $$\sum_{a,ts} q_{r,a,c,ts} = cr\\_ net\\_ fx$$
+>
+> Where *c* is a service demand commodity.
+>
+> **TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves.
+> **TBD** – trade between regions.
+
+### Asset-level commodity flow share constraints for flexible assets
+
+> Restricts share of flow amongst a set of specified flexible commodities. Constraints can be
+> constructed for input side of processes or output side of processes, or both.
+>
+> $$
+> q_{r,a,c,ts} \leq process.commodity.constraint.value(up)\_{r,a,c,ts} *
+> \left( \sum_{flexible\ c} q\_{r,a,c,ts} \right)
+> $$
+>
+> $$
+> q_{r,a,c,ts} \geq process.commodity.constraint.value(lo)\_{r,a,c,ts} *
+> \left( \sum\_{flexible\ c} q_{r,a,c,ts} \right)
+> $$
+>
+> $$
+> q_{r,a,c,ts} = process.commodity.constraint.value(fx)\_{r,a,c,ts} *
+> \left( \sum\_{flexible\ c} q\_{r,a,c,ts} \right)
+> $$
+>
+> Could be used to define flow limits on specific commodities in a flexible process. E.g. a
+> refinery that is flexible and can produce gasoline, diesel or jet fuel, but for a given crude oil
+> input only a limited amount of jet fuel can be produced and remainder of production must be either
+> diesel or gasoline (for example).
+
+### Other net and absolute commodity volume constraints
+
+<!-- markdownlint-disable-next-line MD033 -->
+> Net constraint: There might be a net CO<sub>2</sub> emissions limit of zero in 2050, or even a
+> negative value. Constraint applied on both outputs and inputs of the commodity, sum must less then
+> (or equal to or more than) a user-specified value. For system-wide net commodity production
+> constraint, for each *c*, sum over regions, assets, time slices.
+>
+> $$\sum_{r,a,ts} q_{r,a,c,ts} \leq commodity.constraint.rhs\\_ value(up)$$
+>
+> $$\sum_{r,a,ts} q_{r,a,c,ts} \geq commodity.constraint.rhs\\_ value(lo)$$
+>
+> $$\sum_{r,a,ts} q_{r,a,c,ts} = commodity.constraint.rhs\\_ value(fx)$$
+>
+> Similar constraints can be constructed for net commodity volume over specific regions or sets of
+> regions.
+>
+> Production or consumption constraint: Likewise similar constraints can be constructed to limit
+> absolute production or absolute consumption. In these cases selective choice of *q* focused on
+> process inputs (consumption) or process outputs (production) can be applied.

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -40,9 +40,9 @@ constraints).
 
 ### Non-flexible assets
 
-Assets where ratio between output/s and input/s is strictly proportional. *Energy commodity asset
+Assets where ratio between output/s and input/s is strictly proportional. Energy commodity asset
 inputs and outputs are proportional to first-listed primary activity commodity at a time slice level
-defined for each commodity. Input/output ratio is a fixed value.*
+defined for each commodity. Input/output ratio is a fixed value.
 
 > For each *r*, *a*, *ts*, *c*:
 >

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,9 +5,12 @@ faster version of [the older MUSE tool].
 
 To get started, please look at the [user guide]. For a list of relevant terms, see the [glossary].
 
+For details of the algorithm used, see the [dispatch optimisation formulation].
+
 The [API docs are available here].
 
 [the older MUSE tool]: https://github.com/EnergySystemsModellingLab/MUSE_OS
 [user guide]: ./user_guide.md
 [glossary]: ./glossary.md
 [API docs are available here]: ./api/muse2
+[dispatch optimisation formulation]: ./dispatch_optimisation.md

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,13 +4,12 @@ MUSE 2.0 is a tool for running simulations of energy systems, written in Rust. I
 faster version of [the older MUSE tool].
 
 To get started, please look at the [user guide]. For a list of relevant terms, see the [glossary].
-
 For details of the algorithm used, see the [dispatch optimisation formulation].
 
-The [API docs are available here].
+If you are a developer, please see the [developer guide].
 
 [the older MUSE tool]: https://github.com/EnergySystemsModellingLab/MUSE_OS
 [user guide]: ./user_guide.md
+[developer guide]: ./developer_guide.md
 [glossary]: ./glossary.md
-[API docs are available here]: ./api/muse2
 [dispatch optimisation formulation]: ./dispatch_optimisation.md


### PR DESCRIPTION
# Description

I thought it made sense to have this in a place where it's easily accessible. We can revise it as we go along. I used `pandoc` to auto-convert it from the SRS, but the equations in particular required a lot of manual tweaking to work (among other things it seems like in some contexts you have to escape the underscore in LaTeX equations, even where it's being used for a subscript). The content should be exactly the same as in the SRS though and I've double-checked that the equations all look ok.

To test it locally:

1. Install mdbook: `cargo install mdbook`
2. Serve: `mdbook serve -o`

I'm also happy to send screenshots if anyone doesn't want to go through this rigmarole.

@ahawkes Are you happy with this?

Closes #161.