### PR TITLE
Use new Rust action for CI

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y cmake libclang-dev
-
       - name: Check docs
         run: cargo doc --no-deps --document-private-items
 

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -12,41 +12,31 @@ jobs:
   coverage:
     name: Build and test with coverage
     runs-on: ubuntu-latest
-    env:
-      # Make warnings fatal
-      # **HACK**: Explicitly link against zlib to avoid linking failure
-      RUSTFLAGS: -D warnings -lz
-    container:
-      image: xd009642/tarpaulin:develop-nightly
-      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cargo Cache
-        uses: actions/cache@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          path: |
-            ~/.cargo
-            target
-          key: ubuntu-latest-cargo-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ubuntu-latest-cargo-${{ hashFiles('Cargo.toml') }}
-            ubuntu-latest-cargo
+          toolchain: stable
 
       - name: Install dependencies
         run: |
-          apt update
-          apt install -y cmake libclang-dev
+          sudo apt update
+          sudo apt install -y cmake libclang-dev
 
       - name: Check docs
         run: cargo doc --no-deps --document-private-items
 
       - run: cargo build --verbose
+      - run: cargo test --verbose
+
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
@@ -57,9 +47,6 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ${{ matrix.os }}
-    env:
-      # Make warnings fatal
-      RUSTFLAGS: -D warnings
     strategy:
       fail-fast: false
       matrix:
@@ -68,17 +55,7 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v4
-      - name: Cargo Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            target
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ matrix.os }}-cargo
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo build --verbose

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -12,6 +12,8 @@ jobs:
   coverage:
     name: Build and test with coverage
     runs-on: ubuntu-latest
+    # Longer timeout because this job involves more steps
+    timeout-minutes: 20
     env:
       # Make warnings fatal
       RUSTDOCFLAGS: -D warnings
@@ -48,6 +50,7 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -12,6 +12,9 @@ jobs:
   coverage:
     name: Build and test with coverage
     runs-on: ubuntu-latest
+    env:
+      # Make warnings fatal
+      RUSTDOCFLAGS: -D warnings
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +31,10 @@ jobs:
       - name: Check docs
         run: cargo doc --no-deps --document-private-items
 
+        # Continue even if docs fail
       - run: cargo build --verbose
+        if: always()
+
       - run: cargo test --verbose
 
       - name: Install tarpaulin

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       # Make warnings fatal
       RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Setup pages
         uses: actions/configure-pages@v5
       - name: Install mdBook

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   pre-commit:
     runs-on: [ubuntu-latest]
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
This PR uses a new and improved Rust setup action for CI workflows, as suggested by @cc-a. It seems to be better maintained and handles the cargo caching business itself, which means we can simplify our workflows a bit.

It also gave me a chance to revisit all the hackery we were doing to make `cargo tarpaulin` work (which we use to generate code coverage). Previously, you needed a nightly build of cargo etc. to make it work, but that no longer appears to be necessary so now it's just a case of running `cargo install cargo-tarpaulin`.

Closes #133. Closes #49.