### PR TITLE
Warn about undocumented code

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::input::*;
 use crate::region::*;
 use serde::Deserialize;

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
 use itertools::Itertools;

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::input::read_csv_as_vec;
 use serde::Deserialize;
 use std::path::Path;

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
 //! Common routines for handling input data.
+#![allow(missing_docs)]
 use anyhow::{ensure, Context, Result};
 use itertools::Itertools;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,15 @@
 //! High level functionality for launching the simulation.
 #![warn(missing_docs)]
+pub mod agent;
+pub mod commodity;
+pub mod demand;
+pub mod input;
 pub mod log;
 pub mod model;
+pub mod process;
+pub mod region;
 pub mod settings;
-
-mod agent;
-mod commodity;
-mod demand;
-mod input;
-mod process;
-mod region;
-mod time_slice;
+pub mod time_slice;
 
 use crate::model::Model;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! High level functionality for launching the simulation.
+#![warn(missing_docs)]
 pub mod log;
 pub mod model;
 pub mod settings;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,4 @@
+//! Code for setting up the program logger.
 use env_logger::Env;
 
 pub(crate) const DEFAULT_LOG_LEVEL: &str = "info";

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 //! Code for simulation models.
+#![allow(missing_docs)]
 use crate::agent::{read_agents, Agent};
 use crate::commodity::{read_commodities, Commodity};
 use crate::demand::{read_demand_data, Demand};

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::commodity::Commodity;
 use crate::input::*;
 use crate::region::*;

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::input::*;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,9 +6,10 @@ use std::path::Path;
 
 const SETTINGS_FILE_NAME: &str = "settings.toml";
 
-/// Program settings
+/// Program settings from config file
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct Settings {
+    /// The user's preferred logging level
     pub log_level: Option<String>,
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,6 +2,7 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
+#![allow(missing_docs)]
 use crate::input::*;
 use float_cmp::approx_eq;
 use itertools::Itertools;


### PR DESCRIPTION
See #192.

It seems like we can get warnings about undocumented (public) code, but the option is not enabled by default. I think this would be useful, so I've enabled it crate-wide, and have suppressed the warning individually for modules with undocumented code (currently this is most of them!).

My plan is to make #192 into an umbrella issue with separate issues for fixing individual files. @Sahil590 is adding some doc comments (#162), though there will still be bits to document after this is completed. (In any case we should wait until he's had a first pass at files before adding more doc comments to them.)

@HarmonicReflux FYI this will create a small merge conflict with your PR, because I've added a comment to the top of `log.rs`. Shouldn't be a big problem though.