### PR TITLE
Fix clippy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: clippy
         # Warnings can be suppressed by adding "-A clippy::some_warning" to args
-        args: [--fix, --allow-dirty, --allow-staged, --, -D, clippy::all, -A, clippy::precedence]
+        args: [--fix, --allow-dirty, --allow-staged, --, -D, warnings]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
# Description

For whatever reason, the combination of flags we were passing to `clippy` via the pre-commit hook were resulting in it not working as expected -- in some cases, the hook was passing even when there were warnings (which you could see by running `pre-commit run -a -v` manually). This happened whether the warnings were automatically fixed or not.

I'm still not entirely clear on why the flags I was passing before didn't work -- `clippy` was issuing warnings, but was returning with a code of 0, so pre-commit treated it as passing -- but I've tested the combination I use in this PR and they seem to work (it fails in the presence of warnings and the auto-fixing still works). So let's just use this for now to stop more linter warnings creeping into the code base.

Closes #206.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
