### PR TITLE
A prettier placeholder `run()` function + some helper functions

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -98,6 +98,8 @@ pub enum ObjectiveType {
 /// An asset controlled by an agent.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Asset {
+    /// A unique identifier for the agent
+    pub agent_id: Rc<str>,
     /// The [`Process`] that this asset corresponds to
     pub process: Rc<Process>,
     /// The region in which the asset is located

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -98,7 +98,7 @@ pub enum ObjectiveType {
 /// An asset controlled by an agent.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Asset {
-    /// The [Process] that this asset corresponds to
+    /// The [`Process`] that this asset corresponds to
     pub process: Rc<Process>,
     /// The region in which the asset is located
     pub region_id: Rc<str>,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,7 +50,7 @@ pub fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
     log::init(settings.log_level.as_deref()).context("Failed to initialize logging.")?;
     let model = Model::from_path(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
-    crate::run(&model);
+    crate::simulation::run(&model);
     Ok(())
 }
 

--- a/src/input/agent/asset.rs
+++ b/src/input/agent/asset.rs
@@ -79,8 +79,9 @@ where
         );
 
         Ok((
-            agent_id,
+            Rc::clone(&agent_id),
             Asset {
+                agent_id,
                 process: Rc::clone(process),
                 region_id,
                 capacity: asset.capacity,
@@ -134,6 +135,7 @@ mod tests {
             commission_year: 2010,
         };
         let asset_out = Asset {
+            agent_id: "agent1".into(),
             process: Rc::clone(&process),
             region_id: "GBR".into(),
             capacity: 1.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! High level functionality for launching the simulation.
+//! Common functionality for MUSE 2.0.
 #![warn(missing_docs)]
 pub mod agent;
 pub mod commands;
@@ -10,20 +10,5 @@ pub mod model;
 pub mod process;
 pub mod region;
 pub mod settings;
+pub mod simulation;
 pub mod time_slice;
-
-use crate::model::Model;
-
-/// Run the simulation.
-///
-/// # Arguments:
-///
-/// * `model` - The model to run
-pub fn run(model: &Model) {
-    // TODO: Remove this once we're actually doing something with these values
-    println!("Commodities: {:?}", model.commodities);
-    println!("Regions: {:?}", model.regions);
-    println!("Processes: {:?}", model.processes);
-    println!("Time slices: {:?}", model.time_slice_info);
-    println!("Milestone years: {:?}", model.milestone_years);
-}

--- a/src/log.rs
+++ b/src/log.rs
@@ -39,6 +39,7 @@ pub fn init(log_level_from_settings: Option<&str>) -> Result<()> {
 
     // Convert the log level string to a log::LevelFilter
     let log_level = match log_level.to_lowercase().as_str() {
+        "off" => log::LevelFilter::Off,
         "error" => log::LevelFilter::Error,
         "warn" => log::LevelFilter::Warn,
         "info" => log::LevelFilter::Info,

--- a/src/log.rs
+++ b/src/log.rs
@@ -10,7 +10,10 @@ use fern::colors::{Color, ColoredLevelConfig};
 use fern::Dispatch;
 use std::env;
 
-pub(crate) const DEFAULT_LOG_LEVEL: &str = "info";
+/// The default log level for the program.
+///
+/// Note that we disable logging when running tests.
+const DEFAULT_LOG_LEVEL: &str = if cfg!(test) { "off" } else { "info" };
 
 /// Initialise the program logger using the `fern` logging library with colourised output.
 ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -118,6 +118,11 @@ impl Model {
             regions,
         })
     }
+
+    /// Iterate over the model's milestone years.
+    pub fn iter_years(&self) -> impl Iterator<Item = u32> + '_ {
+        self.milestone_years.iter().copied()
+    }
 }
 
 #[cfg(test)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -123,6 +123,11 @@ impl Model {
     pub fn iter_years(&self) -> impl Iterator<Item = u32> + '_ {
         self.milestone_years.iter().copied()
     }
+
+    /// Iterate over the model's regions (region IDs).
+    pub fn iter_regions(&self) -> impl Iterator<Item = &Rc<str>> + '_ {
+        self.regions.keys()
+    }
 }
 
 #[cfg(test)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Code for simulation models.
 #![allow(missing_docs)]
-use crate::agent::Agent;
+use crate::agent::{Agent, Asset};
 use crate::commodity::Commodity;
 use crate::input::*;
 use crate::process::Process;
@@ -127,6 +127,27 @@ impl Model {
     /// Iterate over the model's regions (region IDs).
     pub fn iter_regions(&self) -> impl Iterator<Item = &Rc<str>> + '_ {
         self.regions.keys()
+    }
+
+    /// Get an iterator of [`Agent`]s for the specified region.
+    pub fn get_agents_for_region<'a>(
+        &'a self,
+        region_id: &'a str,
+    ) -> impl Iterator<Item = &'a Agent> {
+        self.agents
+            .values()
+            .filter(|agent| agent.regions.contains(region_id))
+    }
+
+    /// Get an iterator of active [`Asset`]s for the specified milestone year in a given region.
+    pub fn get_assets<'a>(
+        &'a self,
+        year: u32,
+        region_id: &'a str,
+    ) -> impl Iterator<Item = &'a Asset> {
+        self.get_agents_for_region(region_id)
+            .flat_map(|agent| agent.assets.iter())
+            .filter(move |asset| year >= asset.commission_year)
     }
 }
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,0 +1,16 @@
+//! Functionality for running the MUSE 2.0 simulation.
+use crate::model::Model;
+
+/// Run the simulation.
+///
+/// # Arguments:
+///
+/// * `model` - The model to run
+pub fn run(model: &Model) {
+    // TODO: Remove this once we're actually doing something with these values
+    println!("Commodities: {:?}", model.commodities);
+    println!("Regions: {:?}", model.regions);
+    println!("Processes: {:?}", model.processes);
+    println!("Time slices: {:?}", model.time_slice_info);
+    println!("Milestone years: {:?}", model.milestone_years);
+}

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,5 +1,6 @@
 //! Functionality for running the MUSE 2.0 simulation.
 use crate::model::Model;
+use log::info;
 
 /// Run the simulation.
 ///
@@ -7,10 +8,20 @@ use crate::model::Model;
 ///
 /// * `model` - The model to run
 pub fn run(model: &Model) {
-    // TODO: Remove this once we're actually doing something with these values
-    println!("Commodities: {:?}", model.commodities);
-    println!("Regions: {:?}", model.regions);
-    println!("Processes: {:?}", model.processes);
-    println!("Time slices: {:?}", model.time_slice_info);
-    println!("Milestone years: {:?}", model.milestone_years);
+    for year in model.iter_years() {
+        info!("* Milestone year: {year}");
+        for region_id in model.iter_regions() {
+            info!("** Region: {region_id}");
+            for asset in model.get_assets(year, region_id) {
+                info!(
+                    "*** Agent {} has asset {} (commissioned in {})",
+                    asset.agent_id, asset.process.id, asset.commission_year
+                );
+
+                for flow in asset.process.flows.iter() {
+                    info!("**** Commodity: {}", flow.commodity.id);
+                }
+            }
+        }
+    }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -9,17 +9,17 @@ use log::info;
 /// * `model` - The model to run
 pub fn run(model: &Model) {
     for year in model.iter_years() {
-        info!("* Milestone year: {year}");
+        info!("Milestone year: {year}");
         for region_id in model.iter_regions() {
-            info!("** Region: {region_id}");
+            info!("├── Region: {region_id}");
             for asset in model.get_assets(year, region_id) {
                 info!(
-                    "*** Agent {} has asset {} (commissioned in {})",
+                    "│   ├── Agent {} has asset {} (commissioned in {})",
                     asset.agent_id, asset.process.id, asset.commission_year
                 );
 
                 for flow in asset.process.flows.iter() {
-                    info!("**** Commodity: {}", flow.commodity.id);
+                    info!("│   │   ├── Commodity: {}", flow.commodity.id);
                 }
             }
         }


### PR DESCRIPTION
# Description

Since work has begun on MUSE 2.0, the program has just printed the contents of the loaded model using default implementations of the `Debug` trait. Now that we're reading in almost all of the input files, the model's data structures are rather convoluted so the output is also very convoluted and completely unreadable. This PR changes the code to print something more human readable instead, iterating over data structures in roughly the way we will need to do for the actual simulation. I've added various helper methods for this.

The motivation for this change is that I wanted to work on a draft of the dispatch optimisation code (mostly just to clarify how it worked in my own head) and found that it made sense to write these various helpers, so I thought they should be merged by themselves sooner rather than later as a foundation for future work.

I deliberately avoided making more placeholder functions for different parts of the algorithm (e.g. agent investment etc.) as I think that's a bit more involved and potentially more controversial (e.g. in terms of what inputs/outputs they should have). I thought it'd be better to start with these more modest changes first.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
