### PR TITLE
Write commodity prices to CSV

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -61,7 +61,7 @@ pub fn handle_run_command(model_dir: &Path) -> Result<()> {
     info!("Output directory created: {}", output_path.display());
     let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
-    crate::simulation::run(model, assets);
+    crate::simulation::run(model, assets, &output_path)?;
     Ok(())
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,8 +3,7 @@ use crate::simulation::CommodityPrices;
 use anyhow::{Context, Result};
 use csv::Writer;
 use serde::Serialize;
-use std::fs;
-use std::fs::File;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
 /// The root folder in which model-specific output folders will be created
@@ -45,11 +44,16 @@ struct CommodityPriceRow {
 }
 
 /// Write commodity prices to a CSV file.
-pub fn write_commodity_prices_to_csv(milestone_year: u32, prices: &CommodityPrices) -> Result<()> {
-    let file_path: PathBuf = [OUTPUT_DIRECTORY_ROOT, "commodity_prices.csv"]
-        .iter()
-        .collect();
-    let file = File::create(file_path)?;
+pub fn write_commodity_prices_to_csv(
+    output_path: &Path,
+    milestone_year: u32,
+    prices: &CommodityPrices,
+) -> Result<()> {
+    let file_path = output_path.join("commodity_prices.csv");
+    let file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(file_path)?;
     let mut wtr = Writer::from_writer(file);
 
     for (commodity_id, time_slice, price) in prices.iter() {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -3,8 +3,10 @@ use crate::agent::AssetPool;
 use crate::model::Model;
 use crate::output::write_commodity_prices_to_csv;
 use crate::time_slice::TimeSliceID;
+use anyhow::Result;
 use log::info;
 use std::collections::HashMap;
+use std::path::Path;
 use std::rc::Rc;
 
 pub mod optimisation;
@@ -55,7 +57,7 @@ impl CommodityPrices {
 ///
 /// * `model` - The model to run
 /// * `assets` - The asset pool
-pub fn run(model: Model, mut assets: AssetPool) {
+pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()> {
     let mut prices = CommodityPrices::default();
 
     for year in model.iter_years() {
@@ -74,9 +76,8 @@ pub fn run(model: Model, mut assets: AssetPool) {
         perform_agent_investment(&model, &mut assets);
 
         // Write current commodity prices to CSV
-        match write_commodity_prices_to_csv(year, &prices) {
-            Ok(_) => (),
-            Err(e) => eprintln!("Error writing commodity prices to CSV: {}", e),
-        }
+        write_commodity_prices_to_csv(output_path, year, &prices)?;
     }
+
+    Ok(())
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -6,6 +6,7 @@ use crate::time_slice::TimeSliceID;
 use anyhow::Result;
 use log::info;
 use std::collections::HashMap;
+use std::fs::OpenOptions;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -60,6 +61,12 @@ impl CommodityPrices {
 pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()> {
     let mut prices = CommodityPrices::default();
 
+    let file_path = output_path.join("commodity_prices.csv");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(file_path)?;
+
     for year in model.iter_years() {
         info!("Milestone year: {year}");
 
@@ -76,7 +83,7 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         perform_agent_investment(&model, &mut assets);
 
         // Write current commodity prices to CSV
-        write_commodity_prices_to_csv(output_path, year, &prices)?;
+        write_commodity_prices_to_csv(&mut file, year, &prices)?;
     }
 
     Ok(())

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,6 +1,7 @@
 //! Functionality for running the MUSE 2.0 simulation.
 use crate::agent::AssetPool;
 use crate::model::Model;
+use crate::output::write_commodity_prices_to_csv;
 use crate::time_slice::TimeSliceID;
 use log::info;
 use std::collections::HashMap;
@@ -71,5 +72,11 @@ pub fn run(model: Model, mut assets: AssetPool) {
 
         // Agent investment
         perform_agent_investment(&model, &mut assets);
+
+        // Write current commodity prices to CSV
+        match write_commodity_prices_to_csv(year, &prices) {
+            Ok(_) => (),
+            Err(e) => eprintln!("Error writing commodity prices to CSV: {}", e),
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR introduces functionality to write commodity prices to a CSV file as part of the simulation output.

* Defined the `CommodityPriceRow` struct and implemented the `write_commodity_prices_to_csv` function to write commodity prices to a CSV file.
* Added a call to `write_commodity_prices_to_csv` within the `run` function to output commodity prices after agent investment.

Fixes #378 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
