### PR TITLE
Apply anyhow to region.rs

### DIFF
--- a/src/region.rs
+++ b/src/region.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs)]
 use crate::input::*;
+use anyhow::{ensure, Result};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -106,7 +106,7 @@ fn read_regions_for_entity_from_iter<I, T>(
     entity_iter: I,
     entity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, RegionSelection>, Box<dyn Error>>
+) -> Result<HashMap<Rc<str>, RegionSelection>>
 where
     I: Iterator<Item = T>,
     T: HasID + HasRegionID,
@@ -118,15 +118,16 @@ where
 
         let succeeded = try_insert_region(entity_id, region_id, region_ids, &mut entity_regions);
 
-        if !succeeded {
-            Err("Invalid regions specified for entity. \
-                 Must specify either unique region IDs or \"all\".")?;
-        }
+        ensure!(
+            succeeded,
+            "Invalid regions specified for entity. Must specify either unique region IDs or \"all\"."
+        );
     }
 
-    if entity_regions.len() < entity_ids.len() {
-        Err("At least one region must be specified per entity")?;
-    }
+    ensure!(
+        entity_regions.len() >= entity_ids.len(),
+        "At least one region must be specified per entity"
+    );
 
     Ok(entity_regions)
 }


### PR DESCRIPTION
# Description

Minimal changes required to adapt `region.rs` to use `anyhow` for error handling.

One observation: the `try_insert_region` function turns a `Result` into a `bool` that is then checked and turned back into a `Result`. It feels more "rusty" and in-keeping with `anyhow` to change that so it returns a `Result` and then use `context` for the error message. _Opening in draft so this question can be answered._

Fixes #252 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
