### PR TITLE
Add final doc comments to time slice code

### DIFF
--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,5 +1,4 @@
 //! Code for reading in time slice info from a CSV file.
-#![allow(missing_docs)]
 use crate::input::*;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use anyhow::{ensure, Context, Result};

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,14 +1,12 @@
 //! Code for reading in time slice info from a CSV file.
 #![allow(missing_docs)]
 use crate::input::*;
+use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
-use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
-
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 
 const TIME_SLICES_FILE_NAME: &str = "time_slices.csv";
 
@@ -65,17 +63,6 @@ where
         times_of_day,
         fractions,
     })
-}
-
-/// Refers to a particular aspect of a time slice
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
-pub enum TimeSliceLevel {
-    #[string = "annual"]
-    Annual,
-    #[string = "season"]
-    Season,
-    #[string = "daynight"]
-    DayNight,
 }
 
 /// Read time slices from a CSV file.

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -37,6 +37,20 @@ pub enum TimeSliceSelection {
     Single(TimeSliceID),
 }
 
+/// The time granularity for a particular operation
+#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+pub enum TimeSliceLevel {
+    /// The whole year
+    #[string = "annual"]
+    Annual,
+    /// Whole seasons
+    #[string = "season"]
+    Season,
+    /// Treat individual time slices separately
+    #[string = "daynight"]
+    DayNight,
+}
+
 /// Information about the time slices in the simulation, including names and fractions
 #[derive(PartialEq, Debug)]
 pub struct TimeSliceInfo {
@@ -190,20 +204,6 @@ impl TimeSliceInfo {
         self.iterate_selection_share(selection)
             .map(move |(ts, share)| (ts, value * share))
     }
-}
-
-/// The time granularity for a particular operation
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
-pub enum TimeSliceLevel {
-    /// The whole year
-    #[string = "annual"]
-    Annual,
-    /// Whole seasons
-    #[string = "season"]
-    Season,
-    /// Treat individual time slices separately
-    #[string = "daynight"]
-    DayNight,
 }
 
 #[cfg(test)]

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,7 +2,6 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
-#![allow(missing_docs)]
 use crate::input::*;
 use anyhow::{Context, Result};
 use itertools::Itertools;
@@ -193,13 +192,16 @@ impl TimeSliceInfo {
     }
 }
 
-/// Refers to a particular aspect of a time slice
+/// The time granularity for a particular operation
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {
+    /// The whole year
     #[string = "annual"]
     Annual,
+    /// Whole seasons
     #[string = "season"]
     Season,
+    /// Treat individual time slices separately
     #[string = "daynight"]
     DayNight,
 }


### PR DESCRIPTION
# Description

This PR adds the final missing doc comments to time slice-related code. Now that it's all commented we can enable missing doc comment warnings for these files.

Closes #222.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
