### PR TITLE
Read in demand slices

### DIFF
--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -36,6 +36,8 @@ macro_rules! define_commodity_id_getter {
     };
 }
 
+pub(crate) use define_commodity_id_getter;
+
 /// Type of balance for application of cost
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
 pub enum BalanceType {

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -192,7 +192,13 @@ pub fn read_commodities(
         time_slice_info,
         year_range,
     );
-    let mut demand = read_demand(model_dir, &commodity_ids, region_ids, year_range);
+    let mut demand = read_demand(
+        model_dir,
+        &commodity_ids,
+        region_ids,
+        time_slice_info,
+        year_range,
+    );
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -192,7 +192,7 @@ pub fn read_commodities(
         time_slice_info,
         year_range,
     );
-    let mut demand = read_demand(model_dir, &commodity_ids, region_ids);
+    let mut demand = read_demand(model_dir, &commodity_ids, region_ids, year_range);
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,4 +1,4 @@
-use crate::demand::{read_demand_data, Demand};
+use crate::demand::{read_demand, Demand};
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
 use itertools::Itertools;
@@ -192,7 +192,7 @@ pub fn read_commodities(
         time_slice_info,
         year_range,
     );
-    let mut demand = read_demand_data(model_dir, &commodity_ids, region_ids);
+    let mut demand = read_demand(model_dir, &commodity_ids, region_ids);
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -25,7 +25,7 @@ pub struct Commodity {
     #[serde(skip)]
     pub costs: Vec<CommodityCost>,
     #[serde(skip)]
-    pub demand: Vec<Demand>,
+    pub demand_by_region: HashMap<Rc<str>, Demand>,
 }
 define_id_getter! {Commodity}
 
@@ -192,7 +192,7 @@ pub fn read_commodities(
         time_slice_info,
         year_range,
     );
-    let mut demand = read_demand_data(model_dir, &commodity_ids);
+    let mut demand = read_demand_data(model_dir, &commodity_ids, region_ids);
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {
@@ -200,7 +200,7 @@ pub fn read_commodities(
             commodity.costs = costs;
         }
         if let Some(demand) = demand.remove(id) {
-            commodity.demand = demand;
+            commodity.demand_by_region = demand;
         }
     }
 

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,3 +1,4 @@
+use crate::demand::{read_demand_data, Demand};
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
 use itertools::Itertools;
@@ -23,6 +24,8 @@ pub struct Commodity {
 
     #[serde(skip)]
     pub costs: Vec<CommodityCost>,
+    #[serde(skip)]
+    pub demand: Vec<Demand>,
 }
 define_id_getter! {Commodity}
 
@@ -189,11 +192,15 @@ pub fn read_commodities(
         time_slice_info,
         year_range,
     );
+    let mut demand = read_demand_data(model_dir, &commodity_ids);
 
     // Populate Vecs for each Commodity
     for (id, commodity) in commodities.iter_mut() {
         if let Some(costs) = costs.remove(id) {
             commodity.costs = costs;
+        }
+        if let Some(demand) = demand.remove(id) {
+            commodity.demand = demand;
         }
     }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -67,8 +67,6 @@ where
     let mut map_by_commodity = HashMap::new();
 
     for demand in iter {
-        // **TODO**: add validation checks here? e.g. check not negative, apply interpolation and
-        // extrapolation rules?
         let commodity_id = commodity_ids.get_id(&demand.commodity_id)?;
         let region_id = region_ids.get_id(&demand.region_id)?;
 
@@ -147,7 +145,6 @@ where
         });
     }
 
-    // TODO: Check for demand entries without any demand slices specified?
     Ok(())
 }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -221,6 +221,145 @@ COM1,West,2023,13"
     }
 
     #[test]
+    fn test_read_demand_from_iter() {
+        let commodity_ids = ["COM1".into()].into_iter().collect();
+        let region_ids = ["North".into(), "South".into()].into_iter().collect();
+        let year_range = 2020..=2030;
+
+        // Valid
+        let demand = [
+            Demand {
+                year: 2023,
+                region_id: "North".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "South".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 11.0,
+                demand_slices: Vec::new(),
+            },
+        ];
+        assert!(read_demand_from_iter(
+            demand.into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &year_range
+        )
+        .is_ok());
+
+        // Bad commodity ID
+        let demand = [
+            Demand {
+                year: 2023,
+                region_id: "North".to_string(),
+                commodity_id: "COM2".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "South".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 11.0,
+                demand_slices: Vec::new(),
+            },
+        ];
+        assert!(read_demand_from_iter(
+            demand.into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &year_range
+        )
+        .is_err());
+
+        // Bad region ID
+        let demand = [
+            Demand {
+                year: 2023,
+                region_id: "East".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "South".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 11.0,
+                demand_slices: Vec::new(),
+            },
+        ];
+        assert!(read_demand_from_iter(
+            demand.into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &year_range
+        )
+        .is_err());
+
+        // Bad year
+        let demand = [
+            Demand {
+                year: 2010,
+                region_id: "North".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "South".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 11.0,
+                demand_slices: Vec::new(),
+            },
+        ];
+        assert!(read_demand_from_iter(
+            demand.into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &year_range
+        )
+        .is_err());
+
+        // Multiple entries for same commodity and region
+        let demand = [
+            Demand {
+                year: 2023,
+                region_id: "North".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "North".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 10.0,
+                demand_slices: Vec::new(),
+            },
+            Demand {
+                year: 2023,
+                region_id: "South".to_string(),
+                commodity_id: "COM1".to_string(),
+                demand: 11.0,
+                demand_slices: Vec::new(),
+            },
+        ];
+        assert!(read_demand_from_iter(
+            demand.into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &year_range
+        )
+        .is_err());
+    }
+
+    #[test]
     fn test_read_demand_file() {
         let dir = tempdir().unwrap();
         create_demand_file(dir.path());

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -12,7 +12,7 @@ const DEMAND_SLICES_FILE_NAME: &str = "demand_slicing.csv";
 /// Represents a single demand entry in the dataset.
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Demand {
-    /// The year of the demand entry
+    /// The commodity this demand entry refers to
     pub commodity_id: String,
     /// The region of the demand entry
     pub region_id: String,

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -32,6 +32,7 @@ pub struct DemandSliceRaw {
     pub commodity_id: String,
     pub region_id: String,
     pub time_slice: String,
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     pub fraction: f64,
 }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -20,7 +20,7 @@ pub struct Demand {
     pub demand: f64,
 }
 
-fn read_demand_data_iter<I>(
+fn read_demand_iter<I>(
     iter: I,
     commodity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
@@ -59,15 +59,14 @@ where
 ///
 /// # Returns
 ///
-/// This function returns a `Vec<Demand>` with the parsed demand data.
-pub fn read_demand_data(
+/// This function returns demand data grouped by commodity and then region.
+pub fn read_demand(
     model_dir: &Path,
     commodity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
 ) -> HashMap<Rc<str>, HashMap<Rc<str>, Demand>> {
     let file_path = model_dir.join(DEMAND_FILE_NAME);
-    read_demand_data_iter(read_csv(&file_path), commodity_ids, region_ids)
-        .unwrap_input_err(&file_path)
+    read_demand_iter(read_csv(&file_path), commodity_ids, region_ids).unwrap_input_err(&file_path)
 }
 
 #[cfg(test)]
@@ -101,9 +100,9 @@ COM1,West,2023,13"
         let region_ids = ["North".into(), "South".into(), "East".into(), "West".into()]
             .into_iter()
             .collect();
-        let demand_data = read_demand_data(dir.path(), &commodity_ids, &region_ids);
+        let demand = read_demand(dir.path(), &commodity_ids, &region_ids);
         assert_eq!(
-            demand_data,
+            demand,
             HashMap::from_iter(
                 [(
                     "COM1".into(),

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -26,6 +26,7 @@ pub struct Demand {
     pub demand_slices: Vec<DemandSlice>,
 }
 
+/// How demand varies by time slice
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct DemandSlice {
     pub commodity_id: String,
@@ -34,6 +35,18 @@ pub struct DemandSlice {
     pub fraction: f64,
 }
 
+/// Read the demand data from an iterator
+///
+/// # Arguments
+///
+/// * `iter` - An iterator of `Demand`s
+/// * `commodity_ids` - All possible IDs of commodities
+/// * `region_ids` - All possible IDs for regions
+/// * `year_range` - The year range for the simulation
+///
+/// # Returns
+///
+/// The demand data (except for the demand slice information), grouped by commodity and region.
 fn read_demand_from_iter<I>(
     iter: I,
     commodity_ids: &HashSet<Rc<str>>,
@@ -68,6 +81,19 @@ where
     Ok(map_by_commodity)
 }
 
+/// Read the demand.csv file.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `commodity_ids` - All possible IDs of commodities
+/// * `region_ids` - All possible IDs for regions
+/// * `year_range` - The year range for the simulation
+///
+/// # Returns
+///
+/// The demand data except for the demand slice information, which resides in a separate CSV file.
+/// The data is grouped by commodity and region.
 fn read_demand_file(
     model_dir: &Path,
     commodity_ids: &HashSet<Rc<str>>,
@@ -79,6 +105,7 @@ fn read_demand_file(
         .unwrap_input_err(&file_path)
 }
 
+/// Try to get demand for the given commodity and region. Returns `None` if not found.
 fn try_get_demand<'a>(
     commodity_id: &str,
     region_id: &str,
@@ -87,6 +114,7 @@ fn try_get_demand<'a>(
     demand.get_mut(commodity_id)?.get_mut(region_id)
 }
 
+/// Read demand slices from an iterator and store them in `demand`.
 fn read_demand_slices_from_iter<I>(
     iter: I,
     file_path: &Path,
@@ -112,6 +140,12 @@ fn read_demand_slices_from_iter<I>(
     // TODO: Check for demand entries without any demand slices specified?
 }
 
+/// Read demand slices from specified model directory.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `demand` - Demand data grouped by commodity and region
 fn read_demand_slices(model_dir: &Path, demand: &mut HashMap<Rc<str>, HashMap<Rc<str>, Demand>>) {
     let file_path = model_dir.join(DEMAND_SLICES_FILE_NAME);
     read_demand_slices_from_iter(read_csv(&file_path), &file_path, demand)

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -517,7 +517,7 @@ COM1,West,2023,13"
             fraction: 1.0,
         };
         assert!(read_demand_slices_from_iter(
-            [demand_slice.clone()].into_iter(),
+            [demand_slice].into_iter(),
             &time_slice_info,
             &mut demand,
         )

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -26,6 +26,7 @@ define_commodity_id_getter! {Demand}
 /// # Arguments
 ///
 /// * `model_dir` - Folder containing model configuration files
+/// * `commodity_ids` - All possible IDs of commodities
 ///
 /// # Returns
 ///

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -13,7 +13,7 @@ pub struct Demand {
     pub region_id: String,
     /// The year of the demand entry
     pub year: u32,
-    /// The year of the demand entry
+    /// Annual demand quantity
     pub demand: f64,
 }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -262,26 +262,28 @@ COM1,West,2023,13"
         );
     }
 
-    fn create_demand() -> HashMap<Rc<str>, HashMap<Rc<str>, Demand>> {
-        let demand_by_region = [(
-            "GBR".into(),
-            Demand {
-                commodity_id: "COM1".into(),
-                region_id: "GBR".into(),
-                year: 2020,
-                demand: 1.0,
-                demand_slices: Vec::new(),
-            },
-        )];
-
-        [("COM1".into(), demand_by_region.into_iter().collect())]
-            .into_iter()
-            .collect()
-    }
-
     #[test]
-    fn test_read_demand_slices_from_iter_good() {
-        let mut demand = create_demand();
+    fn test_read_demand_slices_from_iter() {
+        // Demand grouped by region
+        let mut demand = [(
+            "COM1".into(),
+            [(
+                "GBR".into(),
+                Demand {
+                    commodity_id: "COM1".into(),
+                    region_id: "GBR".into(),
+                    year: 2020,
+                    demand: 1.0,
+                    demand_slices: Vec::new(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        )]
+        .into_iter()
+        .collect();
+
+        // Valid
         let demand_slice = DemandSlice {
             commodity_id: "COM1".into(),
             region_id: "GBR".into(),
@@ -295,12 +297,8 @@ COM1,West,2023,13"
                 .demand_slices,
             vec![demand_slice]
         );
-    }
 
-    /// Demand slice with invalid commodity
-    #[test]
-    fn test_read_demand_slices_from_iter_bad_commodity() {
-        let mut demand = create_demand();
+        // Bad commodity
         let demand_slice = DemandSlice {
             commodity_id: "COM2".into(),
             region_id: "GBR".into(),
@@ -308,12 +306,8 @@ COM1,West,2023,13"
             fraction: 1.0,
         };
         assert!(read_demand_slices_from_iter([demand_slice].into_iter(), &mut demand).is_err());
-    }
 
-    /// Demand slice with invalid region
-    #[test]
-    fn test_read_demand_slices_from_iter_bad_region() {
-        let mut demand = create_demand();
+        // Bad region
         let demand_slice = DemandSlice {
             commodity_id: "COM1".into(),
             region_id: "USA".into(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -21,21 +21,6 @@ pub fn read_csv<'a, T: DeserializeOwned + 'a>(file_path: &'a Path) -> impl Itera
         .unwrap_input_err(file_path)
 }
 
-/// Read a series of type `T`s from a CSV file into a `Vec<T>`.
-///
-/// # Arguments
-///
-/// * `file_path` - Path to the CSV file
-pub fn read_csv_as_vec<T: DeserializeOwned>(file_path: &Path) -> Vec<T> {
-    let vec: Vec<T> = read_csv(file_path).collect();
-
-    if vec.is_empty() {
-        input_panic(file_path, "CSV file cannot be empty");
-    }
-
-    vec
-}
-
 /// Parse a TOML file at the specified path.
 ///
 /// # Arguments
@@ -261,10 +246,10 @@ mod tests {
 
     /// Test a normal read
     #[test]
-    fn test_read_csv_as_vec() {
+    fn test_read_csv() {
         let dir = tempdir().unwrap();
         let file_path = create_csv_file(dir.path(), "id,value\nhello,1\nworld,2\n");
-        let records: Vec<Record> = read_csv_as_vec(&file_path);
+        let records: Vec<Record> = read_csv(&file_path).collect();
         assert_eq!(
             records,
             &[
@@ -278,15 +263,6 @@ mod tests {
                 }
             ]
         );
-    }
-
-    /// Empty CSV files should yield an error
-    #[test]
-    #[should_panic]
-    fn test_read_csv_as_vec_empty() {
-        let dir = tempdir().unwrap();
-        let file_path = create_csv_file(dir.path(), "id,value\n");
-        read_csv_as_vec::<Record>(&file_path);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ pub fn run(model: &Model) {
     // TODO: Remove this once we're actually doing something with these values
     println!("Commodities: {:?}", model.commodities);
     println!("Regions: {:?}", model.regions);
-    println!("Demand data: {:?}", model.demand_data);
     println!("Processes: {:?}", model.processes);
     println!("Time slices: {:?}", model.time_slice_info);
     println!("Milestone years: {:?}", model.milestone_years);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,7 @@
 //! Code for simulation models.
 use crate::agent::{read_agents, Agent};
 use crate::commodity::{read_commodities, Commodity};
-use crate::demand::{read_demand_data, Demand};
-use crate::input::{read_toml, UnwrapInputError};
+use crate::input::*;
 use crate::process::{read_processes, Process};
 use crate::region::{read_regions, Region};
 use crate::time_slice::{read_time_slice_info, TimeSliceInfo};
@@ -20,7 +19,6 @@ pub struct Model {
     pub commodities: HashMap<Rc<str>, Commodity>,
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slice_info: TimeSliceInfo,
-    pub demand_data: HashMap<Rc<str>, Vec<Demand>>,
     pub regions: HashMap<Rc<str>, Region>,
 }
 
@@ -89,7 +87,6 @@ impl Model {
             &time_slice_info,
             &year_range,
         );
-        let commodity_ids = commodities.keys().cloned().collect();
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
@@ -105,7 +102,6 @@ impl Model {
             commodities,
             processes,
             time_slice_info,
-            demand_data: read_demand_data(model_dir.as_ref(), &commodity_ids),
             regions,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub commodities: HashMap<Rc<str>, Commodity>,
     pub processes: HashMap<Rc<str>, Process>,
     pub time_slice_info: TimeSliceInfo,
-    pub demand_data: Vec<Demand>,
+    pub demand_data: HashMap<Rc<str>, Vec<Demand>>,
     pub regions: HashMap<Rc<str>, Region>,
 }
 
@@ -89,6 +89,7 @@ impl Model {
             &time_slice_info,
             &year_range,
         );
+        let commodity_ids = commodities.keys().cloned().collect();
         let processes = read_processes(
             model_dir.as_ref(),
             &region_ids,
@@ -104,7 +105,7 @@ impl Model {
             commodities,
             processes,
             time_slice_info,
-            demand_data: read_demand_data(model_dir.as_ref()),
+            demand_data: read_demand_data(model_dir.as_ref(), &commodity_ids),
             regions,
         }
     }


### PR DESCRIPTION
# Description

This PR adds support for reading in `demand_slicing.csv`, which determines how demand varies with time slice.

While I was at it, I reworked the data structures we use for storing demand data such that:

1. Demand is now a field of commodities
2. Demand is grouped by region ID

In retrospect, I might have been a bit premature in implementing the second one: it only really makes sense if we will be looking at demand region by region for each commodity, which I *think* is the case, though I'm not totally sure. I thought I should just ask for advice on this though rather than just unpicking it from the other work. Thoughts welcome!

Closes #61.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
