### PR TITLE
Replace use of tarpaulin with cargo-llvm-cov for test coverage

### DIFF
--- a/.github/workflows/cargo-build-and-test.yml
+++ b/.github/workflows/cargo-build-and-test.yml
@@ -34,12 +34,12 @@ jobs:
 
       - run: cargo test --verbose
 
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
 
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+          cargo llvm-cov --codecov --output-path codecov.json
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -38,6 +38,29 @@ cargo test
 
 More information is available in [the official `cargo` book](https://doc.rust-lang.org/cargo/).
 
+## Checking test coverage
+
+We use [Codecov](https://about.codecov.io/) to check whether pull requests introduce code without
+tests.
+
+To check coverage locally (i.e. to make sure newly written code has tests), we recommend using
+[cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov).
+
+It can be installed with:
+
+```sh
+cargo install cargo-llvm-cov
+```
+
+Once installed, you can use it like so:
+
+```sh
+cargo llvm-cov --open
+```
+
+This will generate a report in HTML format showing which lines are not currently covered by tests
+and open it in your default browser.
+
 ## Developing the documentation
 
 We use [mdBook](https://rust-lang.github.io/mdBook/) for generating technical documentation.


### PR DESCRIPTION
Currently we're using [tarpaulin](https://github.com/xd009642/tarpaulin) to generate test coverage. The only problem is that it produces a lot of false negatives (i.e. falsely reports that some lines of code aren't covered by tests), which limits its utility.

After looking around it seems that tarpaulin's approach to calculating code coverage is actually rather outdated and nowadays you can leverage Rust's compiler backend (LLVM) to generate better, source-based coverage. Cargo-llvm-cov is just a fairly thin wrapper around `rustc`'s built-in functionality.

The coverage stats look much better with cargo-llvm-cov: it covers about 14% more code :partying_face:.

Closes #228.