### PR TITLE
VS Code: Fix debug config for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'muse2'",
+            "name": "Run muse2 with example",
             "cargo": {
                 "args": ["build", "--bin=muse2", "--package=muse2"],
                 "filter": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,15 +21,11 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in executable 'muse2'",
+            "name": "Cargo test",
             "cargo": {
-                "args": ["test", "--no-run", "--bin=muse2", "--package=muse2"],
-                "filter": {
-                    "name": "muse2",
-                    "kind": "bin"
-                }
+                "args": ["test", "--no-run", "--lib"]
             },
-            "cwd": "${workspaceFolder}"
+            "args": []
         }
     ]
 }


### PR DESCRIPTION
The debug config option for tests currently doesn't work. For some reason, when I run it, it just runs the one test. Changing it to run `cargo test` seems to fix things, so we can now debug tests and set breakpoints in them etc.

Note that this can only be launched from the "run and debug" panel; we still don't have proper integrated test support in VS Code for Rust :disappointed: 