### PR TITLE
Store process availabilities in map

### DIFF
--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -92,7 +92,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::process::ProcessParameter;
+    use crate::process::{ProcessAvailabilityMap, ProcessParameter};
     use crate::region::RegionSelection;
     use itertools::assert_equal;
     use std::iter;
@@ -112,7 +112,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            availabilities: vec![],
+            availabilities: ProcessAvailabilityMap::new(),
             flows: vec![],
             parameter: process_param.clone(),
             regions: RegionSelection::All,
@@ -187,7 +187,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            availabilities: vec![],
+            availabilities: ProcessAvailabilityMap::new(),
             flows: vec![],
             parameter: process_param,
             regions: RegionSelection::Some(["GBR".into()].into_iter().collect()),

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -92,7 +92,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::process::{ProcessAvailabilityMap, ProcessParameter};
+    use crate::process::{ProcessCapacityMap, ProcessParameter};
     use crate::region::RegionSelection;
     use itertools::assert_equal;
     use std::iter;
@@ -112,7 +112,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            availabilities: ProcessAvailabilityMap::new(),
+            capacity_fractions: ProcessCapacityMap::new(),
             flows: vec![],
             parameter: process_param.clone(),
             regions: RegionSelection::All,
@@ -187,7 +187,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            availabilities: ProcessAvailabilityMap::new(),
+            capacity_fractions: ProcessCapacityMap::new(),
             flows: vec![],
             parameter: process_param,
             regions: RegionSelection::Some(["GBR".into()].into_iter().collect()),

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -1,7 +1,7 @@
 //! Code for reading process-related information from CSV files.
 use crate::commodity::Commodity;
 use crate::input::*;
-use crate::process::{Process, ProcessAvailability, ProcessFlow, ProcessParameter};
+use crate::process::{Process, ProcessAvailabilityMap, ProcessFlow, ProcessParameter};
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
@@ -38,9 +38,6 @@ struct ProcessDescription {
     description: String,
 }
 define_id_getter! {ProcessDescription}
-
-/// A map of process-related data structures, grouped by process ID
-type GroupedMap<T> = HashMap<Rc<str>, Vec<T>>;
 
 /// Read process information from the specified CSV files.
 ///
@@ -82,8 +79,8 @@ pub fn read_processes(
 
 fn create_process_map<I>(
     descriptions: I,
-    availabilities: GroupedMap<ProcessAvailability>,
-    flows: GroupedMap<ProcessFlow>,
+    availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
+    flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
     parameters: HashMap<Rc<str>, ProcessParameter>,
     regions: HashMap<Rc<str>, RegionSelection>,
 ) -> Result<HashMap<Rc<str>, Rc<Process>>>
@@ -132,8 +129,8 @@ mod tests {
 
     struct ProcessData {
         descriptions: Vec<ProcessDescription>,
-        availabilities: GroupedMap<ProcessAvailability>,
-        flows: GroupedMap<ProcessFlow>,
+        availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
+        flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
         parameters: HashMap<Rc<str>, ProcessParameter>,
         regions: HashMap<Rc<str>, RegionSelection>,
     }
@@ -153,7 +150,7 @@ mod tests {
 
         let availabilities = ["process1", "process2"]
             .into_iter()
-            .map(|id| (id.into(), vec![]))
+            .map(|id| (id.into(), ProcessAvailabilityMap::new()))
             .collect();
 
         let flows = ["process1", "process2"]

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -79,20 +79,14 @@ pub fn read_processes(
 
 fn create_process_map<I>(
     descriptions: I,
-    availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
-    flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
-    parameters: HashMap<Rc<str>, ProcessParameter>,
-    regions: HashMap<Rc<str>, RegionSelection>,
+    mut availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
+    mut flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
+    mut parameters: HashMap<Rc<str>, ProcessParameter>,
+    mut regions: HashMap<Rc<str>, RegionSelection>,
 ) -> Result<HashMap<Rc<str>, Rc<Process>>>
 where
     I: Iterator<Item = ProcessDescription>,
 {
-    // Need to be mutable as we remove elements as we go along
-    let mut availabilities = availabilities;
-    let mut flows = flows;
-    let mut parameters = parameters;
-    let mut regions = regions;
-
     descriptions
         .map(|description| {
             let id = &description.id;

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -1,7 +1,7 @@
 //! Code for reading process-related information from CSV files.
 use crate::commodity::Commodity;
 use crate::input::*;
-use crate::process::{Process, ProcessAvailabilityMap, ProcessFlow, ProcessParameter};
+use crate::process::{Process, ProcessCapacityMap, ProcessFlow, ProcessParameter};
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
@@ -79,7 +79,7 @@ pub fn read_processes(
 
 fn create_process_map<I>(
     descriptions: I,
-    mut availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
+    mut availabilities: HashMap<Rc<str>, ProcessCapacityMap>,
     mut flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
     mut parameters: HashMap<Rc<str>, ProcessParameter>,
     mut regions: HashMap<Rc<str>, RegionSelection>,
@@ -106,7 +106,7 @@ where
             let process = Process {
                 id: Rc::clone(id),
                 description: description.description,
-                availabilities,
+                capacity_fractions: availabilities,
                 flows,
                 parameter,
                 regions,
@@ -123,7 +123,7 @@ mod tests {
 
     struct ProcessData {
         descriptions: Vec<ProcessDescription>,
-        availabilities: HashMap<Rc<str>, ProcessAvailabilityMap>,
+        availabilities: HashMap<Rc<str>, ProcessCapacityMap>,
         flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
         parameters: HashMap<Rc<str>, ProcessParameter>,
         regions: HashMap<Rc<str>, RegionSelection>,
@@ -144,7 +144,7 @@ mod tests {
 
         let availabilities = ["process1", "process2"]
             .into_iter()
-            .map(|id| (id.into(), ProcessAvailabilityMap::new()))
+            .map(|id| (id.into(), ProcessCapacityMap::new()))
             .collect();
 
         let flows = ["process1", "process2"]

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -19,7 +19,21 @@ struct ProcessAvailabilityRaw {
     value: f64,
 }
 
-/// Read the availability of each process over time slices
+/// Read the process availabilities CSV file.
+///
+/// This file contains information about the availability of processes over the course of a year as
+/// a proportion of their maximum capacity.
+///
+/// # Arguments
+///
+/// * `model_dir` - Folder containing model configuration files
+/// * `process_ids` - The possible valid process IDs
+/// * `time_slice_info` - Information about seasons and times of day
+///
+/// # Returns
+///
+/// A [`HashMap`] with process IDs as the keys and [`ProcessAvailabilityMap`]s as the values or an
+/// error.
 pub fn read_process_availabilities(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
@@ -31,6 +45,7 @@ pub fn read_process_availabilities(
         .with_context(|| input_err_msg(&file_path))
 }
 
+/// Process raw process availabilities input data into [`ProcessAvailabilityMap`]s
 fn read_process_availabilities_from_iter<I>(
     iter: I,
     process_ids: &HashSet<Rc<str>>,

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -1,18 +1,14 @@
 //! Code for reading process availabilities CSV file
-use super::define_process_id_getter;
 use crate::input::*;
-use crate::process::{LimitType, ProcessAvailability};
+use crate::process::{LimitType, ProcessAvailability, ProcessAvailabilityMap};
 use crate::time_slice::TimeSliceInfo;
 use anyhow::{Context, Result};
-use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
 const PROCESS_AVAILABILITIES_FILE_NAME: &str = "process_availabilities.csv";
-
-define_process_id_getter! {ProcessAvailability}
 
 /// Represents a row of the process availabilities CSV file
 #[derive(PartialEq, Debug, Deserialize)]
@@ -28,7 +24,7 @@ pub fn read_process_availabilities(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
-) -> Result<HashMap<Rc<str>, Vec<ProcessAvailability>>> {
+) -> Result<HashMap<Rc<str>, ProcessAvailabilityMap>> {
     let file_path = model_dir.join(PROCESS_AVAILABILITIES_FILE_NAME);
     let process_availabilities_csv = read_csv(&file_path)?;
     read_process_availabilities_from_iter(process_availabilities_csv, process_ids, time_slice_info)
@@ -39,24 +35,44 @@ fn read_process_availabilities_from_iter<I>(
     iter: I,
     process_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
-) -> Result<HashMap<Rc<str>, Vec<ProcessAvailability>>>
+) -> Result<HashMap<Rc<str>, ProcessAvailabilityMap>>
 where
     I: Iterator<Item = ProcessAvailabilityRaw>,
 {
-    iter.map(|record| -> Result<_> {
+    let mut map = HashMap::new();
+
+    for record in iter {
         ensure!(
             record.value >= 0.0 && record.value <= 1.0,
             "value for availability must be between 0 and 1 inclusive"
         );
 
-        let time_slice = time_slice_info.get_selection(&record.time_slice)?;
+        let process_id = process_ids.get_id(&record.process_id)?;
+        let map = map
+            .entry(process_id)
+            .or_insert_with(ProcessAvailabilityMap::new);
 
-        Ok(ProcessAvailability {
-            process_id: record.process_id,
-            limit_type: record.limit_type,
-            time_slice,
-            value: record.value,
-        })
-    })
-    .process_results(|iter| iter.into_id_map(process_ids))?
+        let ts_selection = time_slice_info.get_selection(&record.time_slice)?;
+        for (time_slice, _) in time_slice_info.iter_selection(&ts_selection) {
+            let existing = map
+                .insert(
+                    time_slice.clone(),
+                    ProcessAvailability {
+                        limit_type: record.limit_type,
+                        value: record.value,
+                    },
+                )
+                .is_some();
+
+            ensure!(
+                !existing,
+                "Process availability entry covered by more than one time slice \
+                (process: {}, time slice: {})",
+                record.process_id,
+                time_slice
+            )
+        }
+    }
+
+    Ok(map)
 }

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -20,7 +20,6 @@ struct ProcessAvailabilityRaw {
     process_id: String,
     limit_type: LimitType,
     time_slice: String,
-    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     value: f64,
 }
 
@@ -45,6 +44,11 @@ where
     I: Iterator<Item = ProcessAvailabilityRaw>,
 {
     iter.map(|record| -> Result<_> {
+        ensure!(
+            record.value >= 0.0 && record.value <= 1.0,
+            "value for availability must be between 0 and 1 inclusive"
+        );
+
         let time_slice = time_slice_info.get_selection(&record.time_slice)?;
 
         Ok(ProcessAvailability {

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -81,3 +81,138 @@ where
 
     Ok(map)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time_slice::TimeSliceID;
+    use itertools::assert_equal;
+    use std::iter;
+
+    fn get_time_slice_info() -> TimeSliceInfo {
+        let slices = [
+            TimeSliceID {
+                season: "winter".into(),
+                time_of_day: "day".into(),
+            },
+            TimeSliceID {
+                season: "summer".into(),
+                time_of_day: "night".into(),
+            },
+        ];
+
+        TimeSliceInfo {
+            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            times_of_day: ["day".into(), "night".into()].into_iter().collect(),
+            fractions: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    fn check_succeeds(process_id: &str, limit_type: &str, time_slice: &str, value: f64) -> bool {
+        let process_ids = iter::once("process1".into()).collect();
+        let time_slice_info = get_time_slice_info();
+
+        let avail = ProcessAvailabilityRaw {
+            process_id: process_id.into(),
+            limit_type: limit_type.into(),
+            time_slice: time_slice.into(),
+            value,
+        };
+        read_process_availabilities_from_iter(iter::once(avail), &process_ids, &time_slice_info)
+            .is_ok()
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_success() {
+        let process_ids = iter::once("process1".into()).collect();
+        let time_slice_info = get_time_slice_info();
+
+        let value = 0.5;
+        macro_rules! check_with_limit_type {
+            ($limit_type: expr, $range: expr) => {
+                let avail = ProcessAvailabilityRaw {
+                    process_id: "process1".into(),
+                    limit_type: $limit_type.into(),
+                    time_slice: "winter".into(),
+                    value,
+                };
+                let time_slice = time_slice_info
+                    .get_time_slice_id_from_str("winter.day")
+                    .unwrap();
+                let expected_map = iter::once((time_slice, $range)).collect();
+                let expected = iter::once(("process1".into(), expected_map));
+                assert_equal(
+                    read_process_availabilities_from_iter(
+                        iter::once(avail),
+                        &process_ids,
+                        &time_slice_info,
+                    )
+                    .unwrap(),
+                    expected,
+                );
+            };
+        }
+
+        check_with_limit_type!("lo", value..=f64::INFINITY);
+        check_with_limit_type!("up", f64::NEG_INFINITY..=value);
+        check_with_limit_type!("fx", value..=value);
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_values() {
+        macro_rules! succeeds_with_value {
+            ($value:expr) => {{
+                check_succeeds("process1", "fx", "winter.day", $value)
+            }};
+        }
+
+        // Good values
+        assert!(succeeds_with_value!(0.0));
+        assert!(succeeds_with_value!(0.5));
+        assert!(succeeds_with_value!(1.0));
+
+        // Bad values
+        assert!(!succeeds_with_value!(-1.0));
+        assert!(!succeeds_with_value!(2.0));
+        assert!(!succeeds_with_value!(f64::NAN));
+        assert!(!succeeds_with_value!(f64::NEG_INFINITY));
+        assert!(!succeeds_with_value!(f64::INFINITY));
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_bad_overlapping_time_slices() {
+        let process_ids = iter::once("process1".into()).collect();
+        let time_slice_info = get_time_slice_info();
+
+        let value = 0.5;
+        let avail = ["winter", "winter.day"].map(|time_slice| ProcessAvailabilityRaw {
+            process_id: "process1".into(),
+            limit_type: "fx".into(),
+            time_slice: time_slice.into(),
+            value,
+        });
+        assert!(read_process_availabilities_from_iter(
+            avail.into_iter(),
+            &process_ids,
+            &time_slice_info
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_bad_process_id() {
+        assert!(!check_succeeds("MADEUP", "fx", "winter", 0.5));
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_bad_limit_type() {
+        assert!(!check_succeeds("process1", "MADEUP", "winter", 0.5));
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_bad_time_slice() {
+        assert!(!check_succeeds("process1", "fx", "MADEUP", 0.5));
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 pub struct Process {
     pub id: Rc<str>,
     pub description: String,
-    pub availabilities: ProcessAvailabilityMap,
+    pub capacity_fractions: ProcessCapacityMap,
     pub flows: Vec<ProcessFlow>,
     pub parameter: ProcessParameter,
     pub regions: RegionSelection,
@@ -25,10 +25,16 @@ impl Process {
     }
 }
 
-/// A map indicating the availability of a [`Process`] over the course of the year.
+/// A map indicating capacity limits for a [`Process`] throughout the year.
 ///
-/// The availability is a range, depending on the user-specified limit type and value
-pub type ProcessAvailabilityMap = HashMap<TimeSliceID, RangeInclusive<f64>>;
+/// The capacity value is calculated as availability multiplied by time slice length. Note that it
+/// is a *fraction* of capacity for the year; to calculate *actual* capacity for a given time slice
+/// you need to know the maximum capacity for the specific instance of a [`Process`] in use (e.g.
+/// given by [`Asset::capacity`](crate::agent::Asset::capacity)).
+///
+/// The capacity is given as a range, depending on the user-specified limit type and value for
+/// availability.
+pub type ProcessCapacityMap = HashMap<TimeSliceID, RangeInclusive<f64>>;
 
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 pub struct ProcessFlow {

--- a/src/process.rs
+++ b/src/process.rs
@@ -25,27 +25,10 @@ impl Process {
     }
 }
 
-/// A map indicating the availability of a [`Process`] over the course of the year
-pub type ProcessAvailabilityMap = HashMap<TimeSliceID, ProcessAvailability>;
-
-/// The type of limit and availability value
-#[derive(PartialEq, Debug)]
-pub struct ProcessAvailability {
-    /// The limit type - lower bound, upper bound or equality
-    pub limit_type: LimitType,
-    /// The availability value, between 0 and 1 inclusive
-    pub value: f64,
-}
-
-#[derive(PartialEq, Clone, Copy, Debug, DeserializeLabeledStringEnum)]
-pub enum LimitType {
-    #[string = "lo"]
-    LowerBound,
-    #[string = "up"]
-    UpperBound,
-    #[string = "fx"]
-    Equality,
-}
+/// A map indicating the availability of a [`Process`] over the course of the year.
+///
+/// The availability is a range, depending on the user-specified limit type and value
+pub type ProcessAvailabilityMap = HashMap<TimeSliceID, RangeInclusive<f64>>;
 
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 pub struct ProcessFlow {

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,9 +1,10 @@
 #![allow(missing_docs)]
 use crate::commodity::Commodity;
 use crate::region::RegionSelection;
-use crate::time_slice::TimeSliceSelection;
+use crate::time_slice::TimeSliceID;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
 
@@ -11,7 +12,7 @@ use std::rc::Rc;
 pub struct Process {
     pub id: Rc<str>,
     pub description: String,
-    pub availabilities: Vec<ProcessAvailability>,
+    pub availabilities: ProcessAvailabilityMap,
     pub flows: Vec<ProcessFlow>,
     pub parameter: ProcessParameter,
     pub regions: RegionSelection,
@@ -24,20 +25,19 @@ impl Process {
     }
 }
 
-/// The availabilities for a process over time slices
+/// A map indicating the availability of a [`Process`] over the course of the year
+pub type ProcessAvailabilityMap = HashMap<TimeSliceID, ProcessAvailability>;
+
+/// The type of limit and availability value
 #[derive(PartialEq, Debug)]
 pub struct ProcessAvailability {
-    /// Unique identifier for the process
-    pub process_id: String,
     /// The limit type - lower bound, upper bound or equality
     pub limit_type: LimitType,
-    /// The time slice to which the availability applies
-    pub time_slice: TimeSliceSelection,
     /// The availability value, between 0 and 1 inclusive
     pub value: f64,
 }
 
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+#[derive(PartialEq, Clone, Copy, Debug, DeserializeLabeledStringEnum)]
 pub enum LimitType {
     #[string = "lo"]
     LowerBound,


### PR DESCRIPTION
# Description

In MUSEv2 you can specify the availability of a process over the course of a year as a proportion of maximum capacity. This information is contained in the `process_availabilities.csv` input file.

Currently we read this information into a flat `Vec<ProcessAvailability>`, but it will be difficult to use it in this form. As with the `CommodityCostMap` and `DemandMap`, users can specify ranges of time slices for which a given value applies, so in order to make it easy to look up the values by time slice (as well as verifying that there are no overlapping entries) it makes sense to store it in a map.

The `ProcessAvailabilityMap` ended up being simpler than the others I mention because there's only one "key" value (a `TimeSliceID`). Values can be specified to be lower bounds, upper bounds or an equality condition. I've changed the code to convert these to ranges, so we can just have a single value type (as opposed to e.g. a tuple specifying the limit type + the value). (This is also the form the solver needs the values in -- see #301.)

The actual code ends up being a bit shorter after the refactoring, but I've also added tests as there weren't any before, for some reason.

This is a prerequisite for #301.

Closes #340.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
