### PR TITLE
Check that all PACs are inputs or outputs

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -770,11 +770,51 @@ mod tests {
                     costs: CommodityCostMap::new(),
                     demand_by_region: HashMap::new(),
                 };
-
                 (Rc::clone(&commodity.id), commodity.into())
             })
             .collect();
-        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = HashMap::new();
+        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = [
+            (
+                "id1".into(),
+                vec![
+                    ProcessFlow {
+                        process_id: "id1".into(),
+                        commodity_id: "commodity1".into(),
+                        flow: 1.0,
+                        flow_type: FlowType::Fixed,
+                        flow_cost: 1.0,
+                    },
+                    ProcessFlow {
+                        process_id: "id1".into(),
+                        commodity_id: "commodity2".into(),
+                        flow: 1.0,
+                        flow_type: FlowType::Fixed,
+                        flow_cost: 1.0,
+                    },
+                ],
+            ),
+            (
+                "id2".into(),
+                vec![
+                    ProcessFlow {
+                        process_id: "id2".into(),
+                        commodity_id: "commodity1".into(),
+                        flow: 1.0,
+                        flow_type: FlowType::Fixed,
+                        flow_cost: 1.0,
+                    },
+                    ProcessFlow {
+                        process_id: "id2".into(),
+                        commodity_id: "commodity2".into(),
+                        flow: 1.0,
+                        flow_type: FlowType::Flexible,
+                        flow_cost: 1.0,
+                    },
+                ],
+            ),
+        ]
+        .into_iter()
+        .collect();
 
         // duplicate PAC
         let pac = ProcessPAC {

--- a/src/process.rs
+++ b/src/process.rs
@@ -773,7 +773,7 @@ mod tests {
                 (Rc::clone(&commodity.id), commodity.into())
             })
             .collect();
-        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = ["id1", "id2"]
+        let mut flows: HashMap<Rc<str>, Vec<ProcessFlow>> = ["id1", "id2"]
             .into_iter()
             .map(|process_id| {
                 (
@@ -816,8 +816,6 @@ mod tests {
         )
         .is_err());
 
-        // Invalid flows
-
         // Valid
         let pacs = [
             ProcessPAC {
@@ -855,9 +853,28 @@ mod tests {
         .into_iter()
         .collect();
         assert!(
-            read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities, &flows)
-                .unwrap()
+            read_process_pacs_from_iter(
+                pacs.clone().into_iter(),
+                &process_ids,
+                &commodities,
+                &flows
+            )
+            .unwrap()
                 == expected
+        );
+
+        // Invalid flows
+        // Making commodity1 an input so the PACs are a mix of inputs and outputs
+        flows
+            .get_mut(&Rc::from("id1"))
+            .unwrap()
+            .iter_mut()
+            .find(|flow| flow.commodity_id == "commodity1")
+            .unwrap()
+            .flow = -1.0;
+        assert!(
+            read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities, &flows)
+                .is_err()
         );
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -864,7 +864,7 @@ mod tests {
         );
 
         // Invalid flows
-        // Making commodity1 an input so the PACs are a mix of inputs and outputs
+        // Making commodity1 an input so the PACs for process id1 are a mix of inputs and outputs
         flows
             .get_mut(&Rc::from("id1"))
             .unwrap()

--- a/src/process.rs
+++ b/src/process.rs
@@ -355,6 +355,25 @@ where
         .process_results(|iter| iter.into_group_map())?;
 
     // Check that PACs for each process are either all inputs or all outputs
+    validate_pac_flows(&pacs, flows)?;
+
+    // Return result
+    Ok(pacs)
+}
+
+/// Validate that the PACs for each process are either all inputs or all outputs.
+///
+/// # Arguments
+///
+/// * `pacs` - A map of process IDs to PAC commodities
+/// * `flows` - A map of process IDs to process flows
+///
+/// # Returns
+/// An `Ok(())` if the check is successful, or an error.
+fn validate_pac_flows(
+    pacs: &HashMap<Rc<str>, Vec<Rc<Commodity>>>,
+    flows: &HashMap<Rc<str>, Vec<ProcessFlow>>,
+) -> Result<()> {
     for (process_id, pacs) in pacs.iter() {
         // Get the flows for the process (unwrap is safe as every process has associated flows)
         let flows = flows.get(process_id).unwrap();
@@ -384,7 +403,7 @@ where
             flow_sign = Some(current_flow_sign);
         }
     }
-    Ok(pacs)
+    Ok(())
 }
 
 /// Read process Primary Activity Commodities (PACs) from the specified model directory.

--- a/src/process.rs
+++ b/src/process.rs
@@ -344,7 +344,7 @@ where
             let process_id = process_ids.get_id(&pac.process_id)?;
             let commodity = commodities.get(pac.commodity_id.as_str());
 
-            // Check that commodity is valid and not a duplicate
+            // Check that commodity is valid and PAC is not a duplicate
             match commodity {
                 None => bail!("{} is not a valid commodity ID", &pac.commodity_id),
                 Some(commodity) => {
@@ -773,48 +773,24 @@ mod tests {
                 (Rc::clone(&commodity.id), commodity.into())
             })
             .collect();
-        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = [
-            (
-                "id1".into(),
-                vec![
-                    ProcessFlow {
-                        process_id: "id1".into(),
-                        commodity_id: "commodity1".into(),
-                        flow: 1.0,
-                        flow_type: FlowType::Fixed,
-                        flow_cost: 1.0,
-                    },
-                    ProcessFlow {
-                        process_id: "id1".into(),
-                        commodity_id: "commodity2".into(),
-                        flow: 1.0,
-                        flow_type: FlowType::Fixed,
-                        flow_cost: 1.0,
-                    },
-                ],
-            ),
-            (
-                "id2".into(),
-                vec![
-                    ProcessFlow {
-                        process_id: "id2".into(),
-                        commodity_id: "commodity1".into(),
-                        flow: 1.0,
-                        flow_type: FlowType::Fixed,
-                        flow_cost: 1.0,
-                    },
-                    ProcessFlow {
-                        process_id: "id2".into(),
-                        commodity_id: "commodity2".into(),
-                        flow: 1.0,
-                        flow_type: FlowType::Flexible,
-                        flow_cost: 1.0,
-                    },
-                ],
-            ),
-        ]
-        .into_iter()
-        .collect();
+        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = ["id1", "id2"]
+            .into_iter()
+            .map(|process_id| {
+                (
+                    process_id.into(),
+                    ["commodity1", "commodity2"]
+                        .into_iter()
+                        .map(|commodity_id| ProcessFlow {
+                            process_id: process_id.into(),
+                            commodity_id: commodity_id.into(),
+                            flow: 1.0,
+                            flow_type: FlowType::Fixed,
+                            flow_cost: 1.0,
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
 
         // duplicate PAC
         let pac = ProcessPAC {

--- a/src/process.rs
+++ b/src/process.rs
@@ -378,9 +378,9 @@ where
                 None => {
                     flow_sign = Some(current_flow_sign);
                 }
-                Some(existing_flow_type) => {
+                Some(flow_sign) => {
                     ensure!(
-                        existing_flow_type == current_flow_sign,
+                        current_flow_sign == flow_sign,
                         "PACs for process {} are a mix of inputs and outputs",
                         process_id
                     );
@@ -388,7 +388,6 @@ where
             };
         }
     }
-
     Ok(pacs)
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -724,6 +724,7 @@ mod tests {
 
     #[test]
     fn test_read_process_pacs_from_iter() {
+        // Prepare test data
         let process_ids = ["id1".into(), "id2".into()].into_iter().collect();
         let commodities = ["commodity1", "commodity2"]
             .into_iter()
@@ -740,6 +741,7 @@ mod tests {
                 (Rc::clone(&commodity.id), commodity.into())
             })
             .collect();
+        let flows: HashMap<Rc<str>, Vec<ProcessFlow>> = HashMap::new();
 
         // duplicate PAC
         let pac = ProcessPAC {
@@ -747,17 +749,27 @@ mod tests {
             commodity_id: "commodity1".into(),
         };
         let pacs = [pac.clone(), pac];
-        assert!(read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities).is_err());
+        assert!(
+            read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities, &flows)
+                .is_err()
+        );
 
         // invalid commodity ID
         let bad_pac = ProcessPAC {
             process_id: "id1".into(),
             commodity_id: "other_commodity".into(),
         };
-        assert!(
-            read_process_pacs_from_iter([bad_pac].into_iter(), &process_ids, &commodities).is_err()
-        );
+        assert!(read_process_pacs_from_iter(
+            [bad_pac].into_iter(),
+            &process_ids,
+            &commodities,
+            &flows
+        )
+        .is_err());
 
+        // Invalid flows
+
+        // Valid
         let pacs = [
             ProcessPAC {
                 process_id: "id1".into(),
@@ -794,7 +806,8 @@ mod tests {
         .into_iter()
         .collect();
         assert!(
-            read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities).unwrap()
+            read_process_pacs_from_iter(pacs.into_iter(), &process_ids, &commodities, &flows)
+                .unwrap()
                 == expected
         );
     }


### PR DESCRIPTION
# Description

This adds a check in `read_process_pacs_from_iter` to make sure the PACs for each process are either all inputs or all outputs.

I do this by looping through the processes and creating a flag `current_flow_sign` which is compared against the commodity flow for each PAC (positive flows represent outputs, negative flows represent inputs). Implicit is the assumption that flows cannot be zero - I don't think we actually have this check anywhere, we we should add this in.

This required passing `flows` to this function and also `read_process_pacs`. I had to modify all the tests accordingly, and have added a new test.

Fixes #165 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
