### PR TITLE
Fix: Disable logging for integration tests

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -14,6 +14,9 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 /// The default log level for the program.
+///
+/// Used as a fallback if the user hasn't specified something else with the MUSE2_LOG_LEVEL
+/// environment variable or the settings.toml file.
 const DEFAULT_LOG_LEVEL: &str = "info";
 
 /// The file name for the log file containing messages about the ordinary operation of MUSE 2.0

--- a/src/log.rs
+++ b/src/log.rs
@@ -14,9 +14,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 /// The default log level for the program.
-///
-/// Note that we disable logging when running tests.
-const DEFAULT_LOG_LEVEL: &str = if cfg!(test) { "off" } else { "info" };
+const DEFAULT_LOG_LEVEL: &str = "info";
 
 /// The file name for the log file containing messages about the ordinary operation of MUSE 2.0
 const LOG_INFO_FILE_NAME: &str = "muse2_info.log";

--- a/tests/example_run.rs
+++ b/tests/example_run.rs
@@ -4,5 +4,6 @@ use muse2::commands::handle_example_run_command;
 /// An integration test for the `example run` command.
 #[test]
 fn test_handle_example_run_command() {
+    std::env::set_var("MUSE2_LOG_LEVEL", "off");
     handle_example_run_command("simple").unwrap();
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -10,6 +10,7 @@ fn get_model_dir() -> PathBuf {
 /// An integration test for the `run` command.
 #[test]
 fn test_handle_run_command() {
+    std::env::set_var("MUSE2_LOG_LEVEL", "off");
     handle_run_command(&get_model_dir()).unwrap();
 
     // Second time will fail because the logging is already initialised


### PR DESCRIPTION
# Description

The current logic we have to disable logging for tests doesn't work for integration tests, which is annoying because it's the only place we need it. So we're now getting a lot of log spam for `cargo test`.

I've fixed it up by setting the `MUSE2_LOG_LEVEL` env var for the two integration tests.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
