### PR TITLE
Add some more validation checks for process flows

### DIFF
--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -52,9 +52,6 @@ for all commodity flows that the process has (except *pac1*). Where *pac1* is th
 primary activity commodity for the asset (i.e. all input and output flows are made proportional to
 *pac1* flow).
 
-Note – need to handle cases where a flow is set to zero in the input data – should raise a
-warning that the value has been ignored, specifying which region/asset/commodity.
-
 **TBD** - cases where time slice level of the commodity is seasonal or annual.
 
 ### Commodity-flexible assets

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -86,11 +86,12 @@ pub fn read_processes(
             // We've already checked that these exist for each process
             let parameter = parameters.remove(&id).unwrap();
             let regions = regions.remove(&id).unwrap();
+            let availabilities = availabilities.remove(&id).unwrap();
 
             let process = Process {
                 id: desc.id,
                 description: desc.description,
-                availabilities: availabilities.remove(&id).unwrap_or_default(),
+                availabilities,
                 flows,
                 pacs,
                 parameter,

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -79,6 +79,9 @@ pub fn read_processes(
             let flows = flows
                 .remove(&id)
                 .with_context(|| format!("No commodity flows defined for process {id}"))?;
+            let pacs = pacs
+                .remove(&id)
+                .with_context(|| format!("No PACs defined for process {id}"))?;
 
             // We've already checked that these exist for each process
             let parameter = parameters.remove(&id).unwrap();
@@ -89,7 +92,7 @@ pub fn read_processes(
                 description: desc.description,
                 availabilities: availabilities.remove(&id).unwrap_or_default(),
                 flows,
-                pacs: pacs.remove(&id).unwrap_or_default(),
+                pacs,
                 parameter,
                 regions,
             };

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -61,7 +61,7 @@ pub fn read_processes(
     year_range: &RangeInclusive<u32>,
 ) -> Result<HashMap<Rc<str>, Rc<Process>>> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
-    let mut descriptions = read_csv_id_file::<ProcessDescription>(&file_path)?;
+    let descriptions = read_csv_id_file::<ProcessDescription>(&file_path)?;
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
 
     let mut availabilities = read_process_availabilities(model_dir, &process_ids, time_slice_info)?;
@@ -70,12 +70,9 @@ pub fn read_processes(
     let mut parameters = read_process_parameters(model_dir, &process_ids, year_range)?;
     let mut regions = read_process_regions(model_dir, &process_ids, region_ids)?;
 
-    process_ids
+    descriptions
         .into_iter()
-        .map(|id| {
-            // We know entry is present
-            let desc = descriptions.remove(&id).unwrap();
-
+        .map(|(id, description)| {
             let flows = flows
                 .remove(&id)
                 .with_context(|| format!("No commodity flows defined for process {id}"))?;
@@ -89,8 +86,8 @@ pub fn read_processes(
             let availabilities = availabilities.remove(&id).unwrap();
 
             let process = Process {
-                id: desc.id,
-                description: desc.description,
+                id: description.id,
+                description: description.description,
                 availabilities,
                 flows,
                 pacs,

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -111,9 +111,11 @@ where
             let pacs = pacs
                 .remove(id)
                 .with_context(|| format!("No PACs defined for process {id}"))?;
+            let parameter = parameters
+                .remove(id)
+                .with_context(|| format!("No parameters defined for process {id}"))?;
 
             // We've already checked that these exist for each process
-            let parameter = parameters.remove(id).unwrap();
             let regions = regions.remove(id).unwrap();
             let availabilities = availabilities.remove(id).unwrap();
 
@@ -250,5 +252,10 @@ mod tests {
     #[test]
     fn test_create_process_map_missing_flows() {
         test_missing!(flows);
+    }
+
+    #[test]
+    fn test_create_process_map_missing_parameters() {
+        test_missing!(parameters);
     }
 }

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -105,6 +105,9 @@ where
     descriptions
         .map(|description| {
             let id = &description.id;
+            let availabilities = availabilities
+                .remove(id)
+                .with_context(|| format!("No availabilities defined for process {id}"))?;
             let flows = flows
                 .remove(id)
                 .with_context(|| format!("No commodity flows defined for process {id}"))?;
@@ -115,9 +118,8 @@ where
                 .remove(id)
                 .with_context(|| format!("No parameters defined for process {id}"))?;
 
-            // We've already checked that these exist for each process
+            // We've already checked that regions are defined for each process
             let regions = regions.remove(id).unwrap();
-            let availabilities = availabilities.remove(id).unwrap();
 
             let process = Process {
                 id: Rc::clone(id),
@@ -242,6 +244,11 @@ mod tests {
             );
             assert!(result.is_err());
         };
+    }
+
+    #[test]
+    fn test_create_process_map_missing_availabilities() {
+        test_missing!(availabilities);
     }
 
     #[test]

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -3,7 +3,7 @@ use super::define_process_id_getter;
 use crate::input::*;
 use crate::process::{LimitType, ProcessAvailability};
 use crate::time_slice::TimeSliceInfo;
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -44,23 +44,15 @@ fn read_process_availabilities_from_iter<I>(
 where
     I: Iterator<Item = ProcessAvailabilityRaw>,
 {
-    let availabilities = iter
-        .map(|record| -> Result<_> {
-            let time_slice = time_slice_info.get_selection(&record.time_slice)?;
+    iter.map(|record| -> Result<_> {
+        let time_slice = time_slice_info.get_selection(&record.time_slice)?;
 
-            Ok(ProcessAvailability {
-                process_id: record.process_id,
-                limit_type: record.limit_type,
-                time_slice,
-                value: record.value,
-            })
+        Ok(ProcessAvailability {
+            process_id: record.process_id,
+            limit_type: record.limit_type,
+            time_slice,
+            value: record.value,
         })
-        .process_results(|iter| iter.into_id_map(process_ids))??;
-
-    ensure!(
-        availabilities.len() >= process_ids.len(),
-        "Every process must have at least one availability period"
-    );
-
-    Ok(availabilities)
+    })
+    .process_results(|iter| iter.into_id_map(process_ids))?
 }

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -58,6 +58,12 @@ where
             flow.flow
         );
 
+        // **TODO**: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/300
+        ensure!(
+            flow.flow_type == FlowType::Fixed,
+            "Commodity flexible assets are not currently supported"
+        );
+
         Ok(ProcessFlow {
             process_id: flow.process_id,
             commodity: Rc::clone(commodity),

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -51,10 +51,12 @@ where
             .get(flow.commodity_id.as_str())
             .with_context(|| format!("{} is not a valid commodity ID", &flow.commodity_id))?;
 
-        // Check that flow is not zero, infinity, etc.
+        ensure!(flow.flow != 0.0, "Flow cannot be zero");
+
+        // Check that flow is not infinity, nan, etc.
         ensure!(
             flow.flow.is_normal(),
-            "Invalid value for flow: {}",
+            "Invalid value for flow ({})",
             flow.flow
         );
 

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -46,17 +46,17 @@ fn read_process_flows_from_iter<I>(
 where
     I: Iterator<Item = ProcessFlowRaw>,
 {
-    iter.map(|flow_raw| -> Result<ProcessFlow> {
+    iter.map(|flow| -> Result<ProcessFlow> {
         let commodity = commodities
-            .get(flow_raw.commodity_id.as_str())
-            .with_context(|| format!("{} is not a valid commodity ID", &flow_raw.commodity_id))?;
+            .get(flow.commodity_id.as_str())
+            .with_context(|| format!("{} is not a valid commodity ID", &flow.commodity_id))?;
 
         Ok(ProcessFlow {
-            process_id: flow_raw.process_id,
+            process_id: flow.process_id,
             commodity: Rc::clone(commodity),
-            flow: flow_raw.flow,
-            flow_type: flow_raw.flow_type,
-            flow_cost: flow_raw.flow_cost.unwrap_or(0.0),
+            flow: flow.flow,
+            flow_type: flow.flow_type,
+            flow_cost: flow.flow_cost.unwrap_or(0.0),
         })
     })
     .process_results(|iter| iter.into_id_map(process_ids))?

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -134,10 +134,6 @@ where
             "More than one parameter provided for process {id}"
         );
     }
-    ensure!(
-        params.len() == process_ids.len(),
-        "Each process must have an associated parameter"
-    );
     Ok(params)
 }
 
@@ -390,31 +386,6 @@ mod tests {
                 cap2act: Some(1.0),
             },
         ];
-
-        assert!(read_process_parameters_from_iter(
-            params_raw.into_iter(),
-            &process_ids,
-            &year_range
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_read_process_parameters_from_iter_bad_process_missing_param() {
-        let year_range = 2000..=2100;
-        let process_ids = ["A".into(), "B".into()].into_iter().collect();
-
-        let params_raw = [ProcessParameterRaw {
-            process_id: "A".into(),
-            start_year: Some(2010),
-            end_year: Some(2020),
-            capital_cost: 1.0,
-            fixed_operating_cost: 1.0,
-            variable_operating_cost: 1.0,
-            lifetime: 10,
-            discount_rate: Some(1.0),
-            cap2act: Some(1.0),
-        }];
 
         assert!(read_process_parameters_from_iter(
             params_raw.into_iter(),


### PR DESCRIPTION
# Description

I've added some extra validation steps related to process flows, namely:

* Check that process flows are valid numbers
* Check that flow costs are valid numbers
* Check that every process has at least one associated process flow (i.e. it produces or consumes *something*)
* Disallow commodity flexible flows for now (we will only support fixed ones for now)

I also added a check that every process has at least one PAC.

Closes #277. Closes #278. Closes #279.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
