### PR TITLE
Make read_csv return a Result type

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -98,10 +98,11 @@ pub fn read_assets(
     agent_ids: &HashSet<Rc<str>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> HashMap<Rc<str>, Vec<Asset>> {
+) -> Result<HashMap<Rc<str>, Vec<Asset>>> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
-    read_assets_from_iter(read_csv(&file_path), agent_ids, processes, region_ids)
-        .unwrap_input_err(&file_path)
+    let assets_csv = read_csv(&file_path)?;
+    read_assets_from_iter(assets_csv, agent_ids, processes, region_ids)
+        .with_context(|| input_err_msg(&file_path))
 }
 
 #[cfg(test)]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -212,14 +212,15 @@ fn read_commodity_costs(
     milestone_years: &[u32],
 ) -> Result<HashMap<Rc<str>, CommodityCostMap>> {
     let file_path = model_dir.join(COMMODITY_COSTS_FILE_NAME);
+    let commodity_costs_csv = read_csv::<CommodityCostRaw>(&file_path)?;
     read_commodity_costs_iter(
-        read_csv::<CommodityCostRaw>(&file_path),
+        commodity_costs_csv,
         commodity_ids,
         region_ids,
         time_slice_info,
         milestone_years,
     )
-    .context("Error reading commodity costs")
+    .with_context(|| input_err_msg(&file_path))
 }
 
 /// Read commodity data from the specified model directory.

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -258,7 +258,7 @@ pub fn read_commodities(
         region_ids,
         time_slice_info,
         &year_range,
-    );
+    )?;
 
     // Populate Vecs for each Commodity
     Ok(commodities

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,11 +15,16 @@ use std::rc::Rc;
 /// # Arguments
 ///
 /// * `file_path` - Path to the CSV file
-pub fn read_csv<'a, T: DeserializeOwned + 'a>(file_path: &'a Path) -> impl Iterator<Item = T> + 'a {
-    csv::Reader::from_path(file_path)
-        .unwrap_input_err(file_path)
+pub fn read_csv<'a, T: DeserializeOwned + 'a>(
+    file_path: &'a Path,
+) -> Result<impl Iterator<Item = T> + 'a> {
+    let vec = csv::Reader::from_path(file_path)
+        .with_context(|| input_err_msg(file_path))?
         .into_deserialize()
-        .unwrap_input_err(file_path)
+        .process_results(|iter| iter.collect_vec())
+        .with_context(|| input_err_msg(file_path))?;
+
+    Ok(vec.into_iter())
 }
 
 /// Parse a TOML file at the specified path.

--- a/src/input.rs
+++ b/src/input.rs
@@ -89,21 +89,6 @@ impl<T, E: Display> UnwrapInputError<T> for Result<T, E> {
     }
 }
 
-pub trait UnwrapInputErrorIter<T> {
-    /// Maps an `Iterator` of `Result`s with an arbitrary `Error` type to an `Iterator<Item = T>`
-    fn unwrap_input_err(self, file_path: &Path) -> impl Iterator<Item = T>;
-}
-
-impl<T, E, I> UnwrapInputErrorIter<T> for I
-where
-    E: Display,
-    I: Iterator<Item = Result<T, E>>,
-{
-    fn unwrap_input_err(self, file_path: &Path) -> impl Iterator<Item = T> {
-        self.map(|x| x.unwrap_input_err(file_path))
-    }
-}
-
 /// Indicates that the struct has an ID field
 pub trait HasID {
     /// Get a string representation of the struct's ID

--- a/src/input.rs
+++ b/src/input.rs
@@ -244,7 +244,7 @@ mod tests {
     fn test_read_csv() {
         let dir = tempdir().unwrap();
         let file_path = create_csv_file(dir.path(), "id,value\nhello,1\nworld,2\n");
-        let records: Vec<Record> = read_csv(&file_path).collect();
+        let records: Vec<Record> = read_csv(&file_path).unwrap().collect();
         assert_eq!(
             records,
             &[

--- a/src/input.rs
+++ b/src/input.rs
@@ -143,10 +143,10 @@ where
         T: HasID + DeserializeOwned,
     {
         let mut map = HashMap::new();
-        for record in read_csv::<T>(file_path) {
+        for record in read_csv::<T>(file_path)? {
             let id = record.get_id();
 
-            ensure!(!map.contains_key(id), format!("Duplicate ID found: {id}"));
+            ensure!(!map.contains_key(id), "Duplicate ID found: {id}");
 
             map.insert(id.into(), record);
         }
@@ -203,7 +203,7 @@ pub fn read_csv_grouped_by_id<T>(
 where
     T: HasID + DeserializeOwned,
 {
-    read_csv(file_path)
+    read_csv(file_path)?
         .into_id_map(ids)
         .with_context(|| input_err_msg(file_path))
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -92,7 +92,7 @@ impl Model {
     pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Model> {
         let model_file = ModelFile::from_path(&model_dir)?;
 
-        let time_slice_info = read_time_slice_info(model_dir.as_ref());
+        let time_slice_info = read_time_slice_info(model_dir.as_ref())?;
         let regions = read_regions(model_dir.as_ref())?;
         let region_ids = regions.keys().cloned().collect();
         let years = &model_file.milestone_years.years;
@@ -107,7 +107,7 @@ impl Model {
             &time_slice_info,
             &year_range,
         )?;
-        let agents = read_agents(model_dir.as_ref(), &processes, &region_ids);
+        let agents = read_agents(model_dir.as_ref(), &processes, &region_ids)?;
 
         Ok(Model {
             milestone_years: model_file.milestone_years.years,

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 use crate::input::*;
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -142,12 +142,12 @@ pub fn read_regions_for_entity<T>(
     file_path: &Path,
     entity_ids: &HashSet<Rc<str>>,
     region_ids: &HashSet<Rc<str>>,
-) -> HashMap<Rc<str>, RegionSelection>
+) -> Result<HashMap<Rc<str>, RegionSelection>>
 where
     T: HasID + HasRegionID + DeserializeOwned,
 {
-    read_regions_for_entity_from_iter(read_csv::<T>(file_path), entity_ids, region_ids)
-        .unwrap_input_err(file_path)
+    read_regions_for_entity_from_iter(read_csv::<T>(file_path)?, entity_ids, region_ids)
+        .with_context(|| input_err_msg(file_path))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

This PR changes the `read_csv` function in `input.rs` so that it returns a `Result` type to enable propagating errors all the way up to `main`. This required changing all the functions that call `read_csv` and use the outputs of it to also propagate errors. So there are many changes, but they are limited to changing the return types of many functions to `Result` and adding a lot of `?` and `with_context` and `Ok`.

Fixes #249 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
