### PR TITLE
Add code to read in assets

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,4 @@
+use crate::asset::{read_assets, Asset};
 use crate::input::*;
 use crate::region::*;
 use serde::Deserialize;
@@ -62,6 +63,8 @@ pub struct Agent {
     pub regions: RegionSelection,
     #[serde(skip)]
     pub objectives: Vec<AgentObjective>,
+    #[serde(skip)]
+    pub assets: Vec<Asset>,
 }
 define_id_getter! {Agent}
 
@@ -263,11 +266,15 @@ pub fn read_agents(
     let mut agent_regions =
         read_regions_for_entity::<AgentRegion>(&file_path, &agent_ids, region_ids);
     let mut objectives = read_agent_objectives(model_dir, &agents);
+    let mut assets = read_assets(model_dir, &agent_ids, process_ids, region_ids);
 
     // Populate each Agent's Vecs
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();
         agent.objectives = objectives.remove(id).unwrap();
+
+        // **CHECK**: Can you have agents without assets?
+        agent.assets = assets.remove(id).unwrap_or_default();
     }
 
     agents
@@ -294,6 +301,7 @@ mod tests {
             annual_cost_limit: None,
             regions: RegionSelection::All,
             objectives: Vec::new(),
+            assets: Vec::new(),
         }];
         let expected = HashMap::from_iter([("agent".into(), agents[0].clone())]);
         let actual = read_agents_file_from_iter(agents.into_iter(), &process_ids).unwrap();
@@ -312,6 +320,7 @@ mod tests {
             annual_cost_limit: None,
             regions: RegionSelection::All,
             objectives: Vec::new(),
+            assets: Vec::new(),
         }];
         assert!(read_agents_file_from_iter(agents.into_iter(), &process_ids).is_err());
 
@@ -328,6 +337,7 @@ mod tests {
                 annual_cost_limit: None,
                 regions: RegionSelection::All,
                 objectives: Vec::new(),
+                assets: Vec::new(),
             },
             Agent {
                 id: "agent".into(),
@@ -340,6 +350,7 @@ mod tests {
                 annual_cost_limit: None,
                 regions: RegionSelection::All,
                 objectives: Vec::new(),
+                assets: Vec::new(),
             },
         ];
         assert!(read_agents_file_from_iter(agents.into_iter(), &process_ids).is_err());
@@ -401,6 +412,7 @@ mod tests {
                 annual_cost_limit: None,
                 regions: RegionSelection::All,
                 objectives: Vec::new(),
+                assets: Vec::new(),
             },
         )]
         .into_iter()

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,6 @@
 use crate::asset::{read_assets, Asset};
 use crate::input::*;
+use crate::process::Process;
 use crate::region::*;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
@@ -256,17 +257,18 @@ pub fn read_agents_file(
 /// A map of Agents, with the agent ID as the key
 pub fn read_agents(
     model_dir: &Path,
-    process_ids: &HashSet<Rc<str>>,
+    processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
 ) -> HashMap<Rc<str>, Agent> {
-    let mut agents = read_agents_file(model_dir, process_ids);
+    let process_ids = processes.keys().cloned().collect();
+    let mut agents = read_agents_file(model_dir, &process_ids);
     let agent_ids = agents.keys().cloned().collect();
 
     let file_path = model_dir.join(AGENT_REGIONS_FILE_NAME);
     let mut agent_regions =
         read_regions_for_entity::<AgentRegion>(&file_path, &agent_ids, region_ids);
     let mut objectives = read_agent_objectives(model_dir, &agents);
-    let mut assets = read_assets(model_dir, &agent_ids, process_ids, region_ids);
+    let mut assets = read_assets(model_dir, &agent_ids, processes, region_ids);
 
     // Populate each Agent's Vecs
     for (id, agent) in agents.iter_mut() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -275,8 +275,6 @@ pub fn read_agents(
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();
         agent.objectives = objectives.remove(id).unwrap();
-
-        // **CHECK**: Can you have agents without assets?
         agent.assets = assets.remove(id).unwrap_or_default();
     }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,0 +1,73 @@
+use itertools::Itertools;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::error::Error;
+use std::path::Path;
+use std::rc::Rc;
+
+use crate::input::*;
+
+const ASSETS_FILE_NAME: &str = "assets.csv";
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Asset {
+    pub process_id: String,
+    pub region_id: String,
+    pub agent_id: String,
+    pub capacity: f64,
+    pub commission_year: u32,
+}
+
+/// Process assets from an iterator.
+///
+/// # Arguments
+///
+/// * `iter` - Iterator of `AssetRaw`s
+/// * `model_dir` - Folder containing model configuration files
+/// * `process_ids` - All possible process IDs
+/// * `region_ids` - All possible region IDs
+///
+/// # Returns
+///
+/// A `Vec` of assets.
+fn read_assets_from_iter<I>(
+    iter: I,
+    process_ids: &HashSet<Rc<str>>,
+    region_ids: &HashSet<Rc<str>>,
+) -> Result<Vec<Asset>, Box<dyn Error>>
+where
+    I: Iterator<Item = Asset>,
+{
+    iter.map(|asset| {
+        if !process_ids.contains(asset.process_id.as_str()) {
+            Err(format!("Invalid process ID: {}", asset.process_id))?;
+        }
+        if !region_ids.contains(asset.region_id.as_str()) {
+            Err(format!("Invalid region ID: {}", asset.region_id))?;
+        }
+
+        Ok(asset)
+    })
+    .process_results(|iter| iter.collect())
+}
+
+/// Read assets CSV file from model directory.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `process_ids` - All possible process IDs
+/// * `region_ids` - All possible region IDs
+///
+/// # Returns
+///
+/// A `Vec` of assets.
+pub fn read_assets(
+    model_dir: &Path,
+    process_ids: &HashSet<Rc<str>>,
+    region_ids: &HashSet<Rc<str>>,
+) -> Vec<Asset> {
+    let file_path = model_dir.join(ASSETS_FILE_NAME);
+    read_assets_from_iter(read_csv(&file_path), process_ids, region_ids)
+        .unwrap_input_err(&file_path)
+}

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -3,7 +3,7 @@
 //! For a description of what assets are, please see the glossary.
 use crate::input::*;
 use crate::process::Process;
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -59,7 +59,7 @@ where
         let agent_id = agent_ids.get_id(&asset.agent_id)?;
         let process = processes
             .get(asset.process_id.as_str())
-            .ok_or_else(|| anyhow!("Invalid process ID: {}", &asset.process_id))?;
+            .with_context(|| format!("Invalid process ID: {}", &asset.process_id))?;
         let region_id = region_ids.get_id(&asset.region_id)?;
 
         Ok((

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,5 @@ pub fn run(model: &Model) {
     println!("Demand data: {:?}", model.demand_data);
     println!("Processes: {:?}", model.processes);
     println!("Time slices: {:?}", model.time_slice_info);
-    println!("Assets: {:?}", model.assets);
     println!("Milestone years: {:?}", model.milestone_years);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod model;
 pub mod settings;
 
 mod agent;
+mod asset;
 mod commodity;
 mod demand;
 mod input;
@@ -25,5 +26,6 @@ pub fn run(model: &Model) {
     println!("Demand data: {:?}", model.demand_data);
     println!("Processes: {:?}", model.processes);
     println!("Time slices: {:?}", model.time_slice_info);
+    println!("Assets: {:?}", model.assets);
     println!("Milestone years: {:?}", model.milestone_years);
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -18,7 +18,7 @@ pub struct Model {
     pub milestone_years: Vec<u32>,
     pub agents: HashMap<Rc<str>, Agent>,
     pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
-    pub processes: HashMap<Rc<str>, Process>,
+    pub processes: HashMap<Rc<str>, Rc<Process>>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,
     pub regions: HashMap<Rc<str>, Region>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 //! Code for simulation models.
 use crate::agent::{read_agents, Agent};
+use crate::asset::{read_assets, Asset};
 use crate::commodity::{read_commodities, Commodity};
 use crate::demand::{read_demand_data, Demand};
 use crate::input::{read_toml, UnwrapInputError};
@@ -19,6 +20,7 @@ pub struct Model {
     pub agents: HashMap<Rc<str>, Agent>,
     pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
     pub processes: HashMap<Rc<str>, Process>,
+    pub assets: Vec<Asset>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,
     pub regions: HashMap<Rc<str>, Region>,
@@ -98,12 +100,14 @@ impl Model {
         );
         let process_ids = processes.keys().cloned().collect();
         let agents = read_agents(model_dir.as_ref(), &process_ids, &region_ids);
+        let assets = read_assets(model_dir.as_ref(), &process_ids, &region_ids);
 
         Model {
             milestone_years: model_file.milestone_years.years,
             agents,
             commodities,
             processes,
+            assets,
             time_slice_info,
             demand_data: read_demand_data(model_dir.as_ref()),
             regions,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,5 @@
 //! Code for simulation models.
 use crate::agent::{read_agents, Agent};
-use crate::asset::{read_assets, Asset};
 use crate::commodity::{read_commodities, Commodity};
 use crate::demand::{read_demand_data, Demand};
 use crate::input::{read_toml, UnwrapInputError};
@@ -20,7 +19,6 @@ pub struct Model {
     pub agents: HashMap<Rc<str>, Agent>,
     pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
     pub processes: HashMap<Rc<str>, Process>,
-    pub assets: Vec<Asset>,
     pub time_slice_info: TimeSliceInfo,
     pub demand_data: Vec<Demand>,
     pub regions: HashMap<Rc<str>, Region>,
@@ -100,14 +98,12 @@ impl Model {
         );
         let process_ids = processes.keys().cloned().collect();
         let agents = read_agents(model_dir.as_ref(), &process_ids, &region_ids);
-        let assets = read_assets(model_dir.as_ref(), &process_ids, &region_ids);
 
         Model {
             milestone_years: model_file.milestone_years.years,
             agents,
             commodities,
             processes,
-            assets,
             time_slice_info,
             demand_data: read_demand_data(model_dir.as_ref()),
             regions,

--- a/src/model.rs
+++ b/src/model.rs
@@ -96,8 +96,7 @@ impl Model {
             &time_slice_info,
             &year_range,
         );
-        let process_ids = processes.keys().cloned().collect();
-        let agents = read_agents(model_dir.as_ref(), &process_ids, &region_ids);
+        let agents = read_agents(model_dir.as_ref(), &processes, &region_ids);
 
         Model {
             milestone_years: model_file.milestone_years.years,

--- a/src/process.rs
+++ b/src/process.rs
@@ -388,7 +388,7 @@ pub fn read_processes(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
-) -> HashMap<Rc<str>, Process> {
+) -> HashMap<Rc<str>, Rc<Process>> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path);
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
@@ -422,7 +422,7 @@ pub fn read_processes(
                 regions,
             };
 
-            (id, process)
+            (id, process.into())
         })
         .collect()
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -187,7 +187,7 @@ impl ProcessParameterRaw {
     }
 }
 
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Deserialize)]
 pub struct ProcessParameter {
     pub process_id: String,
     pub years: RangeInclusive<u32>,


### PR DESCRIPTION
# Description

This PR adds the code for reading in assets from the `assets.csv` file along with providing the relevant data structures. These assets are assigned to a field of the corresponding `Agent`. I've used the `anyhow` crate for the error handling.

I've got a question for anyone who has an idea: currently the code allows for agents that have no assets, but does that make sense? It sounds a bit daft to me, but then again I may be misunderstanding what it is that agents are supposed to do.

FYI @Sahil590 I've used the definitions in the SRS for the doc comments, so that's another bit of #162 done.

Closes #63.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
