### PR TITLE
Refactor commodity costs for easy lookup

### DIFF
--- a/examples/simple/commodity_costs.csv
+++ b/examples/simple/commodity_costs.csv
@@ -1,2 +1,3 @@
 commodity_id,region_id,balance_type,year,time_slice,value
 CO2EMT,GBR,net,2020,annual,0.04
+CO2EMT,GBR,net,2100,annual,0.04

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -2,11 +2,11 @@
 use crate::demand::{read_demand, Demand};
 use crate::input::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
+use anyhow::{ensure, Result};
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::rc::Rc;
@@ -82,15 +82,17 @@ impl CommodityCostRaw {
         region_ids: &HashSet<Rc<str>>,
         time_slice_info: &TimeSliceInfo,
         year_range: &RangeInclusive<u32>,
-    ) -> Result<CommodityCost, Box<dyn Error>> {
+    ) -> Result<CommodityCost> {
         let commodity_id = commodity_ids.get_id(&self.commodity_id)?;
         let region_id = region_ids.get_id(&self.region_id)?;
         let time_slice = time_slice_info.get_selection(&self.time_slice)?;
 
         // Check year is in range
-        if !year_range.contains(&self.year) {
-            Err(format!("Year {} is out of range", self.year))?;
-        }
+        ensure!(
+            year_range.contains(&self.year),
+            "Year {} is out of range",
+            self.year
+        );
 
         Ok(CommodityCost {
             commodity_id,
@@ -134,7 +136,7 @@ fn read_commodity_costs_iter<I>(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
-) -> Result<HashMap<Rc<str>, Vec<CommodityCost>>, Box<dyn Error>>
+) -> Result<HashMap<Rc<str>, Vec<CommodityCost>>>
 where
     I: Iterator<Item = CommodityCostRaw>,
 {

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,9 +1,8 @@
 #![allow(missing_docs)]
 use crate::demand::{read_demand, Demand};
 use crate::input::*;
-use crate::time_slice::{TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
-use anyhow::Result;
-use itertools::Itertools;
+use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
+use anyhow::{ensure, Result};
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
@@ -27,26 +26,43 @@ pub struct Commodity {
     pub time_slice_level: TimeSliceLevel,
 
     #[serde(skip)]
-    pub costs: Vec<CommodityCost>,
+    pub costs: CommodityCostMap,
     #[serde(skip)]
     pub demand_by_region: HashMap<Rc<str>, Demand>,
 }
 define_id_getter! {Commodity}
 
-macro_rules! define_commodity_id_getter {
-    ($t:ty) => {
-        impl HasID for $t {
-            fn get_id(&self) -> &str {
-                &self.commodity_id
-            }
-        }
-    };
+impl CommodityCostMap {
+    /// Create a new, empty [`CommodityCostMap`]
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Retrieve a [`CommodityCost`] from the map
+    pub fn get(
+        &self,
+        region_id: Rc<str>,
+        year: u32,
+        time_slice: TimeSliceID,
+    ) -> Option<&CommodityCost> {
+        let key = CommodityCostKey {
+            region_id,
+            year,
+            time_slice,
+        };
+        self.0.get(&key)
+    }
 }
 
-pub(crate) use define_commodity_id_getter;
+impl Default for CommodityCostMap {
+    /// Create a new, empty [`CommodityCostMap`]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Type of balance for application of cost
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+#[derive(PartialEq, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum BalanceType {
     #[string = "net"]
     Net,
@@ -57,7 +73,7 @@ pub enum BalanceType {
 }
 
 /// Cost parameters for each commodity
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(PartialEq, Debug, Deserialize, Clone)]
 struct CommodityCostRaw {
     /// Unique identifier for the commodity (e.g. "ELC")
     pub commodity_id: String,
@@ -73,49 +89,26 @@ struct CommodityCostRaw {
     pub value: f64,
 }
 
-impl CommodityCostRaw {
-    /// Convert the raw record type into a validated `CommodityCost` type
-    fn try_into_commodity_cost(
-        self,
-        commodity_ids: &HashSet<Rc<str>>,
-        region_ids: &HashSet<Rc<str>>,
-        time_slice_info: &TimeSliceInfo,
-        milestone_years: &[u32],
-    ) -> Result<CommodityCost> {
-        let commodity_id = commodity_ids.get_id(&self.commodity_id)?;
-        let region_id = region_ids.get_id(&self.region_id)?;
-        let time_slice = time_slice_info.get_selection(&self.time_slice)?;
-
-        if milestone_years.binary_search(&self.year).is_err() {
-            todo!(
-                "Year {} is not a milestone year. \
-                Input of non-milestone years is currently not supported.",
-                self.year
-            );
-        }
-
-        Ok(CommodityCost {
-            commodity_id,
-            region_id,
-            balance_type: self.balance_type,
-            year: self.year,
-            time_slice,
-            value: self.value,
-        })
-    }
-}
-
 /// Cost parameters for each commodity
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct CommodityCost {
-    pub commodity_id: Rc<str>,
-    pub region_id: Rc<str>,
+    /// Type of balance for application of cost.
     pub balance_type: BalanceType,
-    pub year: u32,
-    pub time_slice: TimeSliceSelection,
+    /// Cost per unit commodity. For example, if a CO2 price is specified in input data, it can be applied to net CO2 via this value.
     pub value: f64,
 }
-define_commodity_id_getter! {CommodityCost}
+
+/// Used for looking up [`CommodityCost`]s in a [`CommodityCostMap`]
+#[derive(PartialEq, Eq, Hash, Debug)]
+struct CommodityCostKey {
+    region_id: Rc<str>,
+    year: u32,
+    time_slice: TimeSliceID,
+}
+
+/// A data structure for easy lookup of [`CommodityCost`]s
+#[derive(PartialEq, Debug)]
+pub struct CommodityCostMap(HashMap<CommodityCostKey, CommodityCost>);
 
 /// Commodity balance type
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
@@ -136,15 +129,53 @@ fn read_commodity_costs_iter<I>(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
-) -> Result<HashMap<Rc<str>, Vec<CommodityCost>>>
+) -> Result<HashMap<Rc<str>, CommodityCostMap>>
 where
     I: Iterator<Item = CommodityCostRaw>,
 {
-    iter.map(|cost| {
-        cost.try_into_commodity_cost(commodity_ids, region_ids, time_slice_info, milestone_years)
-    })
-    // Commodity IDs have already been validated
-    .process_results(|iter| iter.into_id_map(commodity_ids).unwrap())
+    let mut map = HashMap::new();
+
+    for cost in iter {
+        let commodity_id = commodity_ids.get_id(&cost.commodity_id)?;
+        let region_id = region_ids.get_id(&cost.region_id)?;
+        let ts_selection = time_slice_info.get_selection(&cost.time_slice)?;
+
+        if milestone_years.binary_search(&cost.year).is_err() {
+            todo!(
+                "Year {} is not a milestone year. \
+                Input of non-milestone years is currently not supported.",
+                cost.year
+            );
+        }
+
+        // Get or create CommodityCostMap for this commodity
+        let map = map
+            .entry(commodity_id)
+            .or_insert_with(|| CommodityCostMap(HashMap::with_capacity(1)));
+
+        for time_slice in time_slice_info.iter_selection(&ts_selection) {
+            let key = CommodityCostKey {
+                region_id: Rc::clone(&region_id),
+                year: cost.year,
+                time_slice: time_slice.clone(),
+            };
+            let value = CommodityCost {
+                balance_type: cost.balance_type.clone(),
+                value: cost.value,
+            };
+
+            ensure!(
+                map.0.insert(key, value).is_none(),
+                "Commodity cost entry covered by more than one time slice \
+                (region: {}, year: {}, time slice: {})",
+                region_id,
+                cost.year,
+                time_slice
+            );
+        }
+    }
+
+    Ok(map)
 }
 
 /// Read costs associated with each commodity from commodity costs CSV file.
@@ -166,7 +197,7 @@ fn read_commodity_costs(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
-) -> HashMap<Rc<str>, Vec<CommodityCost>> {
+) -> HashMap<Rc<str>, CommodityCostMap> {
     let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
     read_commodity_costs_iter(
         read_csv::<CommodityCostRaw>(&file_path),
@@ -234,84 +265,172 @@ pub fn read_commodities(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::iter;
 
     #[test]
-    fn test_try_into_commodity_cost() {
+    fn test_commodity_cost_map_get() {
+        let ts = TimeSliceID {
+            season: "winter".into(),
+            time_of_day: "day".into(),
+        };
+        let key = CommodityCostKey {
+            region_id: "GBR".into(),
+            year: 2010,
+            time_slice: ts.clone(),
+        };
+        let value = CommodityCost {
+            balance_type: BalanceType::Consumption,
+            value: 0.5,
+        };
+        let map = CommodityCostMap(HashMap::from_iter([(key, value.clone())]));
+        assert_eq!(map.get("GBR".into(), 2010, ts).unwrap(), &value);
+    }
+
+    #[test]
+    fn test_read_commodity_costs_iter() {
         let commodity_ids = ["commodity".into()].into_iter().collect();
         let region_ids = ["GBR".into(), "FRA".into()].into_iter().collect();
-        let time_slice_info = TimeSliceInfo::default();
-        let milestone_years = vec![2010, 2020];
+        let slices = [
+            TimeSliceID {
+                season: "winter".into(),
+                time_of_day: "day".into(),
+            },
+            TimeSliceID {
+                season: "summer".into(),
+                time_of_day: "night".into(),
+            },
+        ];
+        let time_slice_info = TimeSliceInfo {
+            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            times_of_day: ["day".into(), "night".into()].into_iter().collect(),
+            fractions: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
+                .into_iter()
+                .collect(),
+        };
+        let time_slice = time_slice_info
+            .get_time_slice_id_from_str("winter.day")
+            .unwrap();
+        let milestone_years = [2010];
 
         // Valid
-        let cost = CommodityCostRaw {
+        let cost1 = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "GBR".into(),
             balance_type: BalanceType::Consumption,
             year: 2010,
-            time_slice: "".into(),
-            value: 5.0,
+            time_slice: "winter.day".into(),
+            value: 0.5,
         };
-        assert!(cost
-            .try_into_commodity_cost(
+        let cost2 = CommodityCostRaw {
+            commodity_id: "commodity".into(),
+            region_id: "FRA".into(),
+            balance_type: BalanceType::Production,
+            year: 2010,
+            time_slice: "winter.day".into(),
+            value: 0.5,
+        };
+        let key1 = CommodityCostKey {
+            region_id: "GBR".into(),
+            year: cost1.year,
+            time_slice: time_slice.clone(),
+        };
+        let value1 = CommodityCost {
+            balance_type: cost1.balance_type.clone(),
+            value: cost1.value,
+        };
+        let key2 = CommodityCostKey {
+            region_id: "FRA".into(),
+            year: cost2.year,
+            time_slice: time_slice.clone(),
+        };
+        let value2 = CommodityCost {
+            balance_type: cost2.balance_type.clone(),
+            value: cost2.value,
+        };
+        let map = CommodityCostMap(HashMap::from_iter([(key1, value1), (key2, value2)]));
+        let expected = HashMap::from_iter([("commodity".into(), map)]);
+        assert_eq!(
+            read_commodity_costs_iter(
+                [cost1.clone(), cost2].into_iter(),
                 &commodity_ids,
                 &region_ids,
                 &time_slice_info,
-                &milestone_years
+                &milestone_years,
             )
-            .is_ok());
+            .unwrap(),
+            expected
+        );
 
-        // Bad commodity
+        // Invalid: Overlapping time slices
+        let cost2 = CommodityCostRaw {
+            commodity_id: "commodity".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Production,
+            year: 2010,
+            time_slice: "winter".into(), // NB: Covers all winter
+            value: 0.5,
+        };
+        assert!(read_commodity_costs_iter(
+            [cost1.clone(), cost2].into_iter(),
+            &commodity_ids,
+            &region_ids,
+            &time_slice_info,
+            &milestone_years,
+        )
+        .is_err());
+
+        // Invalid: Bad commodity
         let cost = CommodityCostRaw {
             commodity_id: "commodity2".into(),
             region_id: "GBR".into(),
-            balance_type: BalanceType::Consumption,
+            balance_type: BalanceType::Production,
             year: 2010,
-            time_slice: "".into(),
-            value: 5.0,
+            time_slice: "winter.day".into(),
+            value: 0.5,
         };
-        assert!(cost
-            .try_into_commodity_cost(
-                &commodity_ids,
-                &region_ids,
-                &time_slice_info,
-                &milestone_years
-            )
-            .is_err());
+        assert!(read_commodity_costs_iter(
+            iter::once(cost),
+            &commodity_ids,
+            &region_ids,
+            &time_slice_info,
+            &milestone_years,
+        )
+        .is_err());
 
-        // Bad region
+        // Invalid: Bad region
         let cost = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "USA".into(),
-            balance_type: BalanceType::Consumption,
+            balance_type: BalanceType::Production,
             year: 2010,
-            time_slice: "".into(),
-            value: 5.0,
+            time_slice: "winter.day".into(),
+            value: 0.5,
         };
-        assert!(cost
-            .try_into_commodity_cost(
-                &commodity_ids,
-                &region_ids,
-                &time_slice_info,
-                &milestone_years
-            )
-            .is_err());
+        assert!(read_commodity_costs_iter(
+            iter::once(cost),
+            &commodity_ids,
+            &region_ids,
+            &time_slice_info,
+            &milestone_years,
+        )
+        .is_err());
 
-        // Bad time slice selection
+        // Invalid: Bad time slice selection
         let cost = CommodityCostRaw {
             commodity_id: "commodity".into(),
             region_id: "GBR".into(),
-            balance_type: BalanceType::Consumption,
+            balance_type: BalanceType::Production,
             year: 2010,
-            time_slice: "spring".into(),
-            value: 5.0,
+            time_slice: "summer.evening".into(),
+            value: 0.5,
         };
-        assert!(cost
-            .try_into_commodity_cost(
-                &commodity_ids,
-                &region_ids,
-                &time_slice_info,
-                &milestone_years
-            )
-            .is_err());
+        assert!(read_commodity_costs_iter(
+            iter::once(cost),
+            &commodity_ids,
+            &region_ids,
+            &time_slice_info,
+            &milestone_years,
+        )
+        .is_err());
     }
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -433,4 +433,29 @@ mod tests {
         )
         .is_err());
     }
+
+    #[test]
+    #[should_panic]
+    fn test_read_commodity_costs_iter_non_milestone_year() {
+        let commodity_ids = ["commodity".into()].into_iter().collect();
+        let region_ids = ["GBR".into(), "FRA".into()].into_iter().collect();
+        let time_slice_info = TimeSliceInfo::default();
+        let milestone_years = [2010, 2020];
+
+        let cost = CommodityCostRaw {
+            commodity_id: "commodity".into(),
+            region_id: "GBR".into(),
+            balance_type: BalanceType::Consumption,
+            year: 2011, // NB: Non-milestone year
+            time_slice: "all-year.all-day".into(),
+            value: 0.5,
+        };
+        let _ = read_commodity_costs_iter(
+            iter::once(cost),
+            &commodity_ids,
+            &region_ids,
+            &time_slice_info,
+            &milestone_years,
+        );
+    }
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -32,35 +32,6 @@ pub struct Commodity {
 }
 define_id_getter! {Commodity}
 
-impl CommodityCostMap {
-    /// Create a new, empty [`CommodityCostMap`]
-    pub fn new() -> Self {
-        Self(HashMap::new())
-    }
-
-    /// Retrieve a [`CommodityCost`] from the map
-    pub fn get(
-        &self,
-        region_id: Rc<str>,
-        year: u32,
-        time_slice: TimeSliceID,
-    ) -> Option<&CommodityCost> {
-        let key = CommodityCostKey {
-            region_id,
-            year,
-            time_slice,
-        };
-        self.0.get(&key)
-    }
-}
-
-impl Default for CommodityCostMap {
-    /// Create a new, empty [`CommodityCostMap`]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Type of balance for application of cost
 #[derive(PartialEq, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum BalanceType {
@@ -107,8 +78,30 @@ struct CommodityCostKey {
 }
 
 /// A data structure for easy lookup of [`CommodityCost`]s
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Default)]
 pub struct CommodityCostMap(HashMap<CommodityCostKey, CommodityCost>);
+
+impl CommodityCostMap {
+    /// Create a new, empty [`CommodityCostMap`]
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Retrieve a [`CommodityCost`] from the map
+    pub fn get(
+        &self,
+        region_id: Rc<str>,
+        year: u32,
+        time_slice: TimeSliceID,
+    ) -> Option<&CommodityCost> {
+        let key = CommodityCostKey {
+            region_id,
+            year,
+            time_slice,
+        };
+        self.0.get(&key)
+    }
+}
 
 /// Commodity balance type
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -2,7 +2,7 @@
 use crate::demand::{read_demand, Demand};
 use crate::input::*;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
@@ -210,7 +210,7 @@ fn read_commodity_costs(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
-) -> HashMap<Rc<str>, CommodityCostMap> {
+) -> Result<HashMap<Rc<str>, CommodityCostMap>> {
     let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
     read_commodity_costs_iter(
         read_csv::<CommodityCostRaw>(&file_path),
@@ -219,7 +219,7 @@ fn read_commodity_costs(
         time_slice_info,
         milestone_years,
     )
-    .unwrap_input_err(&file_path)
+    .context("Error reading commodity costs")
 }
 
 /// Read commodity data from the specified model directory.
@@ -248,7 +248,7 @@ pub fn read_commodities(
         region_ids,
         time_slice_info,
         milestone_years,
-    );
+    )?;
 
     let year_range = *milestone_years.first().unwrap()..=*milestone_years.last().unwrap();
     let mut demand = read_demand(

--- a/src/model.rs
+++ b/src/model.rs
@@ -98,12 +98,8 @@ impl Model {
         let years = &model_file.milestone_years.years;
         let year_range = *years.first().unwrap()..=*years.last().unwrap();
 
-        let commodities = read_commodities(
-            model_dir.as_ref(),
-            &region_ids,
-            &time_slice_info,
-            &year_range,
-        );
+        let commodities =
+            read_commodities(model_dir.as_ref(), &region_ids, &time_slice_info, years);
         let processes = read_processes(
             model_dir.as_ref(),
             &commodities,

--- a/src/process.rs
+++ b/src/process.rs
@@ -438,7 +438,7 @@ pub fn read_processes(
 
 #[cfg(test)]
 mod tests {
-    use crate::commodity::CommodityType;
+    use crate::commodity::{CommodityCostMap, CommodityType};
     use crate::time_slice::TimeSliceLevel;
 
     use super::*;
@@ -733,7 +733,7 @@ mod tests {
                     description: "Some description".into(),
                     kind: CommodityType::InputCommodity,
                     time_slice_level: TimeSliceLevel::Annual,
-                    costs: vec![],
+                    costs: CommodityCostMap::new(),
                     demand_by_region: HashMap::new(),
                 };
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -127,7 +127,7 @@ impl TimeSliceInfo {
     pub fn iter_selection<'a>(
         &'a self,
         selection: &'a TimeSliceSelection,
-    ) -> Box<dyn Iterator<Item = &TimeSliceID> + 'a> {
+    ) -> Box<dyn Iterator<Item = &'a TimeSliceID> + 'a> {
         match selection {
             TimeSliceSelection::Annual => Box::new(self.iter()),
             TimeSliceSelection::Season(season) => {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+use std::iter;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -106,6 +107,23 @@ impl TimeSliceInfo {
         } else {
             let season = self.seasons.get_id(time_slice)?;
             Ok(TimeSliceSelection::Season(season))
+        }
+    }
+
+    /// Iterate over the subset of [`TimeSliceID`] indicated by `selection`
+    pub fn iter_selection<'a>(
+        &'a self,
+        selection: &'a TimeSliceSelection,
+    ) -> Box<dyn Iterator<Item = TimeSliceID> + 'a> {
+        match selection {
+            TimeSliceSelection::Annual => Box::new(self.fractions.keys().cloned()),
+            TimeSliceSelection::Season(season) => Box::new(
+                self.fractions
+                    .keys()
+                    .filter(move |ts| &ts.season == season)
+                    .cloned(),
+            ),
+            TimeSliceSelection::Single(ts) => Box::new(iter::once(ts.clone())),
         }
     }
 }
@@ -296,6 +314,41 @@ autumn,evening,0.25"
     fn test_read_time_slice_info_non_existent() {
         let actual = read_time_slice_info(tempdir().unwrap().path());
         assert_eq!(actual, TimeSliceInfo::default());
+    }
+
+    #[test]
+    fn test_iter_selection() {
+        let slices = [
+            TimeSliceID {
+                season: "winter".into(),
+                time_of_day: "day".into(),
+            },
+            TimeSliceID {
+                season: "summer".into(),
+                time_of_day: "night".into(),
+            },
+        ];
+        let ts_info = TimeSliceInfo {
+            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            times_of_day: ["day".into(), "night".into()].into_iter().collect(),
+            fractions: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
+                .into_iter()
+                .collect(),
+        };
+
+        assert_eq!(
+            HashSet::<TimeSliceID>::from_iter(ts_info.iter_selection(&TimeSliceSelection::Annual)),
+            HashSet::from_iter(slices.iter().cloned())
+        );
+        itertools::assert_equal(
+            ts_info.iter_selection(&TimeSliceSelection::Season("winter".into())),
+            iter::once(slices[0].clone()),
+        );
+        let ts = ts_info.get_time_slice_id_from_str("summer.night").unwrap();
+        itertools::assert_equal(
+            ts_info.iter_selection(&TimeSliceSelection::Single(ts)),
+            iter::once(slices[1].clone()),
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description

Currently commodity costs are specified in a vector belonging to the corresponding commodity. At some point though we will need to actually access these values and this current data structure is a bit limited. Accordingly, I've reorganised the code so that they're specified in a map instead (still assigned to the relevant commodity, though) with a combination of commodity ID, region ID and milestone year used as the key. For the sake of encapsulating this functionality a bit, I've used the [new type idiom](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) to provide a simple wrapper around a `HashMap`, with a `get` method for accessing its contents.

This is in some ways similar to the refactor I want to do for demand slicing (#231), but unfortunately I've got myself in a bit of a tangle with that by trying to do other things first :disappointed:, so I thought this was a better starting point.

Things I'm unsure about:

- I've made a rule that if costs are provided for a given commodity + region pair, then there must be entries covering every milestone year. It seemed like a good idea to try to constrain the input to make the coding easier for now, but I dunno if it makes sense.
- I've made it so that you can look up costs with commodity + region + time slice, but I'm not including balance type in that as I was assuming we won't be usually wanting to look up costs by balance type. Not sure if that's right.
- I don't know what the `time_slice_level` field of commodities actually means and I couldn't figure it out from the docs. I don't *think* it's relevant to this PR, but could be wrong.

Closes #153.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
