### PR TITLE
Input context messages

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -65,11 +65,6 @@ pub fn input_err_msg<P: AsRef<Path>>(file_path: P) -> String {
     format!("Error reading {}", file_path.as_ref().to_string_lossy())
 }
 
-/// Panic including the path to the file along with the message
-pub fn input_panic(file_path: &Path, msg: &str) -> ! {
-    panic!("Error reading {}: {}", file_path.to_string_lossy(), msg);
-}
-
 /// A trait allowing us to add the unwrap_input_err method to `Result`s
 pub trait UnwrapInputError<T> {
     /// Maps a `Result` with an arbitrary `Error` type to an `T`
@@ -80,7 +75,11 @@ impl<T, E: Display> UnwrapInputError<T> for Result<T, E> {
     fn unwrap_input_err(self, file_path: &Path) -> T {
         match self {
             Ok(value) => value,
-            Err(err) => input_panic(file_path, &err.to_string()),
+            Err(err) => panic!(
+                "Error reading {}: {}",
+                file_path.to_string_lossy(),
+                &err.to_string()
+            ),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -203,17 +203,17 @@ where
 ///
 /// # Returns
 ///
-/// A HashMap with ID as a key and a vector of CSV data as a value.
+/// A HashMap with ID as a key and a vector of CSV data as a value or an error.
 pub fn read_csv_grouped_by_id<T>(
     file_path: &Path,
     ids: &HashSet<Rc<str>>,
-) -> HashMap<Rc<str>, Vec<T>>
+) -> Result<HashMap<Rc<str>, Vec<T>>>
 where
     T: HasID + DeserializeOwned,
 {
     read_csv(file_path)
         .into_id_map(ids)
-        .unwrap_input_err(file_path)
+        .with_context(|| input_err_msg(file_path))
 }
 
 #[cfg(test)]
@@ -353,7 +353,7 @@ mod tests {
         let process_ids = create_ids();
         let file_path = dir.path().join("data.csv");
         let map = read_csv_grouped_by_id::<Record>(&file_path, &process_ids);
-        assert_eq!(expected, map);
+        assert_eq!(expected, map.unwrap());
     }
 
     #[test]
@@ -371,6 +371,6 @@ mod tests {
 
         // Check that it fails if a non-existent process ID is provided
         let process_ids = create_ids();
-        read_csv_grouped_by_id::<Record>(&file_path, &process_ids);
+        read_csv_grouped_by_id::<Record>(&file_path, &process_ids).unwrap();
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -73,7 +73,7 @@ impl ModelFile {
         let file_path = model_dir.as_ref().join(MODEL_FILE_NAME);
         let model_file: ModelFile = read_toml(&file_path)?;
         check_milestone_years(&model_file.milestone_years.years)
-            .with_context(|| format!("Error in `{}`", file_path.to_string_lossy()))?;
+            .with_context(|| input_err_msg(file_path))?;
 
         Ok(model_file)
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -110,7 +110,7 @@ impl Model {
             &region_ids,
             &time_slice_info,
             &year_range,
-        );
+        )?;
         let agents = read_agents(model_dir.as_ref(), &processes, &region_ids);
 
         Ok(Model {

--- a/src/model.rs
+++ b/src/model.rs
@@ -93,7 +93,7 @@ impl Model {
         let model_file = ModelFile::from_path(&model_dir)?;
 
         let time_slice_info = read_time_slice_info(model_dir.as_ref());
-        let regions = read_regions(model_dir.as_ref());
+        let regions = read_regions(model_dir.as_ref())?;
         let region_ids = regions.keys().cloned().collect();
         let years = &model_file.milestone_years.years;
         let year_range = *years.first().unwrap()..=*years.last().unwrap();
@@ -103,7 +103,7 @@ impl Model {
             &region_ids,
             &time_slice_info,
             &year_range,
-        );
+        )?;
         let processes = read_processes(
             model_dir.as_ref(),
             &commodities,

--- a/src/process.rs
+++ b/src/process.rs
@@ -4,7 +4,7 @@ use crate::input::*;
 use crate::region::*;
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use ::log::warn;
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Context, Result};
 use itertools::Itertools;
 use serde::{Deserialize, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
@@ -240,7 +240,7 @@ fn read_process_availabilities_from_iter<I>(
     file_path: &Path,
     process_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
-) -> HashMap<Rc<str>, Vec<ProcessAvailability>>
+) -> Result<HashMap<Rc<str>, Vec<ProcessAvailability>>>
 where
     I: Iterator<Item = ProcessAvailabilityRaw>,
 {
@@ -260,14 +260,12 @@ where
         .into_id_map(process_ids)
         .unwrap_input_err(file_path);
 
-    if availabilities.len() < process_ids.len() {
-        input_panic(
-            file_path,
-            "Every process must have at least one availability period",
-        );
-    }
+    ensure!(
+        availabilities.len() >= process_ids.len(),
+        "Every process must have at least one availability period"
+    );
 
-    availabilities
+    Ok(availabilities)
 }
 
 /// Read the availability of each process over time slices
@@ -275,7 +273,7 @@ fn read_process_availabilities(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
-) -> HashMap<Rc<str>, Vec<ProcessAvailability>> {
+) -> Result<HashMap<Rc<str>, Vec<ProcessAvailability>>> {
     let file_path = model_dir.join(PROCESS_AVAILABILITIES_FILE_NAME);
     read_process_availabilities_from_iter(
         read_csv(&file_path),
@@ -283,6 +281,7 @@ fn read_process_availabilities(
         process_ids,
         time_slice_info,
     )
+    .with_context(|| input_err_msg(file_path))
 }
 
 fn read_process_parameters_from_iter<I>(
@@ -402,7 +401,7 @@ pub fn read_processes(
     let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path)?;
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
 
-    let mut availabilities = read_process_availabilities(model_dir, &process_ids, time_slice_info);
+    let mut availabilities = read_process_availabilities(model_dir, &process_ids, time_slice_info)?;
     let file_path = model_dir.join(PROCESS_FLOWS_FILE_NAME);
     let mut flows = read_csv_grouped_by_id(&file_path, &process_ids)?;
     let mut pacs = read_process_pacs(model_dir, &process_ids, commodities);

--- a/src/process.rs
+++ b/src/process.rs
@@ -397,21 +397,21 @@ pub fn read_processes(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
-) -> HashMap<Rc<str>, Rc<Process>> {
+) -> Result<HashMap<Rc<str>, Rc<Process>>> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path);
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
 
     let mut availabilities = read_process_availabilities(model_dir, &process_ids, time_slice_info);
     let file_path = model_dir.join(PROCESS_FLOWS_FILE_NAME);
-    let mut flows = read_csv_grouped_by_id(&file_path, &process_ids);
+    let mut flows = read_csv_grouped_by_id(&file_path, &process_ids)?;
     let mut pacs = read_process_pacs(model_dir, &process_ids, commodities);
     let mut parameters = read_process_parameters(model_dir, &process_ids, year_range);
     let file_path = model_dir.join(PROCESS_REGIONS_FILE_NAME);
     let mut regions =
         read_regions_for_entity::<ProcessRegion>(&file_path, &process_ids, region_ids);
 
-    process_ids
+    Ok(process_ids
         .into_iter()
         .map(|id| {
             // We know entry is present
@@ -433,7 +433,7 @@ pub fn read_processes(
 
             (id, process.into())
         })
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -399,7 +399,7 @@ pub fn read_processes(
     year_range: &RangeInclusive<u32>,
 ) -> Result<HashMap<Rc<str>, Rc<Process>>> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
-    let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path);
+    let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path)?;
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
 
     let mut availabilities = read_process_availabilities(model_dir, &process_ids, time_slice_info);

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 use crate::input::*;
+use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -48,9 +49,8 @@ impl RegionSelection {
 ///
 /// # Returns
 ///
-/// This function returns a `HashMap<Rc<str>, Region>` with the parsed regions data. The keys are
-/// region IDs.
-pub fn read_regions(model_dir: &Path) -> HashMap<Rc<str>, Region> {
+/// A `HashMap<Rc<str>, Region>` with the parsed regions data or an error. The keys are region IDs.
+pub fn read_regions(model_dir: &Path) -> Result<HashMap<Rc<str>, Region>> {
     read_csv_id_file(&model_dir.join(REGIONS_FILE_NAME))
 }
 
@@ -176,7 +176,7 @@ AP,Asia Pacific"
     fn test_read_regions() {
         let dir = tempdir().unwrap();
         create_regions_file(dir.path());
-        let regions = read_regions(dir.path());
+        let regions = read_regions(dir.path()).unwrap();
         assert_eq!(
             regions,
             HashMap::from([


### PR DESCRIPTION
# Description

This PR Goes part of the way towards replacing the `unwrap_input_err` method with `with_context` from anyhow. This is partly addressing both #191 and #232. It does this by creating a function `input_err_msg` that is for ease of use whenever using `with_context` to add context to an error. It also removes all individual uses of the `input_panic` function.

Outstanding tasks:
- [ ] Removing `unwrap_input_err` entirely (there are many uses of it throughout the code - perhaps this is better served in a separate PR) - _Edit: Will be tackled in separate PR to completely address #191)_
- [ ] Removing the use of `unwrap_input_err` from `read_csv` <- this is proving challenging because of the strange serde deserialise iterator. ~**Opening in draft to address this issue**~  - _Edit: Will be tackled in separate PR. Opened in new issue #249)_

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
