### PR TITLE
Remove `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Ensure that all PRs must be approved by at least one of the below
-* @alexdewar @dalonsoa @tsmbland


### PR DESCRIPTION
We don't really need to be tagging everyone on every PR, so let's remove this file.

I've updated the branch protection rule so that reviews from code owners are no longer required.

Closes #214.