### PR TITLE
Split out assets from `Model` struct

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,7 +5,7 @@ use crate::process::Process;
 use crate::region::RegionSelection;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 /// An agent in the simulation
@@ -31,8 +31,6 @@ pub struct Agent {
     pub regions: RegionSelection,
     /// The agent's objectives.
     pub objectives: Vec<AgentObjective>,
-    /// Assets controlled by this agent.
-    pub assets: Vec<Asset>,
 }
 
 /// Which processes apply to this agent
@@ -98,3 +96,6 @@ pub struct Asset {
     /// The year the asset comes online
     pub commission_year: u32,
 }
+
+/// A map of assets where the key is an agent ID
+pub type AssetMap = HashMap<Rc<str>, Vec<Asset>>;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,7 +5,7 @@ use crate::process::Process;
 use crate::region::RegionSelection;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::rc::Rc;
 
 /// An agent in the simulation
@@ -97,5 +97,5 @@ pub struct Asset {
     pub commission_year: u32,
 }
 
-/// A map of assets where the key is an agent ID
-pub type AssetMap = HashMap<Rc<str>, Vec<Asset>>;
+/// A pool of [`Asset`]s
+pub type AssetPool = Vec<Asset>;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,6 @@
 //! The command line interface for the simulation.
-use crate::log;
-use crate::model::Model;
 use crate::settings::Settings;
+use crate::{input::load_model, log};
 use ::log::info;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -48,7 +47,7 @@ pub enum ExampleSubcommands {
 pub fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
     let settings = Settings::from_path(model_dir)?;
     log::init(settings.log_level.as_deref()).context("Failed to initialize logging.")?;
-    let model = Model::from_path(model_dir).context("Failed to load model.")?;
+    let model = load_model(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
     crate::simulation::run(&model);
     Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,9 +47,9 @@ pub enum ExampleSubcommands {
 pub fn handle_run_command(model_dir: &PathBuf) -> Result<()> {
     let settings = Settings::from_path(model_dir)?;
     log::init(settings.log_level.as_deref()).context("Failed to initialize logging.")?;
-    let model = load_model(model_dir).context("Failed to load model.")?;
+    let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
-    crate::simulation::run(&model);
+    crate::simulation::run(&model, &assets);
     Ok(())
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! Common routines for handling input data.
-use crate::agent::AssetMap;
+use crate::agent::AssetPool;
 use crate::model::{Model, ModelFile};
 use crate::time_slice::read_time_slice_info;
 use anyhow::{ensure, Context, Result};
@@ -193,7 +193,7 @@ where
 /// # Returns
 ///
 /// The model contents as a `Model` struct or an error if the model is invalid
-pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetMap)> {
+pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
     let model_file = ModelFile::from_path(&model_dir)?;
 
     let time_slice_info = read_time_slice_info(model_dir.as_ref())?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,6 @@
 //! Common routines for handling input data.
+use crate::model::{Model, ModelFile};
+use crate::time_slice::read_time_slice_info;
 use anyhow::{ensure, Context, Result};
 use float_cmp::approx_eq;
 use itertools::Itertools;
@@ -177,6 +179,44 @@ where
     );
 
     Ok(())
+}
+
+/// Read a model from the specified directory.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+///
+/// # Returns
+///
+/// The model contents as a `Model` struct or an error if the model is invalid
+pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<Model> {
+    let model_file = ModelFile::from_path(&model_dir)?;
+
+    let time_slice_info = read_time_slice_info(model_dir.as_ref())?;
+    let regions = read_regions(model_dir.as_ref())?;
+    let region_ids = regions.keys().cloned().collect();
+    let years = &model_file.milestone_years.years;
+    let year_range = *years.first().unwrap()..=*years.last().unwrap();
+
+    let commodities = read_commodities(model_dir.as_ref(), &region_ids, &time_slice_info, years)?;
+    let processes = read_processes(
+        model_dir.as_ref(),
+        &commodities,
+        &region_ids,
+        &time_slice_info,
+        &year_range,
+    )?;
+    let agents = read_agents(model_dir.as_ref(), &commodities, &processes, &region_ids)?;
+
+    Ok(Model {
+        milestone_years: model_file.milestone_years.years,
+        agents,
+        commodities,
+        processes,
+        time_slice_info,
+        regions,
+    })
 }
 
 #[cfg(test)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -192,7 +192,7 @@ where
 ///
 /// # Returns
 ///
-/// The model contents as a `Model` struct or an error if the model is invalid
+/// The static model data ([`Model`]) and an [`AssetPool`] struct or an error.
 pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
     let model_file = ModelFile::from_path(&model_dir)?;
 

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -65,7 +65,6 @@ pub fn read_agents(
     let mut agent_regions = read_agent_regions(model_dir, &agent_ids, region_ids)?;
     let mut objectives = read_agent_objectives(model_dir, &agents)?;
 
-    // Populate each Agent's Vecs
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();
         agent.objectives = objectives.remove(id).unwrap();

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -10,8 +10,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
-pub mod asset;
-use asset::read_agent_assets;
 pub mod objective;
 use objective::read_agent_objectives;
 pub mod region;
@@ -66,13 +64,11 @@ pub fn read_agents(
 
     let mut agent_regions = read_agent_regions(model_dir, &agent_ids, region_ids)?;
     let mut objectives = read_agent_objectives(model_dir, &agents)?;
-    let mut assets = read_agent_assets(model_dir, &agent_ids, processes, region_ids)?;
 
     // Populate each Agent's Vecs
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();
         agent.objectives = objectives.remove(id).unwrap();
-        agent.assets = assets.remove(id).unwrap_or_default();
     }
 
     Ok(agents)
@@ -139,7 +135,6 @@ where
             annual_cost_limit: agent_raw.annual_cost_limit,
             regions: RegionSelection::default(),
             objectives: Vec::new(),
-            assets: Vec::new(),
         };
 
         ensure!(
@@ -196,7 +191,6 @@ mod tests {
             annual_cost_limit: None,
             regions: RegionSelection::default(),
             objectives: Vec::new(),
-            assets: Vec::new(),
         };
         let expected = HashMap::from_iter([("agent".into(), agent_out)]);
         let actual =

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -177,7 +177,6 @@ mod tests {
                 annual_cost_limit: None,
                 regions: RegionSelection::All,
                 objectives: Vec::new(),
-                assets: Vec::new(),
             },
         )]
         .into_iter()

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -32,12 +32,12 @@ struct AssetRaw {
 /// # Returns
 ///
 /// A `HashMap` containing assets grouped by agent ID.
-pub fn read_agent_assets(
+pub fn read_assets(
     model_dir: &Path,
     agent_ids: &HashSet<Rc<str>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, Vec<Asset>>> {
+) -> Result<AssetMap> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
     let assets_csv = read_csv(&file_path)?;
     read_assets_from_iter(assets_csv, agent_ids, processes, region_ids)
@@ -61,7 +61,7 @@ fn read_assets_from_iter<I>(
     agent_ids: &HashSet<Rc<str>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, Vec<Asset>>>
+) -> Result<AssetMap>
 where
     I: Iterator<Item = AssetRaw>,
 {

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -37,7 +37,7 @@ pub fn read_assets(
     agent_ids: &HashSet<Rc<str>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<AssetMap> {
+) -> Result<Vec<Asset>> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
     let assets_csv = read_csv(&file_path)?;
     read_assets_from_iter(assets_csv, agent_ids, processes, region_ids)
@@ -55,13 +55,13 @@ pub fn read_assets(
 ///
 /// # Returns
 ///
-/// A `HashMap` containing assets grouped by agent ID or an error.
+/// A [`Vec`] of [`Asset`]s or an error.
 fn read_assets_from_iter<I>(
     iter: I,
     agent_ids: &HashSet<Rc<str>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<AssetMap>
+) -> Result<Vec<Asset>>
 where
     I: Iterator<Item = AssetRaw>,
 {
@@ -78,18 +78,15 @@ where
             process.id
         );
 
-        Ok((
-            Rc::clone(&agent_id),
-            Asset {
-                agent_id,
-                process: Rc::clone(process),
-                region_id,
-                capacity: asset.capacity,
-                commission_year: asset.commission_year,
-            },
-        ))
+        Ok(Asset {
+            agent_id,
+            process: Rc::clone(process),
+            region_id,
+            capacity: asset.capacity,
+            commission_year: asset.commission_year,
+        })
     })
-    .process_results(|iter| iter.into_group_map())
+    .try_collect()
 }
 
 #[cfg(test)]
@@ -97,7 +94,8 @@ mod tests {
     use super::*;
     use crate::process::ProcessParameter;
     use crate::region::RegionSelection;
-    use std::vec;
+    use itertools::assert_equal;
+    use std::iter;
 
     #[test]
     fn test_read_assets_from_iter() {
@@ -141,11 +139,10 @@ mod tests {
             capacity: 1.0,
             commission_year: 2010,
         };
-        let expected = [("agent1".into(), vec![asset_out])].into_iter().collect();
-        assert!(
+        assert_equal(
             read_assets_from_iter([asset_in].into_iter(), &agent_ids, &processes, &region_ids)
-                .unwrap()
-                == expected
+                .unwrap(),
+            iter::once(asset_out),
         );
 
         // Bad process ID

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Code for simulation models.
 #![allow(missing_docs)]
-use crate::agent::{Agent, Asset};
+use crate::agent::Agent;
 use crate::commodity::Commodity;
 use crate::input::*;
 use crate::process::Process;
@@ -88,27 +88,6 @@ impl Model {
     /// Iterate over the model's regions (region IDs).
     pub fn iter_regions(&self) -> impl Iterator<Item = &Rc<str>> + '_ {
         self.regions.keys()
-    }
-
-    /// Get an iterator of [`Agent`]s for the specified region.
-    pub fn get_agents_for_region<'a>(
-        &'a self,
-        region_id: &'a str,
-    ) -> impl Iterator<Item = &'a Agent> {
-        self.agents
-            .values()
-            .filter(|agent| agent.regions.contains(region_id))
-    }
-
-    /// Get an iterator of active [`Asset`]s for the specified milestone year in a given region.
-    pub fn get_assets<'a>(
-        &'a self,
-        year: u32,
-        region_id: &'a str,
-    ) -> impl Iterator<Item = &'a Asset> {
-        self.get_agents_for_region(region_id)
-            .flat_map(|agent| agent.assets.iter())
-            .filter(move |asset| year >= asset.commission_year)
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,7 +5,7 @@ use crate::commodity::Commodity;
 use crate::input::*;
 use crate::process::Process;
 use crate::region::Region;
-use crate::time_slice::{read_time_slice_info, TimeSliceInfo};
+use crate::time_slice::TimeSliceInfo;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -26,13 +26,13 @@ pub struct Model {
 
 /// Represents the contents of the entire model file.
 #[derive(Debug, Deserialize, PartialEq)]
-struct ModelFile {
-    milestone_years: MilestoneYears,
+pub struct ModelFile {
+    pub milestone_years: MilestoneYears,
 }
 
 /// Represents the "milestone_years" section of the model file.
 #[derive(Debug, Deserialize, PartialEq)]
-struct MilestoneYears {
+pub struct MilestoneYears {
     pub years: Vec<u32>,
 }
 
@@ -80,45 +80,6 @@ impl ModelFile {
 }
 
 impl Model {
-    /// Read a model from the specified directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `model_dir` - Folder containing model configuration files
-    ///
-    /// # Returns
-    ///
-    /// The model contents as a `Model` struct or an error if the model is invalid
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<Model> {
-        let model_file = ModelFile::from_path(&model_dir)?;
-
-        let time_slice_info = read_time_slice_info(model_dir.as_ref())?;
-        let regions = read_regions(model_dir.as_ref())?;
-        let region_ids = regions.keys().cloned().collect();
-        let years = &model_file.milestone_years.years;
-        let year_range = *years.first().unwrap()..=*years.last().unwrap();
-
-        let commodities =
-            read_commodities(model_dir.as_ref(), &region_ids, &time_slice_info, years)?;
-        let processes = read_processes(
-            model_dir.as_ref(),
-            &commodities,
-            &region_ids,
-            &time_slice_info,
-            &year_range,
-        )?;
-        let agents = read_agents(model_dir.as_ref(), &commodities, &processes, &region_ids)?;
-
-        Ok(Model {
-            milestone_years: model_file.milestone_years.years,
-            agents,
-            commodities,
-            processes,
-            time_slice_info,
-            regions,
-        })
-    }
-
     /// Iterate over the model's milestone years.
     pub fn iter_years(&self) -> impl Iterator<Item = u32> + '_ {
         self.milestone_years.iter().copied()

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,18 +1,17 @@
 //! Functionality for running the MUSE 2.0 simulation.
-use crate::agent::{Asset, AssetMap};
+use crate::agent::{Asset, AssetPool};
 use crate::model::Model;
 use log::info;
 use std::rc::Rc;
 
 /// Get an iterator of active [`Asset`]s for the specified milestone year in a given region.
 fn filter_assets<'a>(
-    assets: &'a AssetMap,
+    assets: &'a AssetPool,
     year: u32,
     region_id: &'a Rc<str>,
 ) -> impl Iterator<Item = &'a Asset> {
     assets
-        .values()
-        .flatten()
+        .iter()
         .filter(move |asset| asset.commission_year >= year && asset.region_id == *region_id)
 }
 
@@ -22,7 +21,7 @@ fn filter_assets<'a>(
 ///
 /// * `model` - The model to run
 /// * `assets` - The asset pool
-pub fn run(model: &Model, assets: &AssetMap) {
+pub fn run(model: &Model, assets: &AssetPool) {
     for year in model.iter_years() {
         info!("Milestone year: {year}");
         for region_id in model.iter_regions() {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,18 +1,33 @@
 //! Functionality for running the MUSE 2.0 simulation.
+use crate::agent::{Asset, AssetMap};
 use crate::model::Model;
 use log::info;
+use std::rc::Rc;
+
+/// Get an iterator of active [`Asset`]s for the specified milestone year in a given region.
+fn filter_assets<'a>(
+    assets: &'a AssetMap,
+    year: u32,
+    region_id: &'a Rc<str>,
+) -> impl Iterator<Item = &'a Asset> {
+    assets
+        .values()
+        .flatten()
+        .filter(move |asset| asset.commission_year >= year && asset.region_id == *region_id)
+}
 
 /// Run the simulation.
 ///
 /// # Arguments:
 ///
 /// * `model` - The model to run
-pub fn run(model: &Model) {
+/// * `assets` - The asset pool
+pub fn run(model: &Model, assets: &AssetMap) {
     for year in model.iter_years() {
         info!("Milestone year: {year}");
         for region_id in model.iter_regions() {
             info!("├── Region: {region_id}");
-            for asset in model.get_assets(year, region_id) {
+            for asset in filter_assets(assets, year, region_id) {
                 info!(
                     "│   ├── Agent {} has asset {} (commissioned in {})",
                     asset.agent_id, asset.process.id, asset.commission_year


### PR DESCRIPTION
# Description

Assets are currently loaded into a single `Model` object along with all the other model data from CSV files. Unlike the rest of the input data though, the pool of assets will change over time. Assets listed in `assets.csv` will be commissioned and decommissioned on set years, but agents can also (de)commission assets during the investment step.

This PR splits the assets out from the rest of the `Model` object. As all the input data is currently loaded in `Model::from_path`, I thought it made sense to make a new function (`input::load_model`) which returns the assets and model separately.

Currently the assets are just stored in a regular `Vec`, but eventually we will probably want to wrap this in a struct so we can have custom methods for updating the pool. For now, I've made a type alias of `type AssetPool = Vec<Asset>`, which we can change to a struct when we're ready to start adding some methods (see #335). I wanted to keep the changes for this PR as minimal as possible though.

Fixing this is a prerequisite to #330.

Closes #332.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
