### PR TITLE
Use `anyhow` crate for `time_slice.rs`

### DIFF
--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -3,7 +3,7 @@
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
 use crate::input::*;
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use float_cmp::approx_eq;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -75,7 +75,7 @@ impl TimeSliceInfo {
         let (season, time_of_day) = time_slice
             .split('.')
             .collect_tuple()
-            .ok_or(anyhow!("Time slice must be in the form season.time_of_day"))?;
+            .context("Time slice must be in the form season.time_of_day")?;
         let season = self
             .seasons
             .iter()

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -3,7 +3,7 @@
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
 use crate::input::*;
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{ensure, Context, Result};
 use float_cmp::approx_eq;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -80,12 +80,12 @@ impl TimeSliceInfo {
             .seasons
             .iter()
             .find(|item| item.eq_ignore_ascii_case(season))
-            .ok_or(anyhow!("{} is not a known season", season))?;
+            .with_context(|| format!("{} is not a known season", season))?;
         let time_of_day = self
             .times_of_day
             .iter()
             .find(|item| item.eq_ignore_ascii_case(time_of_day))
-            .ok_or(anyhow!("{} is not a known time of day", time_of_day))?;
+            .with_context(|| format!("{} is not a known time of day", time_of_day))?;
 
         Ok(TimeSliceID {
             season: Rc::clone(season),


### PR DESCRIPTION
# Description

I was going to refactor `time_slice.rs` a bit for #202 anyway, so I thought it made sense to convert it over to using `anyhow` first.

Closes #201.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
