### PR TITLE
Use `anyhow` crate for read_toml error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["energy", "modelling"]
 categories = ["science", "simulation", "command-line-utilities"]
 
 [dependencies]
+anyhow = "1.0.93"
 csv = "1.3.0"
 env_logger = "0.11.3"
 float-cmp = "0.10.0"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! Common routines for handling input data.
-use anyhow::Result;
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
@@ -43,8 +43,10 @@ pub fn read_csv_as_vec<T: DeserializeOwned>(file_path: &Path) -> Vec<T> {
 ///
 /// * `file_path` - Path to the TOML file
 pub fn read_toml<T: DeserializeOwned>(file_path: &Path) -> Result<T> {
-    let toml_str = fs::read_to_string(file_path)?;
-    let toml_data = toml::from_str(&toml_str)?;
+    let toml_str = fs::read_to_string(file_path)
+        .with_context(|| format!("Failed to read `{}`", file_path.to_string_lossy()))?;
+    let toml_data = toml::from_str(&toml_str)
+        .with_context(|| format!("Could not parse `{}`", file_path.to_string_lossy()))?;
     Ok(toml_data)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,13 @@ fn main() {
     let model_dir = PathBuf::from(args[1].as_str());
 
     // Read program settings
-    let settings = Settings::from_path(&model_dir);
+    let settings = Settings::from_path(&model_dir).unwrap();
 
     // Set the program log level
     log::init(settings.log_level.as_deref());
     log_panics::init(); // Write panic info to logger rather than stderr
 
-    let model = Model::from_path(&model_dir);
+    let model = Model::from_path(&model_dir).unwrap();
     info!("Model loaded successfully.");
 
     // Run simulation

--- a/src/model.rs
+++ b/src/model.rs
@@ -61,7 +61,7 @@ impl ModelFile {
     /// * `model_dir` - Folder containing model configuration files
     pub fn from_path<P: AsRef<Path>>(model_dir: P) -> ModelFile {
         let file_path = model_dir.as_ref().join(MODEL_FILE_NAME);
-        let model_file: ModelFile = read_toml(&file_path);
+        let model_file: ModelFile = read_toml(&file_path).unwrap_input_err(&file_path);
         check_milestone_years(&model_file.milestone_years.years).unwrap_input_err(&file_path);
 
         model_file

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 //! Code for loading program settings.
-use crate::input::read_toml;
+use crate::input::{read_toml, UnwrapInputError};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -25,7 +25,7 @@ impl Settings {
             return Settings::default();
         }
 
-        read_toml(&file_path)
+        read_toml(&file_path).unwrap_input_err(&file_path)
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,6 @@
 //! Code for loading program settings.
-use crate::input::{read_toml, UnwrapInputError};
+use crate::input::read_toml;
+use anyhow::Result;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -19,13 +20,13 @@ impl Settings {
     /// # Arguments
     ///
     /// * `model_dir` - Folder containing model configuration files
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Settings {
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Settings> {
         let file_path = model_dir.as_ref().join(SETTINGS_FILE_NAME);
         if !file_path.is_file() {
-            return Settings::default();
+            return Ok(Settings::default());
         }
 
-        read_toml(&file_path).unwrap_input_err(&file_path)
+        read_toml(&file_path)
     }
 }
 
@@ -39,7 +40,10 @@ mod tests {
     #[test]
     fn test_settings_from_path_no_file() {
         let dir = tempdir().unwrap();
-        assert_eq!(Settings::from_path(dir.path()), Settings::default());
+        assert_eq!(
+            Settings::from_path(dir.path()).unwrap(),
+            Settings::default()
+        );
     }
 
     #[test]
@@ -50,7 +54,7 @@ mod tests {
             writeln!(file, "log_level = \"warn\"").unwrap();
         }
         assert_eq!(
-            Settings::from_path(dir.path()),
+            Settings::from_path(dir.path()).unwrap(),
             Settings {
                 log_level: Some("warn".to_string())
             }

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -15,5 +15,5 @@ fn get_model_dir() -> PathBuf {
 /// An integration test which attempts to load the example model
 #[test]
 fn test_model_from_path() {
-    Model::from_path(get_model_dir());
+    Model::from_path(get_model_dir()).unwrap();
 }


### PR DESCRIPTION
# Description

This PR begins using the `anyhow` crate for error handling. It makes only a few small changes:
- Adds `anyhow` to dependencies
- Defers unwrapping errors from reading TOML files to `main` (i.e. model.toml and settings.toml)
- Makes `read_toml` return an `anyhow::Result` type and propagates errors
- Uses `anyhow` to add context to the errors and simplify `Result` types

This partially addresses #157, and is intentionally kept small so that `anyhow` can be used with new code after this point.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
