### PR TITLE
Add capacity/availability constraints

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -95,8 +95,8 @@ pub struct Asset {
     pub process: Rc<Process>,
     /// The region in which the asset is located
     pub region_id: Rc<str>,
-    /// The maximum commodity output per year
-    pub capacity_a: f64,
+    /// Capacity of asset
+    pub capacity: f64,
     /// The year the asset comes online
     pub commission_year: u32,
 }
@@ -105,9 +105,10 @@ impl Asset {
     /// Get the capacity limits for this asset in a particular time slice
     pub fn get_capacity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.capacity_fractions.get(time_slice).unwrap();
+        let capacity_a = self.capacity * self.process.parameter.cap2act;
 
         // Multiply the fractional capacity in self.process by this asset's actual capacity
-        (self.capacity_a * limits.start())..=(self.capacity_a * limits.end())
+        (capacity_a * limits.start())..=(capacity_a * limits.end())
     }
 }
 
@@ -136,7 +137,7 @@ mod tests {
             variable_operating_cost: 1.0,
             lifetime: 5,
             discount_rate: 0.9,
-            cap2act: 1.0,
+            cap2act: 3.0,
         };
         let commodity = Rc::new(Commodity {
             id: "commodity1".into(),
@@ -169,10 +170,10 @@ mod tests {
             agent_id: "agent1".into(),
             process: Rc::clone(&process),
             region_id: "GBR".into(),
-            capacity_a: 2.0,
+            capacity: 2.0,
             commission_year: 2010,
         };
 
-        assert_eq!(asset.get_capacity_limits(&time_slice), 2.0..=f64::INFINITY);
+        assert_eq!(asset.get_capacity_limits(&time_slice), 6.0..=f64::INFINITY);
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3,9 +3,11 @@
 use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
+use crate::time_slice::TimeSliceID;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashSet;
+use std::ops::RangeInclusive;
 use std::rc::Rc;
 
 /// An agent in the simulation
@@ -99,5 +101,78 @@ pub struct Asset {
     pub commission_year: u32,
 }
 
+impl Asset {
+    /// Get the capacity limits for this asset in a particular time slice
+    pub fn get_capacity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
+        let limits = self.process.capacity_fractions.get(time_slice).unwrap();
+
+        // Multiply the fractional capacity in self.process by this asset's actual capacity
+        (self.capacity_a * limits.start())..=(self.capacity_a * limits.end())
+    }
+}
+
 /// A pool of [`Asset`]s
 pub type AssetPool = Vec<Asset>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commodity::{CommodityCostMap, CommodityType, DemandMap};
+    use crate::process::{FlowType, ProcessFlow, ProcessParameter};
+    use crate::time_slice::TimeSliceLevel;
+    use std::iter;
+
+    #[test]
+    fn test_asset_get_capacity_limits() {
+        let time_slice = TimeSliceID {
+            season: "winter".into(),
+            time_of_day: "day".into(),
+        };
+        let process_param = ProcessParameter {
+            process_id: "process1".into(),
+            years: 2010..=2020,
+            capital_cost: 5.0,
+            fixed_operating_cost: 2.0,
+            variable_operating_cost: 1.0,
+            lifetime: 5,
+            discount_rate: 0.9,
+            cap2act: 1.0,
+        };
+        let commodity = Rc::new(Commodity {
+            id: "commodity1".into(),
+            description: "Some description".into(),
+            kind: CommodityType::InputCommodity,
+            time_slice_level: TimeSliceLevel::Annual,
+            costs: CommodityCostMap::new(),
+            demand: DemandMap::new(),
+        });
+        let flow = ProcessFlow {
+            process_id: "id1".into(),
+            commodity: Rc::clone(&commodity),
+            flow: 1.0,
+            flow_type: FlowType::Fixed,
+            flow_cost: 1.0,
+            is_pac: true,
+        };
+        let fraction_limits = 1.0..=f64::INFINITY;
+        let capacity_fractions = iter::once((time_slice.clone(), fraction_limits)).collect();
+        let process = Rc::new(Process {
+            id: "process1".into(),
+            description: "Description".into(),
+            capacity_fractions,
+            flows: vec![flow.clone()],
+            parameter: process_param.clone(),
+            regions: RegionSelection::All,
+        });
+        let asset = Asset {
+            id: 0,
+            agent_id: "agent1".into(),
+            process: Rc::clone(&process),
+            region_id: "GBR".into(),
+            capacity_a: 2.0,
+            commission_year: 2010,
+        };
+
+        assert_eq!(asset.get_capacity_limits(&time_slice), 2.0..=f64::INFINITY);
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -102,8 +102,8 @@ pub struct Asset {
 }
 
 impl Asset {
-    /// Get the capacity limits for this asset in a particular time slice
-    pub fn get_capacity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
+    /// Get the activity limits for this asset in a particular time slice
+    pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.capacity_fractions.get(time_slice).unwrap();
         let capacity_a = self.capacity * self.process.parameter.cap2act;
 
@@ -174,6 +174,6 @@ mod tests {
             commission_year: 2010,
         };
 
-        assert_eq!(asset.get_capacity_limits(&time_slice), 6.0..=f64::INFINITY);
+        assert_eq!(asset.get_activity_limits(&time_slice), 6.0..=f64::INFINITY);
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -93,8 +93,8 @@ pub struct Asset {
     pub process: Rc<Process>,
     /// The region in which the asset is located
     pub region_id: Rc<str>,
-    /// Capacity of asset
-    pub capacity: f64,
+    /// The maximum commodity output per year
+    pub capacity_a: f64,
     /// The year the asset comes online
     pub commission_year: u32,
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -124,7 +124,7 @@ mod tests {
     use std::iter;
 
     #[test]
-    fn test_asset_get_capacity_limits() {
+    fn test_asset_get_activity_limits() {
         let time_slice = TimeSliceID {
             season: "winter".into(),
             time_of_day: "day".into(),

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -85,7 +85,7 @@ where
             agent_id,
             process: Rc::clone(process),
             region_id,
-            capacity: asset.capacity,
+            capacity_a: asset.capacity * process.parameter.cap2act,
             commission_year: asset.commission_year,
         };
 
@@ -144,7 +144,7 @@ mod tests {
             agent_id: "agent1".into(),
             process: Rc::clone(&process),
             region_id: "GBR".into(),
-            capacity: 1.0,
+            capacity_a: 1.0,
             commission_year: 2010,
         };
         assert_equal(

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -85,7 +85,7 @@ where
             agent_id,
             process: Rc::clone(process),
             region_id,
-            capacity_a: asset.capacity * process.parameter.cap2act,
+            capacity: asset.capacity,
             commission_year: asset.commission_year,
         };
 
@@ -144,7 +144,7 @@ mod tests {
             agent_id: "agent1".into(),
             process: Rc::clone(&process),
             region_id: "GBR".into(),
-            capacity_a: 1.0,
+            capacity: 1.0,
             commission_year: 2010,
         };
         assert_equal(

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -102,7 +102,25 @@ where
         }
     }
 
+    validate_capacity_maps(&map, time_slice_info)?;
+
     Ok(map)
+}
+
+/// Check that every capacity map has an entry for every time slice
+fn validate_capacity_maps(
+    map: &HashMap<Rc<str>, ProcessCapacityMap>,
+    time_slice_info: &TimeSliceInfo,
+) -> Result<()> {
+    for (process_id, map) in map.iter() {
+        ensure!(
+            map.len() == time_slice_info.fractions.len(),
+            "Missing process availability entries for process {process_id}. \
+            There must be entries covering every time slice.",
+        );
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -240,5 +258,58 @@ mod tests {
             "MADEUP",
             0.5
         ));
+    }
+
+    #[test]
+    fn test_read_process_availabilities_from_iter_bad_missing_entry() {
+        let process_ids = iter::once("process1".into()).collect();
+        let slices = [
+            TimeSliceID {
+                season: "winter".into(),
+                time_of_day: "day".into(),
+            },
+            TimeSliceID {
+                season: "summer".into(),
+                time_of_day: "night".into(),
+            },
+        ];
+        let time_slice_info = TimeSliceInfo {
+            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            times_of_day: ["day".into(), "night".into()].into_iter().collect(),
+            fractions: slices.into_iter().map(|ts| (ts, 0.5)).collect(),
+        };
+
+        // Good values
+        let avail = ["winter.day".into(), "summer.night".into()]
+            .into_iter()
+            .map(|time_slice| ProcessAvailabilityRaw {
+                process_id: "process1".into(),
+                limit_type: LimitType::Equality,
+                time_slice,
+                value: 0.0,
+            });
+        assert!(
+            read_process_availabilities_from_iter(avail, &process_ids, &time_slice_info).is_ok()
+        );
+
+        // Missing entry
+        let avail = ["winter.day".into()]
+            .into_iter()
+            .map(|time_slice| ProcessAvailabilityRaw {
+                process_id: "process1".into(),
+                limit_type: LimitType::Equality,
+                time_slice,
+                value: 0.0,
+            });
+        assert_eq!(
+            read_process_availabilities_from_iter(avail, &process_ids, &time_slice_info)
+                .unwrap_err()
+                .chain()
+                .next()
+                .unwrap()
+                .to_string(),
+            "Missing process availability entries for process process1. \
+            There must be entries covering every time slice."
+        );
     }
 }

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -113,23 +113,15 @@ mod tests {
     use std::iter;
 
     fn get_time_slice_info() -> TimeSliceInfo {
-        let slices = [
-            TimeSliceID {
-                season: "winter".into(),
-                time_of_day: "day".into(),
-            },
-            TimeSliceID {
-                season: "summer".into(),
-                time_of_day: "night".into(),
-            },
-        ];
+        let time_slice = TimeSliceID {
+            season: "winter".into(),
+            time_of_day: "day".into(),
+        };
 
         TimeSliceInfo {
-            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
-            times_of_day: ["day".into(), "night".into()].into_iter().collect(),
-            fractions: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
-                .into_iter()
-                .collect(),
+            seasons: iter::once("winter".into()).collect(),
+            times_of_day: iter::once("day".into()).collect(),
+            fractions: iter::once((time_slice, 0.5)).collect(),
         }
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,8 +29,7 @@ impl Process {
 ///
 /// The capacity value is calculated as availability multiplied by time slice length. Note that it
 /// is a *fraction* of capacity for the year; to calculate *actual* capacity for a given time slice
-/// you need to know the maximum capacity for the specific instance of a [`Process`] in use (e.g.
-/// given by [`Asset::capacity`](crate::agent::Asset::capacity)).
+/// you need to know the maximum capacity for the specific instance of a [`Process`] in use.
 ///
 /// The capacity is given as a range, depending on the user-specified limit type and value for
 /// availability.

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -209,7 +209,7 @@ fn add_asset_contraints(
     // See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/360
     add_fixed_asset_constraints(problem, variables, assets, year, &model.time_slice_info);
 
-    add_asset_capacity_constraints(problem, variables, model, assets, year);
+    add_asset_capacity_constraints(problem, variables, assets, year, &model.time_slice_info);
 }
 
 /// Add asset-level input-output commodity balances
@@ -268,17 +268,43 @@ fn add_fixed_asset_constraints(
     }
 }
 
-/// Add asset-level capacity and availability constraints
+/// Add asset-level capacity and availability constraints.
+///
+/// For every asset at every time slice, the sum of the commodity flows for PACs must not exceed the
+/// capacity limits, which are a product of the annual capacity, time slice length and process
+/// availability.
 ///
 /// See description in [the dispatch optimisation documentation][1].
 ///
 /// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html#asset-level-capacity-and-availability-constraints
 fn add_asset_capacity_constraints(
-    _problem: &mut Problem,
-    _variables: &VariableMap,
-    _model: &Model,
-    _assets: &AssetPool,
-    _year: u32,
+    problem: &mut Problem,
+    variables: &VariableMap,
+    assets: &AssetPool,
+    year: u32,
+    time_slice_info: &TimeSliceInfo,
 ) {
     info!("Adding asset-level capacity and availability constraints...");
+
+    let mut terms = Vec::new();
+    for asset in filter_assets(assets, year) {
+        for time_slice in time_slice_info.iter_ids() {
+            let mut is_input = false; // NB: there will be at least one PAC
+            for flow in asset.process.iter_pacs() {
+                is_input = flow.flow < 0.0; // NB: PACs will be all inputs or all outputs
+
+                let var = variables.get(asset.id, &flow.commodity.id, time_slice);
+                terms.push((var, 1.0));
+            }
+
+            let mut limits = asset.get_capacity_limits(time_slice);
+
+            // If it's an input flow, the q's will be negative, so we need to invert the limits
+            if is_input {
+                limits = -limits.end()..=-limits.start();
+            }
+
+            problem.add_row(limits, terms.drain(0..));
+        }
+    }
 }

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -297,7 +297,7 @@ fn add_asset_capacity_constraints(
                 terms.push((var, 1.0));
             }
 
-            let mut limits = asset.get_capacity_limits(time_slice);
+            let mut limits = asset.get_activity_limits(time_slice);
 
             // If it's an input flow, the q's will be negative, so we need to invert the limits
             if is_input {


### PR DESCRIPTION
# Description

This PR adds the capacity/availability constraints to the optimisation.

The relevant part of the docs is [here](https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html#asset-level-capacity-and-availability-constraints). I've deviated from Adam's formulation in a few ways though:

1. We don't need the capacity constraints (at least I don't think so!) because we already calculate the availability for every process for every time slice, so I haven't included this
2. I've moved the denominator of the LHS of the equations to the RHS (so the RHS can just be calculated with a new `Asset::get_capacity_limits()` helper)
3. The limits are inverted (mulitplied by -1 with the start and end swapped) for input flows, as $q<0$ in this case

I think this is correct, but please let me know if I've done something daft! If we're happy with this formulation I'll update the docs.

PS -- the main action for this PR is in `optimisation.rs`: the rest is just helper functions + tests.

Closes #301.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
