### PR TITLE
Fix: Don't use temp folder name in output folder path

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -72,6 +72,8 @@ pub fn handle_example_run_command(name: &str) -> Result<()> {
 
     // Creates temporary directory
     let temp_dir = TempDir::new().context("Failed to create temporary directory.")?;
+    let temp_path = temp_dir.path().join(name);
+    fs::create_dir(&temp_path)?;
 
     // Copies the contents of the subdirectory to the temporary directory
     for entry in sub_dir.entries() {
@@ -79,13 +81,13 @@ pub fn handle_example_run_command(name: &str) -> Result<()> {
             DirEntry::Dir(_) => panic!("Subdirectories in examples not supported"),
             DirEntry::File(f) => {
                 let file_name = f.path().file_name().unwrap();
-                let file_path = temp_dir.path().join(file_name);
+                let file_path = temp_path.join(file_name);
                 fs::write(&file_path, f.contents())?;
             }
         }
     }
 
-    handle_run_command(temp_dir.path())
+    handle_run_command(&temp_path)
 }
 
 /// Handle the `example list` command.


### PR DESCRIPTION
# Description

We use the name of the folder the input files are in as a proxy for the model name, specifically when creating the output folder for the model run (e.g. you get something like `muse2_results/my_model_name`). Unfortunately when extracting the bundled example input files, we use a temporary folder, so you get something like `muse2_results/.tmp4eU71Y` instead. Fix by making a subfolder with a proper name in the temp folder.

Fixes #374.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
