### PR TITLE
Add commodity balance constraints

### DIFF
--- a/docs/dispatch_optimisation.md
+++ b/docs/dispatch_optimisation.md
@@ -133,7 +133,11 @@ For a service demand, for each *c*, within a single region:
 
 $$\sum_{a,ts} q_{r,a,c,ts} = cr\\_ net\\_ fx$$
 
-Where *c* is a service demand commodity.
+Where *c* is a service demand commodity and *cr_net_fx* is the exogenous (user-defined) demand for
+the given time slice selection. Note that the *ts* to be summed over will differ depending on the
+specified time slice level for a given commodity. If the time slice level is `annual`, it will be
+every time slice, if it's `season` then there will be separate constraints for each season and if
+it's `time_slice` then there will be separate constraints for every individual time slice.
 
 **TBD** – commodities that are consumed (so sum of *q* can be a negative value). E.g. oil reserves. \
 **TBD** – trade between regions.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -214,6 +214,25 @@ impl AssetPool {
             .iter()
             .take_while(|asset| asset.commission_year <= self.current_year)
     }
+
+    /// Iterate over active assets for a particular region
+    pub fn iter_for_region<'a>(
+        &'a self,
+        region_id: &'a Rc<str>,
+    ) -> impl Iterator<Item = &'a Asset> {
+        self.iter().filter(|asset| asset.region_id == *region_id)
+    }
+
+    /// Iterate over only the active assets in a given region that produce or consume a given
+    /// commodity
+    pub fn iter_for_region_and_commodity<'a>(
+        &'a self,
+        region_id: &'a Rc<str>,
+        commodity: &'a Rc<Commodity>,
+    ) -> impl Iterator<Item = &'a Asset> {
+        self.iter_for_region(region_id)
+            .filter(|asset| asset.process.contains_commodity_flow(commodity))
+    }
 }
 
 #[cfg(test)]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -132,12 +132,12 @@ impl DemandMap {
     }
 
     /// Retrieve the demand for the specified region, year and time slice
-    pub fn get(&self, region_id: Rc<str>, year: u32, time_slice: TimeSliceID) -> Option<f64> {
+    pub fn get(&self, region_id: &Rc<str>, year: u32, time_slice: &TimeSliceID) -> Option<f64> {
         self.0
             .get(&DemandMapKey {
-                region_id,
+                region_id: region_id.clone(),
                 year,
-                time_slice,
+                time_slice: time_slice.clone(),
             })
             .copied()
     }
@@ -169,7 +169,7 @@ mod tests {
         let mut map = DemandMap::new();
         map.insert("North".into(), 2020, time_slice.clone(), value);
 
-        assert_eq!(map.get("North".into(), 2020, time_slice).unwrap(), value)
+        assert_eq!(map.get(&"North".into(), 2020, &time_slice).unwrap(), value)
     }
 
     #[test]

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -132,7 +132,7 @@ impl DemandMap {
     }
 
     /// Retrieve the demand for the specified region, year and time slice
-    pub fn get(&self, region_id: &Rc<str>, year: u32, time_slice: &TimeSliceID) -> Option<f64> {
+    pub fn get(&self, region_id: &Rc<str>, year: u32, time_slice: &TimeSliceID) -> f64 {
         self.0
             .get(&DemandMapKey {
                 region_id: region_id.clone(),
@@ -140,6 +140,7 @@ impl DemandMap {
                 time_slice: time_slice.clone(),
             })
             .copied()
+            .expect("Missing demand entry")
     }
 
     /// Insert a new demand entry for the specified region, year and time slice
@@ -169,7 +170,7 @@ mod tests {
         let mut map = DemandMap::new();
         map.insert("North".into(), 2020, time_slice.clone(), value);
 
-        assert_eq!(map.get(&"North".into(), 2020, &time_slice).unwrap(), value)
+        assert_eq!(map.get(&"North".into(), 2020, &time_slice), value)
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -19,6 +19,13 @@ pub struct Process {
 }
 
 impl Process {
+    /// Whether the process contains a flow for a given commodity
+    pub fn contains_commodity_flow(&self, commodity: &Rc<Commodity>) -> bool {
+        self.flows
+            .iter()
+            .any(|flow| Rc::ptr_eq(&flow.commodity, commodity))
+    }
+
     /// Iterate over this process's Primary Activity Commodity flows
     pub fn iter_pacs(&self) -> impl Iterator<Item = &ProcessFlow> {
         self.flows.iter().filter(|flow| flow.is_pac)

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -142,6 +142,25 @@ impl TimeSliceInfo {
         }
     }
 
+    /// Iterate over the different time slice selections for a given time slice level.
+    ///
+    /// For example, if [`TimeSliceLevel::Season`] is specified, this function will return an
+    /// iterator of [`TimeSliceSelection`]s covering each season.
+    pub fn iter_selections_for_level(
+        &self,
+        level: TimeSliceLevel,
+    ) -> Box<dyn Iterator<Item = TimeSliceSelection> + '_> {
+        match level {
+            TimeSliceLevel::Annual => Box::new(iter::once(TimeSliceSelection::Annual)),
+            TimeSliceLevel::Season => {
+                Box::new(self.seasons.iter().cloned().map(TimeSliceSelection::Season))
+            }
+            TimeSliceLevel::DayNight => {
+                Box::new(self.iter_ids().cloned().map(TimeSliceSelection::Single))
+            }
+        }
+    }
+
     /// Iterate over a subset of time slices calculating the relative duration of each.
     ///
     /// The relative duration is specified as a fraction of the total time (proportion of year)
@@ -194,7 +213,7 @@ impl TimeSliceInfo {
 }
 
 /// Refers to a particular aspect of a time slice
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
+#[derive(PartialEq, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {
     #[string = "annual"]
     Annual,


### PR DESCRIPTION
# Description

This PR adds the commodity balance constraints to the optimisation, which ensure supply matches demand for the system.  See detail in docs [here](https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html#commodity-balance-constraints).

There are two kinds of commodity that this is relevant for: "supply equals demand" and "service demand". The former is a simple case of just matching supply and demand within the simulation (e.g. coal production has to match the demand from coal power plants etc.). The latter is similar but effectively includes additional demand for outside the system: for example we might need to service a demand for residential heat, so the model effectively needs to produce an excess of the residential heat "commodity" to match this.

This ended up being more fiddly than I expected, because commodities also have a "time slice level" property, which determines over which time slices supply and demand should be matched. The options are annual (all time slices), seasonal (each season) or time slice (i.e. supply should match demand for each time slice). For example, you can store natural gas to an extent, so you could produce more gas in one time slice and consume it in another.

With these constraints in place, we can now read prices out from the solution by reading the dual row values. I don't understand how this works in any detail but I double-checked with Adam that this is what he wanted, so it's a bit of an article of faith!

There aren't any tests for this at the mo, as with the other functions for adding constraints. We should probably remedy this at some point but it will require a bit of thought because mocking will be more of a faff in Rust than it would be in Python.

Closes #302. Closes #341.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
