### PR TITLE
Keep (some) input data ordered in MUSE2

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,11 +4,15 @@ use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceID;
+use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashSet;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
+
+/// A map of [`Agent`]s, keyed by agent ID
+pub type AgentMap = IndexMap<Rc<str>, Agent>;
 
 /// An agent in the simulation
 #[derive(Debug, Clone, PartialEq)]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,10 +1,14 @@
 #![allow(missing_docs)]
 use crate::input::*;
 use crate::time_slice::{TimeSliceID, TimeSliceLevel};
+use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::rc::Rc;
+
+/// A map of [`Commodity`]s, keyed by commodity ID
+pub type CommodityMap = IndexMap<Rc<str>, Rc<Commodity>>;
 
 /// A commodity within the simulation. Represents a substance (e.g. CO2) or form of energy (e.g.
 /// electricity) that can be produced and/or consumed by technologies in the model.

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,6 +3,7 @@ use crate::agent::AssetPool;
 use crate::model::{Model, ModelFile};
 use anyhow::{ensure, Context, Result};
 use float_cmp::approx_eq;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use std::collections::{HashMap, HashSet};
@@ -115,16 +116,19 @@ impl IDCollection for HashSet<Rc<str>> {
     }
 }
 
-/// Read a CSV file of items with IDs
-pub fn read_csv_id_file<T>(file_path: &Path) -> Result<HashMap<Rc<str>, T>>
+/// Read a CSV file of items with IDs.
+///
+/// As this function is only ever used for top-level CSV files (i.e. the ones which actually define
+/// the IDs for a given type), we use an ordered map to maintain the order in the input files.
+pub fn read_csv_id_file<T>(file_path: &Path) -> Result<IndexMap<Rc<str>, T>>
 where
     T: HasID + DeserializeOwned,
 {
-    fn fill_and_validate_map<T>(file_path: &Path) -> Result<HashMap<Rc<str>, T>>
+    fn fill_and_validate_map<T>(file_path: &Path) -> Result<IndexMap<Rc<str>, T>>
     where
         T: HasID + DeserializeOwned,
     {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         for record in read_csv::<T>(file_path)? {
             let id = record.get_id();
 

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -1,7 +1,7 @@
 //! Code for reading in agent-related data from CSV files.
 use super::*;
 use crate::agent::{Agent, AgentMap, DecisionRule, SearchSpace};
-use crate::commodity::Commodity;
+use crate::commodity::CommodityMap;
 use crate::process::Process;
 use crate::region::RegionSelection;
 use anyhow::{ensure, Context, Result};
@@ -54,7 +54,7 @@ struct AgentRaw {
 /// A map of Agents, with the agent ID as the key
 pub fn read_agents(
     model_dir: &Path,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
 ) -> Result<AgentMap> {
@@ -86,7 +86,7 @@ pub fn read_agents(
 /// A map of Agents, with the agent ID as the key
 pub fn read_agents_file(
     model_dir: &Path,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     process_ids: &HashSet<Rc<str>>,
 ) -> Result<AgentMap> {
     let file_path = model_dir.join(AGENT_FILE_NAME);
@@ -98,7 +98,7 @@ pub fn read_agents_file(
 /// Read agents info from an iterator.
 fn read_agents_file_from_iter<I>(
     iter: I,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     process_ids: &HashSet<Rc<str>>,
 ) -> Result<AgentMap>
 where
@@ -149,7 +149,7 @@ where
 mod tests {
     use super::*;
     use crate::agent::DecisionRule;
-    use crate::commodity::{CommodityCostMap, CommodityType, DemandMap};
+    use crate::commodity::{Commodity, CommodityCostMap, CommodityType, DemandMap};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
     use std::iter;

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -2,11 +2,11 @@
 use super::*;
 use crate::agent::{Agent, AgentMap, DecisionRule, SearchSpace};
 use crate::commodity::CommodityMap;
-use crate::process::Process;
+use crate::process::ProcessMap;
 use crate::region::RegionSelection;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -55,7 +55,7 @@ struct AgentRaw {
 pub fn read_agents(
     model_dir: &Path,
     commodities: &CommodityMap,
-    processes: &HashMap<Rc<str>, Rc<Process>>,
+    processes: &ProcessMap,
     region_ids: &HashSet<Rc<str>>,
 ) -> Result<AgentMap> {
     let process_ids = processes.keys().cloned().collect();

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -1,6 +1,6 @@
 //! Code for reading in agent-related data from CSV files.
 use super::*;
-use crate::agent::{Agent, DecisionRule, SearchSpace};
+use crate::agent::{Agent, AgentMap, DecisionRule, SearchSpace};
 use crate::commodity::Commodity;
 use crate::process::Process;
 use crate::region::RegionSelection;
@@ -57,7 +57,7 @@ pub fn read_agents(
     commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     processes: &HashMap<Rc<str>, Rc<Process>>,
     region_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, Agent>> {
+) -> Result<AgentMap> {
     let process_ids = processes.keys().cloned().collect();
     let mut agents = read_agents_file(model_dir, commodities, &process_ids)?;
     let agent_ids = agents.keys().cloned().collect();
@@ -88,7 +88,7 @@ pub fn read_agents_file(
     model_dir: &Path,
     commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     process_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, Agent>> {
+) -> Result<AgentMap> {
     let file_path = model_dir.join(AGENT_FILE_NAME);
     let agents_csv = read_csv(&file_path)?;
     read_agents_file_from_iter(agents_csv, commodities, process_ids)
@@ -100,11 +100,11 @@ fn read_agents_file_from_iter<I>(
     iter: I,
     commodities: &HashMap<Rc<str>, Rc<Commodity>>,
     process_ids: &HashSet<Rc<str>>,
-) -> Result<HashMap<Rc<str>, Agent>>
+) -> Result<AgentMap>
 where
     I: Iterator<Item = AgentRaw>,
 {
-    let mut agents = HashMap::new();
+    let mut agents = AgentMap::new();
     for agent_raw in iter {
         let commodity = commodities
             .get(agent_raw.commodity_id.as_str())
@@ -191,7 +191,7 @@ mod tests {
             regions: RegionSelection::default(),
             objectives: Vec::new(),
         };
-        let expected = HashMap::from_iter([("agent".into(), agent_out)]);
+        let expected = AgentMap::from_iter(iter::once(("agent".into(), agent_out)));
         let actual =
             read_agents_file_from_iter(iter::once(agent), &commodities, &process_ids).unwrap();
         assert_eq!(actual, expected);

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -1,6 +1,6 @@
 //! Code for reading the agent objectives CSV file.
 use super::super::*;
-use crate::agent::{Agent, AgentObjective, DecisionRule};
+use crate::agent::{Agent, AgentMap, AgentObjective, DecisionRule};
 use anyhow::{ensure, Context, Result};
 use std::collections::HashMap;
 use std::path::Path;
@@ -21,7 +21,7 @@ define_id_getter! {Agent}
 /// A map of Agents, with the agent ID as the key
 pub fn read_agent_objectives(
     model_dir: &Path,
-    agents: &HashMap<Rc<str>, Agent>,
+    agents: &AgentMap,
 ) -> Result<HashMap<Rc<str>, Vec<AgentObjective>>> {
     let file_path = model_dir.join(AGENT_OBJECTIVES_FILE_NAME);
     let agent_objectives_csv = read_csv(&file_path)?;
@@ -31,7 +31,7 @@ pub fn read_agent_objectives(
 
 fn read_agent_objectives_from_iter<I>(
     iter: I,
-    agents: &HashMap<Rc<str>, Agent>,
+    agents: &AgentMap,
 ) -> Result<HashMap<Rc<str>, Vec<AgentObjective>>>
 where
     I: Iterator<Item = AgentObjective>,
@@ -164,7 +164,7 @@ mod tests {
             costs: CommodityCostMap::new(),
             demand: DemandMap::new(),
         });
-        let agents: HashMap<_, _> = [(
+        let agents = [(
             "agent".into(),
             Agent {
                 id: "agent".into(),

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -1,11 +1,11 @@
 //! Code for reading [Asset]s from a CSV file.
 use crate::agent::Asset;
 use crate::input::*;
-use crate::process::Process;
+use crate::process::ProcessMap;
 use anyhow::{ensure, Context, Result};
 use itertools::Itertools;
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -35,7 +35,7 @@ struct AssetRaw {
 pub fn read_assets(
     model_dir: &Path,
     agent_ids: &HashSet<Rc<str>>,
-    processes: &HashMap<Rc<str>, Rc<Process>>,
+    processes: &ProcessMap,
     region_ids: &HashSet<Rc<str>>,
 ) -> Result<Vec<Asset>> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
@@ -59,7 +59,7 @@ pub fn read_assets(
 fn read_assets_from_iter<I>(
     iter: I,
     agent_ids: &HashSet<Rc<str>>,
-    processes: &HashMap<Rc<str>, Rc<Process>>,
+    processes: &ProcessMap,
     region_ids: &HashSet<Rc<str>>,
 ) -> Result<Vec<Asset>>
 where
@@ -92,7 +92,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::process::{ProcessCapacityMap, ProcessParameter};
+    use crate::process::{Process, ProcessCapacityMap, ProcessParameter};
     use crate::region::RegionSelection;
     use itertools::assert_equal;
     use std::iter;

--- a/src/input/commodity.rs
+++ b/src/input/commodity.rs
@@ -1,9 +1,9 @@
 //! Code for reading in commodity-related data from CSV files.
-use crate::commodity::Commodity;
+use crate::commodity::{Commodity, CommodityMap};
 use crate::input::*;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -32,7 +32,7 @@ pub fn read_commodities(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
-) -> Result<HashMap<Rc<str>, Rc<Commodity>>> {
+) -> Result<CommodityMap> {
     let commodities = read_csv_id_file::<Commodity>(&model_dir.join(COMMODITY_FILE_NAME))?;
     let commodity_ids = commodities.keys().cloned().collect();
     let mut costs = read_commodity_costs(

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -1,5 +1,5 @@
 //! Code for reading process-related information from CSV files.
-use crate::commodity::{Commodity, CommodityType};
+use crate::commodity::{Commodity, CommodityMap, CommodityType};
 use crate::input::*;
 use crate::process::{Process, ProcessCapacityMap, ProcessFlow, ProcessParameter};
 use crate::region::RegionSelection;
@@ -55,7 +55,7 @@ define_id_getter! {ProcessDescription}
 /// This function returns a map of processes, with the IDs as keys.
 pub fn read_processes(
     model_dir: &Path,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
@@ -83,7 +83,7 @@ pub fn read_processes(
 
 /// Perform consistency checks for commodity flows.
 fn validate_commodities(
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     flows: &HashMap<Rc<str>, Vec<ProcessFlow>>,
 ) -> anyhow::Result<()> {
     for (commodity_id, commodity) in commodities {
@@ -303,7 +303,7 @@ mod tests {
             demand: DemandMap::new(),
         });
 
-        let commodities: HashMap<Rc<str>, Rc<Commodity>> = [
+        let commodities: CommodityMap = [
             (Rc::clone(&commodity_sed.id), Rc::clone(&commodity_sed)),
             (
                 Rc::clone(&commodity_non_sed.id),

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -1,7 +1,7 @@
 //! Code for reading process-related information from CSV files.
 use crate::commodity::{Commodity, CommodityMap, CommodityType};
 use crate::input::*;
-use crate::process::{Process, ProcessCapacityMap, ProcessFlow, ProcessParameter};
+use crate::process::{Process, ProcessCapacityMap, ProcessFlow, ProcessMap, ProcessParameter};
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
@@ -59,7 +59,7 @@ pub fn read_processes(
     region_ids: &HashSet<Rc<str>>,
     time_slice_info: &TimeSliceInfo,
     year_range: &RangeInclusive<u32>,
-) -> Result<HashMap<Rc<str>, Rc<Process>>> {
+) -> Result<ProcessMap> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let descriptions = read_csv_id_file::<ProcessDescription>(&file_path)?;
     let process_ids = HashSet::from_iter(descriptions.keys().cloned());
@@ -128,7 +128,7 @@ fn create_process_map<I>(
     mut flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
     mut parameters: HashMap<Rc<str>, ProcessParameter>,
     mut regions: HashMap<Rc<str>, RegionSelection>,
-) -> Result<HashMap<Rc<str>, Rc<Process>>>
+) -> Result<ProcessMap>
 where
     I: Iterator<Item = ProcessDescription>,
 {
@@ -159,7 +159,7 @@ where
 
             Ok((description.id, process.into()))
         })
-        .process_results(|iter| iter.collect())
+        .try_collect()
 }
 
 #[cfg(test)]

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -1,6 +1,6 @@
 //! Code for reading process flows file
 use super::define_process_id_getter;
-use crate::commodity::Commodity;
+use crate::commodity::CommodityMap;
 use crate::input::*;
 use crate::process::{FlowType, ProcessFlow};
 use anyhow::{ensure, Context, Result};
@@ -30,7 +30,7 @@ define_process_id_getter! {ProcessFlowRaw}
 pub fn read_process_flows(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
 ) -> Result<HashMap<Rc<str>, Vec<ProcessFlow>>> {
     let file_path = model_dir.join(PROCESS_FLOWS_FILE_NAME);
     let process_flow_csv = read_csv(&file_path)?;
@@ -42,7 +42,7 @@ pub fn read_process_flows(
 fn read_process_flows_from_iter<I>(
     iter: I,
     process_ids: &HashSet<Rc<str>>,
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
 ) -> Result<HashMap<Rc<str>, Vec<ProcessFlow>>>
 where
     I: Iterator<Item = ProcessFlowRaw>,
@@ -151,14 +151,14 @@ fn validate_pac_flows(flows: &HashMap<Rc<str>, Vec<ProcessFlow>>) -> Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commodity::{CommodityCostMap, CommodityType, DemandMap};
+    use crate::commodity::{Commodity, CommodityCostMap, CommodityType, DemandMap};
     use crate::time_slice::TimeSliceLevel;
     use std::iter;
 
     #[test]
     fn test_read_process_flows_from_iter_good() {
         let process_ids = ["id1".into(), "id2".into()].into_iter().collect();
-        let commodities: HashMap<Rc<str>, Rc<Commodity>> = ["commodity1", "commodity2"]
+        let commodities: CommodityMap = ["commodity1", "commodity2"]
             .into_iter()
             .map(|id| {
                 let commodity = Commodity {

--- a/src/input/region.rs
+++ b/src/input/region.rs
@@ -1,6 +1,6 @@
 //! Code for reading region-related information from CSV files.
 use super::*;
-use crate::region::{Region, RegionSelection};
+use crate::region::{Region, RegionMap, RegionSelection};
 use anyhow::{anyhow, ensure, Context, Result};
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet};
@@ -37,7 +37,7 @@ pub(crate) use define_region_id_getter;
 /// # Returns
 ///
 /// A `HashMap<Rc<str>, Region>` with the parsed regions data or an error. The keys are region IDs.
-pub fn read_regions(model_dir: &Path) -> Result<HashMap<Rc<str>, Region>> {
+pub fn read_regions(model_dir: &Path) -> Result<RegionMap> {
     read_csv_id_file(&model_dir.join(REGIONS_FILE_NAME))
 }
 
@@ -164,7 +164,7 @@ AP,Asia Pacific"
         let regions = read_regions(dir.path()).unwrap();
         assert_eq!(
             regions,
-            HashMap::from([
+            RegionMap::from([
                 (
                     "NA".into(),
                     Region {

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,14 +1,13 @@
 //! Code for reading in time slice info from a CSV file.
 #![allow(missing_docs)]
 use crate::input::*;
+use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use anyhow::{ensure, Context, Result};
+use indexmap::IndexSet;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
-
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 
 const TIME_SLICES_FILE_NAME: &str = "time_slices.csv";
 
@@ -22,7 +21,7 @@ struct TimeSliceRaw {
 }
 
 /// Get the specified `String` from `set` or insert if it doesn't exist
-fn get_or_insert(value: String, set: &mut HashSet<Rc<str>>) -> Rc<str> {
+fn get_or_insert(value: String, set: &mut IndexSet<Rc<str>>) -> Rc<str> {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
     match set.get(value.as_str()) {
         Some(value) => Rc::clone(value),
@@ -39,9 +38,9 @@ fn read_time_slice_info_from_iter<I>(iter: I) -> Result<TimeSliceInfo>
 where
     I: Iterator<Item = TimeSliceRaw>,
 {
-    let mut seasons: HashSet<Rc<str>> = HashSet::new();
-    let mut times_of_day = HashSet::new();
-    let mut fractions = HashMap::new();
+    let mut seasons = IndexSet::new();
+    let mut times_of_day = IndexSet::new();
+    let mut fractions = IndexMap::new();
     for time_slice in iter {
         let season = get_or_insert(time_slice.season, &mut seasons);
         let time_of_day = get_or_insert(time_slice.time_of_day, &mut times_of_day);

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,12 +3,11 @@
 use crate::agent::AgentMap;
 use crate::commodity::CommodityMap;
 use crate::input::*;
-use crate::process::Process;
+use crate::process::ProcessMap;
 use crate::region::RegionMap;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -19,7 +18,7 @@ pub struct Model {
     pub milestone_years: Vec<u32>,
     pub agents: AgentMap,
     pub commodities: CommodityMap,
-    pub processes: HashMap<Rc<str>, Rc<Process>>,
+    pub processes: ProcessMap,
     pub time_slice_info: TimeSliceInfo,
     pub regions: RegionMap,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,7 @@ use crate::agent::Agent;
 use crate::commodity::Commodity;
 use crate::input::*;
 use crate::process::Process;
-use crate::region::Region;
+use crate::region::RegionMap;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
@@ -21,7 +21,7 @@ pub struct Model {
     pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
     pub processes: HashMap<Rc<str>, Rc<Process>>,
     pub time_slice_info: TimeSliceInfo,
-    pub regions: HashMap<Rc<str>, Region>,
+    pub regions: RegionMap,
 }
 
 /// Represents the contents of the entire model file.

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 //! Code for simulation models.
 #![allow(missing_docs)]
 use crate::agent::AgentMap;
-use crate::commodity::Commodity;
+use crate::commodity::CommodityMap;
 use crate::input::*;
 use crate::process::Process;
 use crate::region::RegionMap;
@@ -18,7 +18,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 pub struct Model {
     pub milestone_years: Vec<u32>,
     pub agents: AgentMap,
-    pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
+    pub commodities: CommodityMap,
     pub processes: HashMap<Rc<str>, Rc<Process>>,
     pub time_slice_info: TimeSliceInfo,
     pub regions: RegionMap,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Code for simulation models.
 #![allow(missing_docs)]
-use crate::agent::Agent;
+use crate::agent::AgentMap;
 use crate::commodity::Commodity;
 use crate::input::*;
 use crate::process::Process;
@@ -17,7 +17,7 @@ const MODEL_FILE_NAME: &str = "model.toml";
 /// Model definition
 pub struct Model {
     pub milestone_years: Vec<u32>,
-    pub agents: HashMap<Rc<str>, Agent>,
+    pub agents: AgentMap,
     pub commodities: HashMap<Rc<str>, Rc<Commodity>>,
     pub processes: HashMap<Rc<str>, Rc<Process>>,
     pub time_slice_info: TimeSliceInfo,

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,11 +2,15 @@
 use crate::commodity::Commodity;
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceID;
+use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
+
+/// A map of [`Process`]es, keyed by process ID
+pub type ProcessMap = IndexMap<Rc<str>, Rc<Process>>;
 
 #[derive(PartialEq, Debug)]
 pub struct Process {

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,9 +1,13 @@
 //! Regions represent different geographical areas in which agents, processes, etc. are active.
+use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::rc::Rc;
+
+/// A map of [`Region`]s, keyed by region ID
+pub type RegionMap = IndexMap<Rc<str>, Region>;
 
 /// Represents a region with an ID and a longer description.
 #[derive(Debug, Deserialize, PartialEq)]

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -2,8 +2,8 @@
 use crate::agent::AssetPool;
 use crate::model::Model;
 use crate::time_slice::TimeSliceID;
+use indexmap::IndexMap;
 use log::info;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 pub mod optimisation;
@@ -18,7 +18,7 @@ type CommodityPriceKey = (Rc<str>, TimeSliceID);
 
 /// A map relating commodity ID + time slice to current price (endogenous)
 #[derive(Default)]
-pub struct CommodityPrices(HashMap<CommodityPriceKey, f64>);
+pub struct CommodityPrices(IndexMap<CommodityPriceKey, f64>);
 
 impl CommodityPrices {
     /// Get the price for the given commodity and time slice

--- a/src/simulation/update.rs
+++ b/src/simulation/update.rs
@@ -2,9 +2,9 @@
 use super::optimisation::Solution;
 use super::CommodityPrices;
 use crate::agent::AssetPool;
-use crate::commodity::Commodity;
+use crate::commodity::CommodityMap;
 use log::info;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::rc::Rc;
 
 /// Update commodity flows for assets based on the result of the dispatch optimisation.
@@ -14,7 +14,7 @@ pub fn update_commodity_flows(_solution: &Solution, _assets: &mut AssetPool) {
 
 /// Update commodity prices for assets based on the result of the dispatch optimisation.
 pub fn update_commodity_prices(
-    commodities: &HashMap<Rc<str>, Rc<Commodity>>,
+    commodities: &CommodityMap,
     solution: &Solution,
     prices: &mut CommodityPrices,
 ) {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -3,11 +3,10 @@
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
 #![allow(missing_docs)]
-use crate::input::*;
 use anyhow::{Context, Result};
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::iter;
 use std::rc::Rc;
@@ -42,11 +41,11 @@ pub enum TimeSliceSelection {
 #[derive(PartialEq, Debug)]
 pub struct TimeSliceInfo {
     /// Names of seasons
-    pub seasons: HashSet<Rc<str>>,
+    pub seasons: IndexSet<Rc<str>>,
     /// Names of times of day (e.g. "evening")
-    pub times_of_day: HashSet<Rc<str>>,
+    pub times_of_day: IndexSet<Rc<str>>,
     /// The fraction of the year that this combination of season and time of day occupies
-    pub fractions: HashMap<TimeSliceID, f64>,
+    pub fractions: IndexMap<TimeSliceID, f64>,
 }
 
 impl Default for TimeSliceInfo {
@@ -102,7 +101,11 @@ impl TimeSliceInfo {
             let time_slice = self.get_time_slice_id_from_str(time_slice)?;
             Ok(TimeSliceSelection::Single(time_slice))
         } else {
-            let season = self.seasons.get_id(time_slice)?;
+            let season = self
+                .seasons
+                .get(time_slice)
+                .with_context(|| format!("'{time_slice}' is not a valid season"))?
+                .clone();
             Ok(TimeSliceSelection::Season(season))
         }
     }
@@ -208,6 +211,7 @@ pub enum TimeSliceLevel {
 mod tests {
     use super::*;
     use float_cmp::assert_approx_eq;
+    use itertools::assert_equal;
 
     #[test]
     fn test_iter_selection() {
@@ -229,22 +233,20 @@ mod tests {
                 .collect(),
         };
 
-        assert_eq!(
-            HashSet::<&TimeSliceID>::from_iter(
-                ts_info
-                    .iter_selection(&TimeSliceSelection::Annual)
-                    .map(|(ts, _)| ts)
-            ),
-            HashSet::from_iter(slices.iter())
+        assert_equal(
+            ts_info
+                .iter_selection(&TimeSliceSelection::Annual)
+                .map(|(ts, _)| ts),
+            slices.iter(),
         );
-        itertools::assert_equal(
+        assert_equal(
             ts_info
                 .iter_selection(&TimeSliceSelection::Season("winter".into()))
                 .map(|(ts, _)| ts),
             iter::once(&slices[0]),
         );
         let ts = ts_info.get_time_slice_id_from_str("summer.night").unwrap();
-        itertools::assert_equal(
+        assert_equal(
             ts_info
                 .iter_selection(&TimeSliceSelection::Single(ts))
                 .map(|(ts, _)| ts),
@@ -281,7 +283,7 @@ mod tests {
         macro_rules! check_share {
             ($selection:expr, $expected:expr) => {
                 let expected = $expected;
-                let actual: HashMap<_, _> = HashMap::from_iter(
+                let actual: IndexMap<_, _> = IndexMap::from_iter(
                     ts_info
                         .calculate_share(&$selection, 8.0)
                         .map(|(ts, share)| (ts.clone(), share)),
@@ -294,12 +296,13 @@ mod tests {
         }
 
         // Whole year
-        let expected: HashMap<_, _> = HashMap::from_iter(slices.iter().map(|ts| (ts.clone(), 2.0)));
+        let expected: IndexMap<_, _> =
+            IndexMap::from_iter(slices.iter().map(|ts| (ts.clone(), 2.0)));
         check_share!(TimeSliceSelection::Annual, expected);
 
         // One season
         let selection = TimeSliceSelection::Season("winter".into());
-        let expected: HashMap<_, _> = HashMap::from_iter(
+        let expected: IndexMap<_, _> = IndexMap::from_iter(
             ts_info
                 .iter_selection(&selection)
                 .map(|(ts, _)| (ts.clone(), 4.0)),
@@ -309,7 +312,7 @@ mod tests {
         // Single time slice
         let time_slice = ts_info.get_time_slice_id_from_str("winter.day").unwrap();
         let selection = TimeSliceSelection::Single(time_slice.clone());
-        let expected: HashMap<_, _> = HashMap::from_iter(iter::once((time_slice, 8.0)));
+        let expected: IndexMap<_, _> = IndexMap::from_iter(iter::once((time_slice, 8.0)));
         check_share!(selection, expected);
     }
 }


### PR DESCRIPTION
# Description

We make heavy use of `HashMap`s to store data in MUSE2, usually with the key being some kind of user-specified string ID (representing a commodity, process etc.). `HashMap`s are not ordered data structures, meaning if you iterate over their contents you will get a different ordering every time you run the program, even when using the same input files.

While the dispatch optimisation model doesn't care about ordering (even time slices within a year are independent of one another), a consequence of this design is that the output files will be effectively randomly shuffled every time the user runs the program with the same input data, which is annoying and potentially confusing. As it stands, if a user was to e.g. make a bar chart of commodity prices by time slice in Excel, unless they sorted the data properly beforehand they would get a different-looking plot every time they run the program. You'd have the same problem with Python too: users will end up having to write a whole bunch of logic to sort the input data just in order to plot it. Note that sorting time slices alphabetically will give a confusing order, so they'll have to have an ordered list of time slices -- and if they add/remove time slices to the model then they'll end up having to change the script. In addition, this will also make it really annoying to debug the code: every time you start the program under a debugger, your decision variables will be in a different randomised order.

So let's use an ordered map where it makes sense (i.e. if the ordering will be user-visible). There's an external crate (`indexmap`) which maintains the insertion order of elements. We're using it already, so I've just replaced various `HashMap`s with `IndexMap`s (as well as using a few ordered sets in the time slice code). While I was at it, I defined type aliases for various common map types we're using to make the code a bit cleaner: e.g. a `CommodityMap` as an alias for `IndexMap<Rc<str>, Rc<Commodity>>`.

Closes #327.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
