### PR TITLE
Fix: Put integration tests in `tests` folder

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -95,35 +95,3 @@ pub fn handle_example_list_command() -> Result<()> {
     }
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::{Path, PathBuf};
-    /// Get the path to the example model.
-    fn get_model_dir() -> PathBuf {
-        Path::new(file!())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("examples")
-            .join("simple")
-    }
-    /// An integration test for the `run` command.
-    #[test]
-    fn test_handle_run_command() {
-        handle_run_command(&get_model_dir()).unwrap();
-
-        // Second time will fail because the logging is already initialised
-        assert_eq!(
-            handle_run_command(&get_model_dir())
-                .unwrap_err()
-                .chain()
-                .next()
-                .unwrap()
-                .to_string(),
-            "Failed to initialize logging."
-        );
-    }
-}

--- a/tests/example_run.rs
+++ b/tests/example_run.rs
@@ -1,0 +1,8 @@
+/// Integration tests for the `example run` command.
+use muse2::commands::handle_example_run_command;
+
+/// An integration test for the `example run` command.
+#[test]
+fn test_handle_example_run_command() {
+    handle_example_run_command("simple").unwrap();
+}

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,16 +1,10 @@
 //! Integration tests for the `run` command.
 use muse2::commands::handle_run_command;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Get the path to the example model.
 fn get_model_dir() -> PathBuf {
-    Path::new(file!())
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("examples")
-        .join("simple")
+    PathBuf::from("examples/simple")
 }
 
 /// An integration test for the `run` command.

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,0 +1,31 @@
+//! Integration tests for the `run` command.
+use muse2::commands::handle_run_command;
+use std::path::{Path, PathBuf};
+
+/// Get the path to the example model.
+fn get_model_dir() -> PathBuf {
+    Path::new(file!())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("examples")
+        .join("simple")
+}
+
+/// An integration test for the `run` command.
+#[test]
+fn test_handle_run_command() {
+    handle_run_command(&get_model_dir()).unwrap();
+
+    // Second time will fail because the logging is already initialised
+    assert_eq!(
+        handle_run_command(&get_model_dir())
+            .unwrap_err()
+            .chain()
+            .next()
+            .unwrap()
+            .to_string(),
+        "Failed to initialize logging."
+    );
+}


### PR DESCRIPTION
# Description

Having our integration test built inside the binary (in the `tests` module in `commands.rs`) means that it isn't possible to add more integration tests, because the program will try to initialise twice and fail. For details, see #369.

I've moved our one existing integration test to the `tests` folder and I've added one for the new `example run` command, which wasn't possible before.

Fixes #369.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
