### PR TITLE
adding argument parser using clap

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
                     "kind": "bin"
                 }
             },
-            "args": ["${workspaceFolder}/examples/simple"],
+            "args": ["run", "${workspaceFolder}/examples/simple"],
             "cwd": "${workspaceFolder}"
         },
         {
@@ -29,7 +29,6 @@
                     "kind": "bin"
                 }
             },
-            "args": ["${workspaceFolder}/examples/simple"],
             "cwd": "${workspaceFolder}"
         }
     ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +129,39 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -215,6 +297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +372,7 @@ dependencies = [
  "anyhow",
  "atty",
  "chrono",
+ "clap",
  "csv",
  "fern",
  "float-cmp",
@@ -398,6 +487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +561,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ unicase = "2.7.0"
 fern = {version = "0.7.0", features = ["chrono", "colored"]}
 atty = "0.2"
 chrono = "0.4"
-clap = { version = "4.5.21", features = ["cargo"] }
+clap = {version = "4.5.21", features = ["cargo"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ unicase = "2.7.0"
 fern = {version = "0.7.0", features = ["chrono", "colored"]}
 atty = "0.2"
 chrono = "0.4"
+clap = { version = "4.5.21", features = ["cargo"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn handle_run_command(sub_matches: &clap::ArgMatches) {
 
 fn main() {
     let cmd = Command::new("muse2")
-        .version("2.0")
+        .version("1.0")
         .about("MUSE2 Simulation Tool")
         .subcommand(build_run_command());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ fn main() {
                 .get_one::<PathBuf>("model_dir")
                 .expect("Required argument");
 
-            // Your existing simulation logic
             let settings = Settings::from_path(model_dir).unwrap();
             log::init(settings.log_level.as_deref());
             log_panics::init();
@@ -37,7 +36,6 @@ fn main() {
             muse2::run(&model);
         }
         _ => {
-            // No need to handle help explicitly - clap does it automatically
             println!("Use 'muse2 run <MODEL_DIR>' to run a simulation");
             println!("Use 'muse2 --help' for more information");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,20 +6,22 @@ use muse2::model::Model;
 use muse2::settings::Settings;
 use std::path::PathBuf;
 
+fn build_run_command() -> Command {
+    Command::new("run").about("Run a model simulation").arg(
+        Arg::new("model_dir")
+            .help("Path to the model directory")
+            .required(true)
+            .index(1)
+            .value_parser(clap::value_parser!(PathBuf)),
+    )
+}
+
 /// The main entry point for the `muse2 run` command.
 fn main() {
     let cmd = Command::new("muse2")
         .version("2.0")
         .about("MUSE2 Simulation Tool")
-        .subcommand(
-            Command::new("run").about("Run a model simulation").arg(
-                Arg::new("model_dir")
-                    .help("Path to the model directory")
-                    .required(true)
-                    .index(1)
-                    .value_parser(clap::value_parser!(PathBuf)),
-            ),
-        );
+        .subcommand(build_run_command());
 
     let matches = cmd.get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,8 @@ use std::path::PathBuf;
 fn build_run_command() -> Command {
     Command::new("run")
         .about("Use 'muse2 run <MODEL_DIR>' to run a simulation")
-        .override_usage("muse2 run <MODEL_DIR>")
         .arg(
-            Arg::new("model_dir")
+            Arg::new("MODEL_DIR")
                 .help("Path to the model directory")
                 .required(true)
                 .index(1)
@@ -21,7 +20,7 @@ fn build_run_command() -> Command {
 
 fn handle_run_command(sub_matches: &clap::ArgMatches) {
     let model_dir = sub_matches
-        .get_one::<PathBuf>("model_dir")
+        .get_one::<PathBuf>("MODEL_DIR")
         .expect("Required argument");
 
     // Read program settings
@@ -32,23 +31,23 @@ fn handle_run_command(sub_matches: &clap::ArgMatches) {
     log_panics::init();
 
     // Load and run model
-    let model = Model::from_path(model_dir).unwrap();
+    let model = Model::from_path(&model_dir).unwrap();
     info!("Model loaded successfully.");
     muse2::run(&model);
 }
 
 fn main() {
-    let cmd = Command::new("muse2")
-        .version("1.0")
-        .about("MUSE2 Simulation Tool")
+    let cmd = Command::new(clap::crate_name!())
+        .version(clap::crate_version!())
+        .about(clap::crate_description!())
+        .arg_required_else_help(true)
         .subcommand(build_run_command());
 
     let matches = cmd.get_matches();
     match matches.subcommand() {
         Some(("run", sub_matches)) => handle_run_command(sub_matches),
         _ => {
-            println!("Use 'muse2 run <MODEL_DIR>' to run a simulation");
-            println!("Use 'muse2 --help' for more information");
+            std::process::exit(1);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn handle_run_command(sub_matches: &clap::ArgMatches) {
     log_panics::init();
 
     // Load and run model
-    let model = Model::from_path(&model_dir).unwrap();
+    let model = Model::from_path(model_dir).unwrap();
     info!("Model loaded successfully.");
     muse2::run(&model);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,45 @@
-//! Provides the main entry point to the program.
 use ::log::info;
+use clap::{Arg, Command};
 use muse2::log;
 use muse2::model::Model;
 use muse2::settings::Settings;
-use std::env;
 use std::path::PathBuf;
 
-/// The main entry point to the program
 fn main() {
-    // Parse command-line arguments
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        panic!("Must provide path to model folder.");
+    let cmd = Command::new("muse2")
+        .version("2.0")
+        .about("MUSE2 Simulation Tool")
+        .subcommand(
+            Command::new("run").about("Run a model simulation").arg(
+                Arg::new("model_dir")
+                    .help("Path to the model directory")
+                    .required(true)
+                    .index(1)
+                    .value_parser(clap::value_parser!(PathBuf)),
+            ),
+        );
+
+    let matches = cmd.get_matches();
+
+    match matches.subcommand() {
+        Some(("run", sub_matches)) => {
+            let model_dir = sub_matches
+                .get_one::<PathBuf>("model_dir")
+                .expect("Required argument");
+
+            // Your existing simulation logic
+            let settings = Settings::from_path(model_dir).unwrap();
+            log::init(settings.log_level.as_deref());
+            log_panics::init();
+
+            let model = Model::from_path(model_dir).unwrap();
+            info!("Model loaded successfully.");
+            muse2::run(&model);
+        }
+        _ => {
+            // No need to handle help explicitly - clap does it automatically
+            println!("Use 'muse2 run <MODEL_DIR>' to run a simulation");
+            println!("Use 'muse2 --help' for more information");
+        }
     }
-    let model_dir = PathBuf::from(args[1].as_str());
-
-    // Read program settings
-    let settings = Settings::from_path(&model_dir).unwrap();
-
-    // Set the program log level
-    log::init(settings.log_level.as_deref());
-    log_panics::init(); // Write panic info to logger rather than stderr
-
-    let model = Model::from_path(&model_dir).unwrap();
-    info!("Model loaded successfully.");
-
-    // Run simulation
-    muse2::run(&model)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,23 @@ use muse2::settings::Settings;
 use std::path::PathBuf;
 
 fn build_run_command() -> Command {
-    Command::new("run").about("Run a model simulation").arg(
-        Arg::new("model_dir")
-            .help("Path to the model directory")
-            .required(true)
-            .index(1)
-            .value_parser(clap::value_parser!(PathBuf)),
-    )
+    Command::new("run")
+        .about("Use 'muse2 run <MODEL_DIR>' to run a simulation")
+        .override_usage("muse2 run <MODEL_DIR>")
+        .arg(
+            Arg::new("model_dir")
+                .help("Path to the model directory")
+                .required(true)
+                .index(1)
+                .value_parser(clap::value_parser!(PathBuf)),
+        )
 }
 
-fn handle_run_command(model_dir: &PathBuf) {
+fn handle_run_command(sub_matches: &clap::ArgMatches) {
+    let model_dir = sub_matches
+        .get_one::<PathBuf>("model_dir")
+        .expect("Required argument");
+
     // Read program settings
     let settings = Settings::from_path(model_dir).unwrap();
 
@@ -29,7 +36,7 @@ fn handle_run_command(model_dir: &PathBuf) {
     info!("Model loaded successfully.");
     muse2::run(&model);
 }
-/// The main entry point for the `muse2 run` command.
+
 fn main() {
     let cmd = Command::new("muse2")
         .version("2.0")
@@ -37,15 +44,8 @@ fn main() {
         .subcommand(build_run_command());
 
     let matches = cmd.get_matches();
-
     match matches.subcommand() {
-        Some(("run", sub_matches)) => {
-            let model_dir = sub_matches
-                .get_one::<PathBuf>("model_dir")
-                .expect("Required argument");
-
-            handle_run_command(model_dir);
-        }
+        Some(("run", sub_matches)) => handle_run_command(sub_matches),
         _ => {
             println!("Use 'muse2 run <MODEL_DIR>' to run a simulation");
             println!("Use 'muse2 --help' for more information");

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,19 @@ fn build_run_command() -> Command {
     )
 }
 
+fn handle_run_command(model_dir: &PathBuf) {
+    // Read program settings
+    let settings = Settings::from_path(model_dir).unwrap();
+
+    // Set up logging
+    log::init(settings.log_level.as_deref());
+    log_panics::init();
+
+    // Load and run model
+    let model = Model::from_path(model_dir).unwrap();
+    info!("Model loaded successfully.");
+    muse2::run(&model);
+}
 /// The main entry point for the `muse2 run` command.
 fn main() {
     let cmd = Command::new("muse2")
@@ -31,16 +44,7 @@ fn main() {
                 .get_one::<PathBuf>("model_dir")
                 .expect("Required argument");
 
-            // Read program settings
-            let settings = Settings::from_path(model_dir).unwrap();
-            // Set the program to log level
-            log::init(settings.log_level.as_deref());
-            log_panics::init();
-
-            let model = Model::from_path(model_dir).unwrap();
-            info!("Model loaded successfully.");
-            // Run simulation
-            muse2::run(&model);
+            handle_run_command(model_dir);
         }
         _ => {
             println!("Use 'muse2 run <MODEL_DIR>' to run a simulation");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+//! The main entry point for the `muse2` command-line tool.
 use ::log::info;
 use clap::{Arg, Command};
 use muse2::log;
@@ -5,6 +6,7 @@ use muse2::model::Model;
 use muse2::settings::Settings;
 use std::path::PathBuf;
 
+/// The main entry point for the `muse2 run` command.
 fn main() {
     let cmd = Command::new("muse2")
         .version("2.0")
@@ -27,12 +29,15 @@ fn main() {
                 .get_one::<PathBuf>("model_dir")
                 .expect("Required argument");
 
+            // Read program settings
             let settings = Settings::from_path(model_dir).unwrap();
+            // Set the program to log level
             log::init(settings.log_level.as_deref());
             log_panics::init();
 
             let model = Model::from_path(model_dir).unwrap();
             info!("Model loaded successfully.");
+            // Run simulation
             muse2::run(&model);
         }
         _ => {


### PR DESCRIPTION
# Description
In this PR I added the clap crate which lets us use the command `muse2` to run models. To get this started, run the following commands 
1. `cargo build`
2. `cargo install --path  .`
now you can run `muse2` and it should show a list of available commands.

For more info about how the clap crate works, I found this [video ](https://www.youtube.com/watch?v=Ot3qCA3Iv_8&t=2583s) very useful. 

Fixes #185  (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)
 
## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
