### PR TITLE
initial attempt at adding the example arg and adding include_dir crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +405,7 @@ dependencies = [
  "csv",
  "fern",
  "float-cmp",
+ "include_dir",
  "itertools",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ fern = {version = "0.7.0", features = ["chrono", "colored"]}
 atty = "0.2"
 chrono = "0.4"
 clap = {version = "4.5.23", features = ["cargo", "derive"]}
+include_dir = "0.7.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,6 @@ fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
 
 fn handle_example_command(example_name: Option<String>) -> Result<()> {
     if let Some("list") = example_name.as_deref() {
-        println!("Available examples:");
         for entry in EXAMPLES_DIR.dirs() {
             println!("{}", entry.path().display());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,24 +46,15 @@ fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
 }
 
 fn handle_example_command(example_name: Option<String>) -> Result<()> {
-    match example_name.as_deref() {
-        Some("list") => {
-            println!("Available examples:");
-            for entry in EXAMPLES_DIR.dirs() {
-                println!("{}", entry.path().display());
-            }
-            Ok(())
+    if let Some("list") = example_name.as_deref() {
+        println!("Available examples:");
+        for entry in EXAMPLES_DIR.dirs() {
+            println!("{}", entry.path().display());
         }
-        Some(name) => {
-            let example_dir = EXAMPLES_DIR.get_dir(name).context("Example not found")?;
-            info!("Found example directory: {}", example_dir.path().display());
-            let model_dir = PathBuf::from(example_dir.path());
-            handle_run_command(&model_dir)
-        }
-        None => {
-            println!("Please provide an example name or 'list' to list available examples.");
-            Ok(())
-        }
+        Ok(())
+    } else {
+        println!("Please provide an example name or 'list' to list available examples.");
+        Ok(())
     }
 }
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn handle_example_command(example_name: Option<String>) -> Result<()> {
         }
         Ok(())
     } else {
-        println!("Please provide an example name or 'list' to list available examples.");
+        eprintln!("Please provide an example name or 'list' to list available examples.");
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,17 @@ enum Commands {
         #[arg(help = "Path to the model directory")]
         model_dir: PathBuf,
     },
-    #[command(about = "Run an example model.")]
+    #[command(about = "Manage example models.")]
     Example {
-        #[arg(help = "Name of the example model")]
-        example_name: Option<String>,
+        #[command(subcommand)]
+        subcommand: ExampleSubcommands,
     },
+}
+
+#[derive(Subcommand)]
+enum ExampleSubcommands {
+    #[command(about = "List available examples.")]
+    List,
 }
 
 fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
@@ -44,26 +50,23 @@ fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
 
     Ok(())
 }
-
-fn handle_example_command(example_name: Option<String>) -> Result<()> {
-    if let Some("list") = example_name.as_deref() {
-        for entry in EXAMPLES_DIR.dirs() {
-            println!("{}", entry.path().display());
-        }
-        Ok(())
-    } else {
-        eprintln!("Please provide an example name or 'list' to list available examples.");
-        Ok(())
+fn handle_example_list_command() -> Result<()> {
+    for entry in EXAMPLES_DIR.dirs() {
+        println!("{}", entry.path().display());
     }
+    Ok(())
 }
+
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Run { model_dir } => handle_run_command(&model_dir),
-        Commands::Example { example_name } => handle_example_command(example_name),
+        Commands::Example { subcommand } => match subcommand {
+            ExampleSubcommands::List => handle_example_list_command(),
+        },
     }
-    .unwrap_or_else(|err| print!("{:?}", err))
+    .unwrap_or_else(|err| eprintln!("{:?}", err))
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Description

@alexdewar is this what you had in mind with the include_dir crate? Still having some trouble with the `muse2 example simple` command, but this is a good starting point to get a list of examples.
Currently, this PR only implements the `muse2 example list` command, which retrieves the list of folders in the examples' directory. 

Fixes #271  (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
