### PR TITLE
Arg parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -149,6 +150,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -253,6 +266,12 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ unicase = "2.7.0"
 fern = {version = "0.7.0", features = ["chrono", "colored"]}
 atty = "0.2"
 chrono = "0.4"
-clap = {version = "4.5.21", features = ["cargo"]}
+clap = {version = "4.5.21", features = ["cargo", "derive"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,7 @@ use muse2::settings::Settings;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(name = clap::crate_name!())]
-#[command(version = clap::crate_version!())]
-#[command(about = clap::crate_description!())]
+#[command(version, about)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,6 @@ enum Commands {
         #[arg(help = "Path to the model directory")]
         model_dir: PathBuf,
     },
-    #[command(about = "Run the test suite.")]
-    Test,
 }
 
 fn handle_run_command(model_dir: &PathBuf) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    #[command(about = "Run a simulation model.")]
     Run {
         #[arg(help = "Path to the model directory")]
         model_dir: PathBuf,
     },
+    #[command(about = "Run the test suite.")]
+    Test,
 }
 
 fn handle_run_command(model_dir: &PathBuf) {


### PR DESCRIPTION
# Description

This PR changes the way the arg parser works before I was using the builder API approach, but after the comments made in #245 it makes sense to use the derive api so we can use a struct for defining new args in the future. 

Fixes #256  (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
