### PR TITLE
Install and use the human-panic crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +77,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -73,7 +88,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -87,6 +102,21 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bindgen"
@@ -231,7 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -280,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -311,15 +341,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "windows-targets",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -357,6 +404,22 @@ checksum = "84793ab0a88a3afe0148d042677634c24c90a0303205666cc88970a1073a77ef"
 dependencies = [
  "bindgen",
  "cmake",
+]
+
+[[package]]
+name = "human-panic"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "backtrace",
+ "os_info",
+ "serde",
+ "serde_derive",
+ "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -498,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "muse2"
 version = "2.0.0-dev1"
 dependencies = [
@@ -508,6 +580,7 @@ dependencies = [
  "fern",
  "float-cmp",
  "highs",
+ "human-panic",
  "include_dir",
  "indexmap",
  "itertools 0.14.0",
@@ -539,10 +612,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "os_info"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6520c8cc998c5741ee68ec1dc369fc47e5f0ea5320018ecf2a1ccd6328f48b"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "prettyplease"
@@ -602,6 +695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +716,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -705,10 +804,10 @@ checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -762,6 +861,21 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+dependencies = [
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -835,6 +949,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ clap = {version = "4.5.27", features = ["cargo", "derive"]}
 include_dir = "0.7.4"
 highs = "1.6.1"
 indexmap = "2.7.1"
+human-panic = "2.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use human_panic::setup_panic;
 use muse2::commands;
 
 use commands::{
@@ -6,6 +7,8 @@ use commands::{
 };
 
 fn main() {
+    setup_panic!();
+
     let cli = Cli::parse();
     match cli.command {
         Commands::Run { model_dir } => handle_run_command(&model_dir),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use human_panic::setup_panic;
+use human_panic::{metadata, setup_panic};
 use muse2::commands;
 
 use commands::{
@@ -7,7 +7,10 @@ use commands::{
 };
 
 fn main() {
-    setup_panic!();
+    setup_panic!(metadata!().support(format!(
+        "Open an issue on Github: {}/issues/new?template=bug_report.md",
+        env!("CARGO_PKG_REPOSITORY")
+    )));
 
     let cli = Cli::parse();
     match cli.command {


### PR DESCRIPTION
# Description

This PR adds the [human-panic](https://crates.io/crates/human-panic) crate to the package and initialises it. This is all that is required to use it with all the default settings.

Note that this does not change the way the input errors are currently displayed because that is useful, immediate feedback to the users. This is for unexpected errors in the code that mean something went wrong and it's not immediately clear what the error in the input file was (unlike with input validation).

It only runs in release mode, so to test it, add in a panic macro somewhere and run the following:

```
cargo run --release run examples/simple
```

You should see this error message:
```
Well, this is embarrassing.

muse2 had a problem and crashed. To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/var/folders/td/5nhj1569101bqjj_vmltr_7r0000gp/T/report-34dd8ee3-f3f1-4a6d-8b78-e2b0e3fa9774.toml". Submit an issue or email with the subject of "muse2 Crash Report" and include the report as an attachment.

- Authors: Hawkes Research Group @ Chemical Engineering, Imperial College London <a.hawkes@imperial.ac.uk>, Imperial College London RSE Team <ict-rse-team@imperial.ac.uk>

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thank you kindly!
```

In the report folder you should see something like:

```
name = "muse2"
operating_system = "Mac OS 14.7.2 [64-bit]"
crate_version = "2.0.0-dev1"
explanation = """
Panic occurred in file 'src/main.rs' at line 20
"""
cause = "OMG EVERYTHING IS ON FIRE!!!"
method = "Panic"
backtrace = """
   0:        0x1006b5b4c - backtrace::capture::Backtrace::create::ha9e0463f3802142f
   1:        0x1006b5a88 - backtrace::capture::Backtrace::new::hcde11c4180a9e306
   2:        0x10066f184 - human_panic::report::Report::new::h000769b429af4ba2
   3:        0x100671a54 - human_panic::handle_dump::h9f09775c88abb5fd
   4:        0x1006059dc - human_panic::setup_panic::{{closure}}::h5e55b460711e4064
   5:        0x1007338e4 - std::panicking::rust_panic_with_hook::h7d795911432661cb
   6:        0x100733534 - std::panicking::begin_panic_handler::{{closure}}::h36f15310ecbde379
   7:        0x100732644 - std::sys::backtrace::__rust_end_short_backtrace::heed121414170e0c7
   8:        0x100733214 - _rust_begin_unwind
   9:        0x100762e54 - core::panicking::panic_fmt::h17b1b80ec02ffd19
  10:        0x100607568 - muse2::main::hbfb3bcaba49d87ae
  11:        0x100606fd4 - std::sys::backtrace::__rust_begin_short_backtrace::hefad40ed45d34232
  12:        0x100606fbc - std::rt::lang_start::{{closure}}::h9893b1fcd28e6a2c
  13:        0x100729e40 - std::rt::lang_start_internal::h77891a2543177e4b
  14:        0x100607610 - _main
"""
```

Fixes #186 
Close #232 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
