### PR TITLE
Add instructions on generating test coverage to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 # mdBook output
 book/
 index.html
+
+# Coverage report from tarpaulin
+tarpaulin-report.html

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -38,6 +38,29 @@ cargo test
 
 More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
 
+## Checking test coverage
+
+We use [Codecov](https://about.codecov.io/) to check whether pull requests introduce code without
+tests.
+
+To check coverage locally (i.e. to make sure newly written code has tests), we recommend using
+[Tarpaulin](https://github.com/xd009642/tarpaulin).
+
+It can be installed with:
+
+```sh
+cargo install cargo-tarpaulin
+```
+
+Once installed, you can use it like so:
+
+```sh
+cargo tarpaulin --out html
+```
+
+This will generate a file, `tarpaulin-report.html`, showing which lines of code are not currently
+covered by tests.
+
 ## Developing the documentation
 
 We use [mdBook](https://rust-lang.github.io/mdBook/) for generating technical documentation.


### PR DESCRIPTION
There are currently no instructions on how to generate test coverage locally. Given that it's quite a useful thing to be able to do and it's not obvious how to do it in Rust, I thought it deserved a section in the developer guide, so I've added it.