### PR TITLE
Use `anyhow` for `demand.rs` + misc tidying

### DIFF
--- a/src/demand.rs
+++ b/src/demand.rs
@@ -1,7 +1,7 @@
 //! Code for working with demand for a given commodity. Demand can vary by region and year.
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::ops::RangeInclusive;
@@ -137,11 +137,10 @@ where
 {
     for slice in iter {
         let demand =
-            try_get_demand(&slice.commodity_id, &slice.region_id, demand).ok_or_else(|| {
-                anyhow!(
+            try_get_demand(&slice.commodity_id, &slice.region_id, demand).with_context(|| {
+                format!(
                     "No demand specified for commodity {} in region {}",
-                    &slice.commodity_id,
-                    &slice.region_id
+                    &slice.commodity_id, &slice.region_id
                 )
             })?;
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Code for working with demand for a given commodity. Demand can vary by region and year.
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use anyhow::{anyhow, ensure, Result};
@@ -40,7 +40,9 @@ struct DemandSliceRaw {
 /// How demand varies by time slice
 #[derive(Debug, PartialEq)]
 pub struct DemandSlice {
+    /// Which time slice(s) this applies to
     pub time_slice: TimeSliceSelection,
+    /// The fraction of total demand (between 0 and 1 inclusive)
     pub fraction: f64,
 }
 

--- a/src/demand.rs
+++ b/src/demand.rs
@@ -29,12 +29,12 @@ pub struct Demand {
 }
 
 #[derive(Clone, Deserialize)]
-pub struct DemandSliceRaw {
-    pub commodity_id: String,
-    pub region_id: String,
-    pub time_slice: String,
+struct DemandSliceRaw {
+    commodity_id: String,
+    region_id: String,
+    time_slice: String,
     #[serde(deserialize_with = "deserialise_proportion_nonzero")]
-    pub fraction: f64,
+    fraction: f64,
 }
 
 /// How demand varies by time slice


### PR DESCRIPTION
# Description

This PR changes `demand.rs` to use `anyhow`, which should make it tidier.

While I was at it, I fixed a couple of other things:

- `DemandSliceRaw` was public, even though it didn't need to be
- I added missing doc comments to all the public bits of code

Closes #205. Closes #217.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
