### PR TITLE
Add cost coefficients to optimisation

### DIFF
--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -27,7 +27,7 @@ Where *cost* is a vector of cost coefficients representing the cost of
 each commodity flow.
 
 $$
-  cost_{r,a,c,ts} = var\\_ opex_{r,a,pacs,ts} + flow\\_ cost_{r,a,c,ts} + commodity\\_ cost_{r,c,ts}
+  cost_{r,a,c,ts} = var\\_ opex_{r,a,pacs} + flow\\_ cost_{r,a,c} + commodity\\_ cost_{r,c,ts}
 $$
 
 *var\_opex* is the variable operating cost for a PAC. If the commodity is not a PAC, this value is

--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -33,11 +33,13 @@ $$
 *var\_opex* is the variable operating cost for a PAC. If the commodity is not a PAC, this value is
 zero.
 
-*flow\_cost* is the cost per unit flow. Note that if this is for an input flow, its value should be
-multiplied by &minus;1 so that the impact on the objective function is a positive cost.
+*flow\_cost* is the cost per unit flow.
 
 *commodity\_cost* is the exogenous (user-defined) cost for a commodity. If none is defined for this
 combination of parameters, this value is zero.
+
+**NOTE:** If the commodity flow is an input (i.e. flow <0), then the value of *cost* should be
+multiplied by &minus;1 so that the impact on the objective function is positive.
 
 Constraints.
 

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -84,14 +84,14 @@ impl CommodityCostMap {
     /// Retrieve a [`CommodityCost`] from the map
     pub fn get(
         &self,
-        region_id: Rc<str>,
+        region_id: &Rc<str>,
         year: u32,
-        time_slice: TimeSliceID,
+        time_slice: &TimeSliceID,
     ) -> Option<&CommodityCost> {
         let key = CommodityCostKey {
-            region_id,
+            region_id: Rc::clone(region_id),
             year,
-            time_slice,
+            time_slice: time_slice.clone(),
         };
         self.0.get(&key)
     }
@@ -186,6 +186,6 @@ mod tests {
         assert!(map
             .insert("GBR".into(), 2010, ts.clone(), value.clone())
             .is_none());
-        assert_eq!(map.get("GBR".into(), 2010, ts).unwrap(), &value);
+        assert_eq!(map.get(&"GBR".into(), 2010, &ts).unwrap(), &value);
     }
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -48,7 +48,7 @@ pub struct CommodityCost {
 }
 
 /// Used for looking up [`CommodityCost`]s in a [`CommodityCostMap`]
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
 struct CommodityCostKey {
     region_id: Rc<str>,
     year: u32,
@@ -56,7 +56,7 @@ struct CommodityCostKey {
 }
 
 /// A data structure for easy lookup of [`CommodityCost`]s
-#[derive(PartialEq, Debug, Default)]
+#[derive(PartialEq, Debug, Default, Clone)]
 pub struct CommodityCostMap(HashMap<CommodityCostKey, CommodityCost>);
 
 impl CommodityCostMap {

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -199,10 +199,13 @@ fn calculate_cost_coefficient(
 
     // If there is a user-provided commodity cost for this combination of parameters, include it
     if let Some(cost) = flow.commodity.costs.get(&asset.region_id, year, time_slice) {
-        if cost.balance_type == BalanceType::Net
-            || (cost.balance_type == BalanceType::Consumption && flow.flow < 0.0)
-            || (cost.balance_type == BalanceType::Production && flow.flow > 0.0)
-        {
+        let apply_cost = match cost.balance_type {
+            BalanceType::Net => true,
+            BalanceType::Consumption => flow.flow < 0.0,
+            BalanceType::Production => flow.flow > 0.0,
+        };
+
+        if apply_cost {
             coeff += cost.value;
         }
     }

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -2,6 +2,7 @@
 //!
 //! This is used to calculate commodity flows and prices.
 use crate::agent::{Asset, AssetPool};
+use crate::commodity::BalanceType;
 use crate::model::Model;
 use crate::process::ProcessFlow;
 use crate::simulation::filter_assets;
@@ -157,7 +158,7 @@ fn add_variables(
     for asset in filter_assets(assets, year) {
         for flow in asset.process.flows.iter() {
             for time_slice in model.time_slice_info.iter_ids() {
-                let coeff = calculate_cost_coefficient(year, asset, flow, time_slice);
+                let coeff = calculate_cost_coefficient(asset, flow, year, time_slice);
 
                 // var's value must be <= 0 for inputs and >= 0 for outputs
                 let var = if flow.flow < 0.0 {
@@ -183,13 +184,32 @@ fn add_variables(
 
 /// Calculate the cost coefficient for a decision variable
 fn calculate_cost_coefficient(
-    _year: u32,
-    _asset: &Asset,
-    _flow: &ProcessFlow,
-    _time_slice: &TimeSliceID,
+    asset: &Asset,
+    flow: &ProcessFlow,
+    year: u32,
+    time_slice: &TimeSliceID,
 ) -> f64 {
-    // **PLACEHOLDER**
-    1.0
+    // Cost per unit flow
+    let mut coeff = flow.flow_cost;
+
+    // Only applies if commodity is PAC
+    if flow.is_pac {
+        coeff += asset.process.parameter.variable_operating_cost
+    }
+
+    // If there is a user-provided commodity cost for this combination of parameters, include it
+    if let Some(cost) = flow.commodity.costs.get(&asset.region_id, year, time_slice) {
+        if cost.balance_type == BalanceType::Net
+            || (cost.balance_type == BalanceType::Consumption && flow.flow < 0.0)
+            || (cost.balance_type == BalanceType::Production && flow.flow > 0.0)
+        {
+            coeff += cost.value;
+        }
+    }
+
+    // If flow is negative (representing an input), we multiply by -1 to ensure impact of
+    // coefficient on objective function is a positive cost
+    coeff.copysign(flow.flow)
 }
 
 /// Add asset-level constraints
@@ -281,4 +301,133 @@ fn add_asset_capacity_constraints(
     _year: u32,
 ) {
     info!("Adding asset-level capacity and availability constraints...");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commodity::{Commodity, CommodityCost, CommodityCostMap, CommodityType, DemandMap};
+    use crate::process::{FlowType, Process, ProcessCapacityMap, ProcessParameter};
+    use crate::region::RegionSelection;
+    use crate::time_slice::TimeSliceLevel;
+    use float_cmp::assert_approx_eq;
+    use std::rc::Rc;
+
+    fn get_cost_coeff_args(
+        flow: f64,
+        is_pac: bool,
+        costs: CommodityCostMap,
+    ) -> (Asset, ProcessFlow) {
+        let process_param = ProcessParameter {
+            process_id: "process1".into(),
+            years: 2010..=2020,
+            capital_cost: 5.0,
+            fixed_operating_cost: 2.0,
+            variable_operating_cost: 1.0,
+            lifetime: 5,
+            discount_rate: 0.9,
+            cap2act: 1.0,
+        };
+        let commodity = Rc::new(Commodity {
+            id: "commodity1".into(),
+            description: "Some description".into(),
+            kind: CommodityType::InputCommodity,
+            time_slice_level: TimeSliceLevel::Annual,
+            costs,
+            demand: DemandMap::new(),
+        });
+        let flow = ProcessFlow {
+            process_id: "id1".into(),
+            commodity: Rc::clone(&commodity),
+            flow,
+            flow_type: FlowType::Fixed,
+            flow_cost: 1.0,
+            is_pac,
+        };
+        let process = Rc::new(Process {
+            id: "process1".into(),
+            description: "Description".into(),
+            capacity_fractions: ProcessCapacityMap::new(),
+            flows: vec![flow.clone()],
+            parameter: process_param.clone(),
+            regions: RegionSelection::All,
+        });
+        let asset = Asset {
+            id: 0,
+            agent_id: "agent1".into(),
+            process: Rc::clone(&process),
+            region_id: "GBR".into(),
+            capacity: 1.0,
+            commission_year: 2010,
+        };
+
+        (asset, flow)
+    }
+
+    #[test]
+    fn test_calculate_cost_coefficient() {
+        let time_slice = TimeSliceID {
+            season: "winter".into(),
+            time_of_day: "day".into(),
+        };
+
+        macro_rules! check_coeff {
+            ($flow:expr, $is_pac:expr, $costs:expr, $expected:expr) => {
+                let (asset, flow) = get_cost_coeff_args($flow, $is_pac, $costs);
+                assert_approx_eq!(
+                    f64,
+                    calculate_cost_coefficient(&asset, &flow, 2010, &time_slice),
+                    $expected
+                );
+            };
+        }
+
+        // not PAC, no commodity cost
+        check_coeff!(1.0, false, CommodityCostMap::new(), 1.0);
+        check_coeff!(-1.0, false, CommodityCostMap::new(), -1.0);
+
+        // PAC, no commodity cost
+        check_coeff!(1.0, true, CommodityCostMap::new(), 2.0);
+        check_coeff!(-1.0, true, CommodityCostMap::new(), -2.0);
+
+        // not PAC, commodity cost for output
+        let cost = CommodityCost {
+            balance_type: BalanceType::Production,
+            value: 2.0,
+        };
+        let mut costs = CommodityCostMap::new();
+        costs.insert("GBR".into(), 2010, time_slice.clone(), cost);
+        check_coeff!(1.0, false, costs.clone(), 3.0);
+        check_coeff!(-1.0, false, costs, -1.0);
+
+        // not PAC, commodity cost for output and input
+        let cost = CommodityCost {
+            balance_type: BalanceType::Net,
+            value: 2.0,
+        };
+        let mut costs = CommodityCostMap::new();
+        costs.insert("GBR".into(), 2010, time_slice.clone(), cost);
+        check_coeff!(1.0, false, costs.clone(), 3.0);
+        check_coeff!(-1.0, false, costs, -3.0);
+
+        // not PAC, commodity cost for input
+        let cost = CommodityCost {
+            balance_type: BalanceType::Consumption,
+            value: 2.0,
+        };
+        let mut costs = CommodityCostMap::new();
+        costs.insert("GBR".into(), 2010, time_slice.clone(), cost);
+        check_coeff!(1.0, false, costs.clone(), 1.0);
+        check_coeff!(-1.0, false, costs, -3.0);
+
+        // PAC, commodity cost for output
+        let cost = CommodityCost {
+            balance_type: BalanceType::Production,
+            value: 2.0,
+        };
+        let mut costs = CommodityCostMap::new();
+        costs.insert("GBR".into(), 2010, time_slice.clone(), cost);
+        check_coeff!(1.0, true, costs.clone(), 4.0);
+        check_coeff!(-1.0, true, costs, -2.0);
+    }
 }


### PR DESCRIPTION
# Description

This PR computes the cost coefficients for the optimisation using the equation in the dispatch optimisation doc. Although there are only three terms that make up the coefficients, two of them are only applied conditionally (`var_opex` only applies to PACs and `commodity_cost` only applies if a) the user has specified one and b) it's of the right type for the particular commodity flow).

Other changes:

- Fixed up a couple of issues in the dispatch doc
- Changed `CommodityCostMap::get` to take its arguments as references to make the interface cleaner

Closes #299.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
