### PR TITLE
Fix another build error

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,6 @@
 //! Common routines for handling input data.
 use crate::agent::AssetPool;
 use crate::model::{Model, ModelFile};
-use crate::time_slice::read_time_slice_info;
 use anyhow::{ensure, Context, Result};
 use float_cmp::approx_eq;
 use itertools::Itertools;


### PR DESCRIPTION
# Description

It happened again. When I merged #336 it broke the build because the branch wasn't up to date. Dammit. I've checked the "require branches to be up to date" option for the branch protection rule so this shouldn't happen again.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
