### PR TITLE
Remove last use of unwrap_input_err

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -5,7 +5,6 @@ use itertools::Itertools;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde_string_enum::{DeserializeLabeledStringEnum, SerializeLabeledStringEnum};
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
 use std::fs;
 use std::path::Path;
 use std::rc::Rc;
@@ -68,25 +67,6 @@ pub enum LimitType {
 /// Format an error message to include the file path. To be used with `anyhow::Context`.
 pub fn input_err_msg<P: AsRef<Path>>(file_path: P) -> String {
     format!("Error reading {}", file_path.as_ref().to_string_lossy())
-}
-
-/// A trait allowing us to add the unwrap_input_err method to `Result`s
-pub trait UnwrapInputError<T> {
-    /// Maps a `Result` with an arbitrary `Error` type to an `T`
-    fn unwrap_input_err(self, file_path: &Path) -> T;
-}
-
-impl<T, E: Display> UnwrapInputError<T> for Result<T, E> {
-    fn unwrap_input_err(self, file_path: &Path) -> T {
-        match self {
-            Ok(value) => value,
-            Err(err) => panic!(
-                "Error reading {}: {}",
-                file_path.to_string_lossy(),
-                &err.to_string()
-            ),
-        }
-    }
 }
 
 /// Indicates that the struct has an ID field


### PR DESCRIPTION
# Description

Looks like a small change, but the change in `process.rs` was slightly more complicated than I expected. I needed to change away from using the `.map()` to using a `for` loop because the errors couldn't be propagated outside of the closure inside the map. But this required building a `Vec`, which when needed to be converted into an interator to apply `into_id_map`. This feels like it is less efficient than the previous solution, but I can't think of another solution to propagate the errors from `time_slice_info.get_selection`.

Fixes #191
Fixes #157 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
