### PR TITLE
Fix: Commodity prices are time-sliced

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,6 +1,7 @@
 //! Functionality for running the MUSE 2.0 simulation.
 use crate::agent::{Asset, AssetPool};
 use crate::model::Model;
+use crate::time_slice::TimeSliceID;
 use log::info;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -12,8 +13,29 @@ use investment::perform_agent_investment;
 pub mod update;
 use update::{update_commodity_flows, update_commodity_prices};
 
-/// A map relating commodity ID to current price (endogenous)
-pub type CommodityPrices = HashMap<Rc<str>, f64>;
+/// A combination of commodity ID and time slice
+type CommodityPriceKey = (Rc<str>, TimeSliceID);
+
+/// A map relating commodity ID + time slice to current price (endogenous)
+#[derive(Default)]
+pub struct CommodityPrices(HashMap<CommodityPriceKey, f64>);
+
+impl CommodityPrices {
+    /// Get the price for the given commodity and time slice
+    pub fn get(&self, commodity_id: &Rc<str>, time_slice: &TimeSliceID) -> f64 {
+        let key = (Rc::clone(commodity_id), time_slice.clone());
+        *self
+            .0
+            .get(&key)
+            .expect("Missing price for given commodity and time slice")
+    }
+
+    /// Insert a price for the given commodity and time slice
+    pub fn insert(&mut self, commodity_id: &Rc<str>, time_slice: &TimeSliceID, price: f64) {
+        let key = (Rc::clone(commodity_id), time_slice.clone());
+        self.0.insert(key, price);
+    }
+}
 
 /// Run the simulation.
 ///
@@ -22,8 +44,7 @@ pub type CommodityPrices = HashMap<Rc<str>, f64>;
 /// * `model` - The model to run
 /// * `assets` - The asset pool
 pub fn run(model: Model, mut assets: AssetPool) {
-    // Commodity prices (endogenous)
-    let mut prices = CommodityPrices::new();
+    let mut prices = CommodityPrices::default();
 
     for year in model.iter_years() {
         info!("Milestone year: {year}");

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -35,6 +35,17 @@ impl CommodityPrices {
         let key = (Rc::clone(commodity_id), time_slice.clone());
         self.0.insert(key, price);
     }
+
+    /// Iterate over the map.
+    ///
+    /// # Returns
+    ///
+    /// An iterator of tuples containing commodity ID, time slice and price.
+    pub fn iter(&self) -> impl Iterator<Item = (&Rc<str>, &TimeSliceID, f64)> {
+        self.0
+            .iter()
+            .map(|((commodity_id, ts), price)| (commodity_id, ts, *price))
+    }
 }
 
 /// Run the simulation.

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -84,7 +84,7 @@ impl Solution {
             .zip(self.solution.columns().iter().copied())
     }
 
-    /// Iterate over the newly calculated commodity prices.
+    /// Iterate over the newly calculated commodity prices for each time slice.
     ///
     /// Note that there may only be prices for a subset of the commodities; the rest will need to be
     /// calculated in another way.

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -88,7 +88,7 @@ impl Solution {
     ///
     /// Note that there may only be prices for a subset of the commodities; the rest will need to be
     /// calculated in another way.
-    pub fn iter_commodity_prices(&self) -> impl Iterator<Item = (&Rc<str>, f64)> {
+    pub fn iter_commodity_prices(&self) -> impl Iterator<Item = (&Rc<str>, &TimeSliceID, f64)> {
         // **PLACEHOLDER**
         iter::empty()
     }

--- a/src/simulation/update.rs
+++ b/src/simulation/update.rs
@@ -38,8 +38,8 @@ fn update_commodity_prices_from_solution(
 
     let mut commodities_updated = HashSet::new();
 
-    for (commodity_id, price) in solution.iter_commodity_prices() {
-        prices.insert(Rc::clone(commodity_id), price);
+    for (commodity_id, time_slice, price) in solution.iter_commodity_prices() {
+        prices.insert(commodity_id, time_slice, price);
         commodities_updated.insert(Rc::clone(commodity_id));
     }
 


### PR DESCRIPTION
# Description

This escaped my notice before, but commodity prices also vary by commodity, so we need to include a time slice ID as part of the key for the commodity price map.

I came across this while I was working on trying to get prices out of the optimisation result, but you'll also need it for your issue (#378) @TinyMarsh.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
