### PR TITLE
Print errors instead of unwrapping in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
     log::init(settings.log_level.as_deref()).context("Failed to initialize logging.")?;
 
     // Load and run model
-    let model = Model::from_path(model_dir).context("Failed to load Model.")?;
+    let model = Model::from_path(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
     muse2::run(&model);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,9 @@ mod tests {
                 .unwrap_err()
                 .chain()
                 .next()
-                .map(|x| format!("{x}")),
-            Some("Failed to initialize logging.".to_owned())
+                .unwrap()
+                .to_string(),
+            "Failed to initialize logging."
         );
     }
 }


### PR DESCRIPTION
# Description

This catches and prints errors that are propagated up to main instead of just unwrapping them.

I've included a test to check the right `context` is included in the error. It's a bit convoluted, but I couldn't find a better way. Any suggestions are welcome there.

Also, there are some more uses of `unwrap` throughout the code which should be changed, so I don't think the can mark #232 as complete until an audit of those have been done.

Fixes #233 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
