### PR TITLE
Remove use of `atty` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,15 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +390,6 @@ name = "muse2"
 version = "2.0.0-dev1"
 dependencies = [
  "anyhow",
- "atty",
  "chrono",
  "clap",
  "csv",
@@ -669,28 +648,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ tempfile = "3.15.0"
 toml = "0.8.13"
 unicase = "2.8.1"
 fern = {version = "0.7.1", features = ["chrono", "colored"]}
-atty = "0.2"
 chrono = "0.4"
 clap = {version = "4.5.26", features = ["cargo", "derive"]}
 include_dir = "0.7.4"

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,11 +4,11 @@
 //! colourisation based on terminal support. It also allows configuration of the log level through
 //! environment variables.
 use anyhow::{bail, Result};
-use atty;
 use chrono::Local;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::Dispatch;
 use std::env;
+use std::io::IsTerminal;
 
 /// The default log level for the program.
 ///
@@ -55,7 +55,7 @@ pub fn init(log_level_from_settings: Option<&str>) -> Result<()> {
     let timestamp_format = "%H:%M:%S";
 
     // Automatically apply colours only if the output is a terminal
-    let use_colour = atty::is(atty::Stream::Stdout);
+    let use_colour = std::io::stdout().is_terminal();
 
     // Set up colours for log levels
     let colours = ColoredLevelConfig::new()


### PR DESCRIPTION
# Description

There's an open security advisory about `atty`: https://github.com/EnergySystemsModellingLab/MUSE_2.0/security/dependabot/1

It doesn't actually affect us, but we don't need the `atty` crate anyway, as the functionality is now in the standard library instead. So let's just use that instead.

Fixes #244.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
