### PR TITLE
Validate agent commodity IDs + other tidy-ups

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,7 +2,6 @@
 use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
-use anyhow::Result;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashSet;
@@ -19,7 +18,7 @@ pub struct Agent {
     pub commodity: Rc<Commodity>,
     /// The proportion of the commodity production that the agent is responsible for.
     pub commodity_portion: f64,
-    /// The list of processes that the agent will consider investing in.
+    /// The processes that the agent will consider investing in.
     pub search_space: SearchSpace,
     /// The decision rule that the agent uses to decide investment.
     pub decision_rule: DecisionRule,
@@ -39,23 +38,7 @@ pub struct Agent {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SearchSpace {
     AllProcesses,
-    Some(HashSet<String>),
-}
-
-impl<'de> Deserialize<'de> for SearchSpace {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = Option::<&str>::deserialize(deserializer)?;
-        match value {
-            None => Ok(SearchSpace::AllProcesses),
-            Some(processes_str) => {
-                let processes = HashSet::from_iter(processes_str.split(';').map(String::from));
-                Ok(SearchSpace::Some(processes))
-            }
-        }
-    }
+    Some(HashSet<Rc<str>>),
 }
 
 /// The decision rule for a particular objective

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use crate::input::deserialise_proportion_nonzero;
+use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
 use anyhow::Result;
@@ -9,15 +9,14 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 /// An agent in the simulation
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Agent {
     /// A unique identifier for the agent.
     pub id: Rc<str>,
     /// A text description of the agent.
     pub description: String,
     /// The commodity that the agent produces (could be a service demand too).
-    pub commodity_id: String,
-    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
+    pub commodity: Rc<Commodity>,
     /// The proportion of the commodity production that the agent is responsible for.
     pub commodity_portion: f64,
     /// The list of processes that the agent will consider investing in.
@@ -28,12 +27,11 @@ pub struct Agent {
     pub capex_limit: Option<f64>,
     /// The maximum annual operating cost (fuel plus var_opex etc) that the agent will pay.
     pub annual_cost_limit: Option<f64>,
-
-    #[serde(skip)]
+    /// The regions in which this agent operates.
     pub regions: RegionSelection,
-    #[serde(skip)]
+    /// The agent's objectives.
     pub objectives: Vec<AgentObjective>,
-    #[serde(skip)]
+    /// Assets controlled by this agent.
     pub assets: Vec<Asset>,
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,5 @@
-#![allow(missing_docs)]
+//! Agents drive the economy of the MUSE 2.0 simulation, through relative investment in different
+//! assets.
 use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
@@ -37,17 +38,22 @@ pub struct Agent {
 /// Which processes apply to this agent
 #[derive(Debug, Clone, PartialEq)]
 pub enum SearchSpace {
+    /// All processes are considered
     AllProcesses,
+    /// Only these specific processes are considered
     Some(HashSet<Rc<str>>),
 }
 
 /// The decision rule for a particular objective
 #[derive(Debug, Clone, PartialEq, DeserializeLabeledStringEnum)]
 pub enum DecisionRule {
+    /// Used when there is only a single objective
     #[string = "single"]
     Single,
+    /// A simple weighting of objectives
     #[string = "weighted"]
     Weighted,
+    /// Objectives are considered in a specific order
     #[string = "lexico"]
     Lexicographical,
 }
@@ -70,8 +76,10 @@ pub struct AgentObjective {
 /// **TODO** Add more objective types
 #[derive(Debug, Clone, PartialEq, DeserializeLabeledStringEnum)]
 pub enum ObjectiveType {
+    /// Average cost of one unit of output commodity over its lifetime
     #[string = "lcox"]
     LevelisedCostOfX,
+    /// Cost of serving agent's demand for a year, considering the asset's entire lifetime
     #[string = "eac"]
     EquivalentAnnualCost,
 }

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -1,8 +1,11 @@
 //! Code for reading in agent-related data from CSV files.
 use super::*;
-use crate::agent::{Agent, SearchSpace};
+use crate::agent::{Agent, DecisionRule, SearchSpace};
+use crate::commodity::Commodity;
 use crate::process::Process;
+use crate::region::RegionSelection;
 use anyhow::{bail, ensure, Context, Result};
+use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
@@ -16,11 +19,34 @@ use region::read_agent_regions;
 
 const AGENT_FILE_NAME: &str = "agents.csv";
 
+/// An agent in the simulation
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+struct AgentRaw {
+    /// A unique identifier for the agent.
+    id: Rc<str>,
+    /// A text description of the agent.
+    description: String,
+    /// The commodity that the agent produces (could be a service demand too).
+    commodity_id: String,
+    /// The proportion of the commodity production that the agent is responsible for.
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
+    commodity_portion: f64,
+    /// The list of processes that the agent will consider investing in.
+    search_space: SearchSpace,
+    /// The decision rule that the agent uses to decide investment.
+    decision_rule: DecisionRule,
+    /// The maximum capital cost the agent will pay.
+    capex_limit: Option<f64>,
+    /// The maximum annual operating cost (fuel plus var_opex etc) that the agent will pay.
+    annual_cost_limit: Option<f64>,
+}
+
 /// Read agents info from various CSV files.
 ///
 /// # Arguments
 ///
 /// * `model_dir` - Folder containing model configuration files
+/// * `commodities` - Commodities for the model
 /// * `process_ids` - The possible valid process IDs
 /// * `region_ids` - The possible valid region IDs
 ///
@@ -29,11 +55,12 @@ const AGENT_FILE_NAME: &str = "agents.csv";
 /// A map of Agents, with the agent ID as the key
 pub fn read_agents(
     model_dir: &Path,
+    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
 ) -> Result<HashMap<Rc<str>, Agent>> {
     let process_ids = processes.keys().cloned().collect();
-    let mut agents = read_agents_file(model_dir, &process_ids)?;
+    let mut agents = read_agents_file(model_dir, commodities, &process_ids)?;
     let agent_ids = agents.keys().cloned().collect();
 
     let mut agent_regions = read_agent_regions(model_dir, &agent_ids, region_ids)?;
@@ -55,6 +82,7 @@ pub fn read_agents(
 /// # Arguments
 ///
 /// * `model_dir` - Folder containing model configuration files
+/// * `commodities` - Commodities for the model
 /// * `process_ids` - The possible valid process IDs
 ///
 /// # Returns
@@ -62,24 +90,27 @@ pub fn read_agents(
 /// A map of Agents, with the agent ID as the key
 pub fn read_agents_file(
     model_dir: &Path,
+    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     process_ids: &HashSet<Rc<str>>,
 ) -> Result<HashMap<Rc<str>, Agent>> {
     let file_path = model_dir.join(AGENT_FILE_NAME);
     let agents_csv = read_csv(&file_path)?;
-    read_agents_file_from_iter(agents_csv, process_ids).with_context(|| input_err_msg(&file_path))
+    read_agents_file_from_iter(agents_csv, commodities, process_ids)
+        .with_context(|| input_err_msg(&file_path))
 }
 
 /// Read agents info from an iterator.
 fn read_agents_file_from_iter<I>(
     iter: I,
+    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     process_ids: &HashSet<Rc<str>>,
 ) -> Result<HashMap<Rc<str>, Agent>>
 where
-    I: Iterator<Item = Agent>,
+    I: Iterator<Item = AgentRaw>,
 {
     let mut agents = HashMap::new();
-    for agent in iter {
-        if let SearchSpace::Some(ref search_space) = agent.search_space {
+    for agent_raw in iter {
+        if let SearchSpace::Some(ref search_space) = agent_raw.search_space {
             // Check process IDs are all valid
             if !search_space
                 .iter()
@@ -89,8 +120,26 @@ where
             }
         }
 
+        let commodity = commodities
+            .get(agent_raw.commodity_id.as_str())
+            .context("Invalid commodity ID")?;
+
+        let agent = Agent {
+            id: Rc::clone(&agent_raw.id),
+            description: agent_raw.description,
+            commodity: Rc::clone(commodity),
+            commodity_portion: agent_raw.commodity_portion,
+            search_space: agent_raw.search_space,
+            decision_rule: agent_raw.decision_rule,
+            capex_limit: agent_raw.capex_limit,
+            annual_cost_limit: agent_raw.annual_cost_limit,
+            regions: RegionSelection::default(),
+            objectives: Vec::new(),
+            assets: Vec::new(),
+        };
+
         ensure!(
-            agents.insert(Rc::clone(&agent.id), agent).is_none(),
+            agents.insert(agent_raw.id, agent).is_none(),
             "Duplicate agent ID"
         );
     }
@@ -100,79 +149,109 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use super::*;
     use crate::agent::DecisionRule;
+    use crate::commodity::{CommodityCostMap, CommodityType};
     use crate::region::RegionSelection;
+    use crate::time_slice::TimeSliceLevel;
 
     #[test]
     fn test_read_agents_file_from_iter() {
         let process_ids = ["A".into(), "B".into()].into_iter().collect();
+        let commodity = Rc::new(Commodity {
+            id: "commodity1".into(),
+            description: "A commodity".into(),
+            kind: CommodityType::SupplyEqualsDemand,
+            time_slice_level: TimeSliceLevel::Annual,
+            costs: CommodityCostMap::new(),
+            demand_by_region: HashMap::new(),
+        });
+        let commodities = iter::once(("commodity1".into(), Rc::clone(&commodity))).collect();
 
         // Valid case
-        let search_space = ["A".into()].into_iter().collect();
-        let agents = [Agent {
+        let search_space = HashSet::from_iter(["A".into()]);
+        let agent = AgentRaw {
             id: "agent".into(),
             description: "".into(),
-            commodity_id: "".into(),
+            commodity_id: "commodity1".into(),
+            commodity_portion: 1.0,
+            search_space: SearchSpace::Some(search_space.clone()),
+            decision_rule: DecisionRule::Single,
+            capex_limit: None,
+            annual_cost_limit: None,
+        };
+        let agent_out = Agent {
+            id: "agent".into(),
+            description: "".into(),
+            commodity,
             commodity_portion: 1.0,
             search_space: SearchSpace::Some(search_space),
             decision_rule: DecisionRule::Single,
             capex_limit: None,
             annual_cost_limit: None,
-            regions: RegionSelection::All,
+            regions: RegionSelection::default(),
             objectives: Vec::new(),
             assets: Vec::new(),
-        }];
-        let expected = HashMap::from_iter([("agent".into(), agents[0].clone())]);
-        let actual = read_agents_file_from_iter(agents.into_iter(), &process_ids).unwrap();
+        };
+        let expected = HashMap::from_iter([("agent".into(), agent_out)]);
+        let actual =
+            read_agents_file_from_iter(iter::once(agent), &commodities, &process_ids).unwrap();
         assert_eq!(actual, expected);
 
-        // Invalid process ID
-        let search_space = ["C".into()].into_iter().collect();
-        let agents = [Agent {
+        // Invalid commodity ID
+        let agent = AgentRaw {
             id: "agent".into(),
             description: "".into(),
-            commodity_id: "".into(),
+            commodity_id: "made_up_commodity".into(),
+            commodity_portion: 1.0,
+            search_space: SearchSpace::AllProcesses,
+            decision_rule: DecisionRule::Single,
+            capex_limit: None,
+            annual_cost_limit: None,
+        };
+        assert!(read_agents_file_from_iter(iter::once(agent), &commodities, &process_ids).is_err());
+
+        // Invalid process ID
+        let search_space = iter::once("C".into()).collect();
+        let agent = AgentRaw {
+            id: "agent".into(),
+            description: "".into(),
+            commodity_id: "commodity1".into(),
             commodity_portion: 1.0,
             search_space: SearchSpace::Some(search_space),
             decision_rule: DecisionRule::Single,
             capex_limit: None,
             annual_cost_limit: None,
-            regions: RegionSelection::All,
-            objectives: Vec::new(),
-            assets: Vec::new(),
-        }];
-        assert!(read_agents_file_from_iter(agents.into_iter(), &process_ids).is_err());
+        };
+        assert!(read_agents_file_from_iter(iter::once(agent), &commodities, &process_ids).is_err());
 
         // Duplicate agent ID
         let agents = [
-            Agent {
+            AgentRaw {
                 id: "agent".into(),
                 description: "".into(),
-                commodity_id: "".into(),
+                commodity_id: "commodity1".into(),
                 commodity_portion: 1.0,
                 search_space: SearchSpace::AllProcesses,
                 decision_rule: DecisionRule::Single,
                 capex_limit: None,
                 annual_cost_limit: None,
-                regions: RegionSelection::All,
-                objectives: Vec::new(),
-                assets: Vec::new(),
             },
-            Agent {
+            AgentRaw {
                 id: "agent".into(),
                 description: "".into(),
-                commodity_id: "".into(),
+                commodity_id: "commodity1".into(),
                 commodity_portion: 1.0,
                 search_space: SearchSpace::AllProcesses,
                 decision_rule: DecisionRule::Single,
                 capex_limit: None,
                 annual_cost_limit: None,
-                regions: RegionSelection::All,
-                objectives: Vec::new(),
-                assets: Vec::new(),
             },
         ];
-        assert!(read_agents_file_from_iter(agents.into_iter(), &process_ids).is_err());
+        assert!(
+            read_agents_file_from_iter(agents.into_iter(), &commodities, &process_ids).is_err()
+        );
     }
 }

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -109,7 +109,9 @@ fn check_objective_parameter(
 mod tests {
     use super::*;
     use crate::agent::{ObjectiveType, SearchSpace};
+    use crate::commodity::{Commodity, CommodityCostMap, CommodityType};
     use crate::region::RegionSelection;
+    use crate::time_slice::TimeSliceLevel;
 
     #[test]
     fn test_check_objective_parameter() {
@@ -154,12 +156,20 @@ mod tests {
 
     #[test]
     fn test_read_agent_objectives_from_iter() {
+        let commodity = Rc::new(Commodity {
+            id: "commodity1".into(),
+            description: "A commodity".into(),
+            kind: CommodityType::SupplyEqualsDemand,
+            time_slice_level: TimeSliceLevel::Annual,
+            costs: CommodityCostMap::new(),
+            demand_by_region: HashMap::new(),
+        });
         let agents: HashMap<_, _> = [(
             "agent".into(),
             Agent {
                 id: "agent".into(),
                 description: "".into(),
-                commodity_id: "".into(),
+                commodity,
                 commodity_portion: 1.0,
                 search_space: SearchSpace::AllProcesses,
                 decision_rule: DecisionRule::Single,

--- a/src/model.rs
+++ b/src/model.rs
@@ -107,7 +107,7 @@ impl Model {
             &time_slice_info,
             &year_range,
         )?;
-        let agents = read_agents(model_dir.as_ref(), &processes, &region_ids)?;
+        let agents = read_agents(model_dir.as_ref(), &commodities, &processes, &region_ids)?;
 
         Ok(Model {
             milestone_years: model_file.milestone_years.years,


### PR DESCRIPTION
# Description

This PR changes the CSV-reading code for agents so that we can use an `Rc<Commodity>` for the relevant field rather than an unvalidated commodity ID, which is what we have now. I've refactored things so the input code is more like what we've done for other structs: there's now an `AgentRaw` struct with the raw info in, which is then further processed into a "proper" `Agent` struct. This also means I was able to tidy the code for parsing the agents' search space (which is composed of process IDs). Finally, I added missing doc comments and enabled doc warnings for `src/agent.rs` (#215).

Closes #215. Closes #319.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
