### PR TITLE
Fix: Change of demand field causing compile failures

### DIFF
--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -153,13 +153,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
-
     use super::*;
     use crate::agent::DecisionRule;
-    use crate::commodity::{CommodityCostMap, CommodityType};
+    use crate::commodity::{CommodityCostMap, CommodityType, DemandMap};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
+    use std::iter;
 
     #[test]
     fn test_read_agents_file_from_iter() {
@@ -170,7 +169,7 @@ mod tests {
             kind: CommodityType::SupplyEqualsDemand,
             time_slice_level: TimeSliceLevel::Annual,
             costs: CommodityCostMap::new(),
-            demand_by_region: HashMap::new(),
+            demand: DemandMap::new(),
         });
         let commodities = iter::once(("commodity1".into(), Rc::clone(&commodity))).collect();
 

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -109,7 +109,7 @@ fn check_objective_parameter(
 mod tests {
     use super::*;
     use crate::agent::{ObjectiveType, SearchSpace};
-    use crate::commodity::{Commodity, CommodityCostMap, CommodityType};
+    use crate::commodity::{Commodity, CommodityCostMap, CommodityType, DemandMap};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
 
@@ -162,7 +162,7 @@ mod tests {
             kind: CommodityType::SupplyEqualsDemand,
             time_slice_level: TimeSliceLevel::Annual,
             costs: CommodityCostMap::new(),
-            demand_by_region: HashMap::new(),
+            demand: DemandMap::new(),
         });
         let agents: HashMap<_, _> = [(
             "agent".into(),

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -223,7 +223,7 @@ mod tests {
             kind: CommodityType::InputCommodity,
             time_slice_level: TimeSliceLevel::Annual,
             costs: CommodityCostMap::new(),
-            demand_by_region: HashMap::new(),
+            demand: DemandMap::new(),
         })
         .map(|c| (c.id.clone(), Rc::new(c)))
         .collect();
@@ -259,7 +259,7 @@ mod tests {
             kind: CommodityType::InputCommodity,
             time_slice_level: TimeSliceLevel::Annual,
             costs: CommodityCostMap::new(),
-            demand_by_region: HashMap::new(),
+            demand: DemandMap::new(),
         })
         .map(|c| (c.id.clone(), Rc::new(c)))
         .collect();


### PR DESCRIPTION
# Description

Seems I should have been a bit more careful about merging all those PRs at once... Now the tests are failing to compile (see below for output).

I guess this is the downside of unchecking the "require branches to be up to date" option.

Errors:

```
   Compiling muse2 v2.0.0-dev1 (/home/alex/code/MUSE_2.0)
error[E0560]: struct `commodity::Commodity` has no field named `demand_by_region`
   --> src/input/agent/objective.rs:165:13
    |
165 |             demand_by_region: HashMap::new(),
    |             ^^^^^^^^^^^^^^^^ `commodity::Commodity` does not have this field
    |
    = note: available fields are: `demand`

error[E0560]: struct `commodity::Commodity` has no field named `demand_by_region`
   --> src/input/agent.rs:173:13
    |
173 |             demand_by_region: HashMap::new(),
    |             ^^^^^^^^^^^^^^^^ `commodity::Commodity` does not have this field
    |
    = note: available fields are: `demand`

error[E0560]: struct `commodity::Commodity` has no field named `demand_by_region`
   --> src/input/process/flow.rs:226:13
    |
226 |             demand_by_region: HashMap::new(),
    |             ^^^^^^^^^^^^^^^^ `commodity::Commodity` does not have this field
    |
    = note: available fields are: `demand`

error[E0560]: struct `commodity::Commodity` has no field named `demand_by_region`
   --> src/input/process/flow.rs:262:13
    |
262 |             demand_by_region: HashMap::new(),
    |             ^^^^^^^^^^^^^^^^ `commodity::Commodity` does not have this field
    |
    = note: available fields are: `demand`

For more information about this error, try `rustc --explain E0560`.
error: could not compile `muse2` (lib test) due to 4 previous errors
```

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
