### PR TITLE
Fix logging of fatal errors

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -92,7 +92,7 @@ pub fn handle_example_list_command() {
 /// Handle the `example run` command.
 pub fn handle_example_run_command(name: &str) -> Result<()> {
     // Find the subdirectory in EXAMPLES_DIR whose name matches `name`.
-    let sub_dir = EXAMPLES_DIR.get_dir(name).context("Directory not found.")?;
+    let sub_dir = EXAMPLES_DIR.get_dir(name).context("Example not found.")?;
 
     // Creates temporary directory
     let temp_dir = TempDir::new().context("Failed to create temporary directory.")?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@
 use crate::output::create_output_directory;
 use crate::settings::Settings;
 use crate::{input::load_model, log};
-use ::log::info;
+use ::log::{error, info};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use include_dir::{include_dir, Dir, DirEntry};
@@ -52,25 +52,32 @@ pub enum ExampleSubcommands {
 }
 
 /// Handle the `run` command.
-pub fn handle_run_command(model_dir: &Path) -> Result<()> {
+pub fn handle_run_command(model_path: &Path) -> Result<()> {
     // Load program settings
-    let settings = Settings::from_path(model_dir).context("Failed to load settings.")?;
+    let settings = Settings::from_path(model_path).context("Failed to load settings.")?;
 
     // Create output folder
     let output_path =
-        create_output_directory(model_dir).context("Failed to create output directory.")?;
+        create_output_directory(model_path).context("Failed to create output directory.")?;
 
     // Initialise program logger
     log::init(settings.log_level.as_deref(), &output_path)
-        .context("Failed to initialize logging.")?;
+        .context("Failed to initialise logging.")?;
 
-    // Load the model to run
-    let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
-    info!("Loaded model from {}", model_dir.display());
-    info!("Output data will be written to {}", output_path.display());
+    let load_and_run_model = || {
+        // Load the model to run
+        let (model, assets) = load_model(model_path).context("Failed to load model.")?;
+        info!("Loaded model from {}", model_path.display());
+        info!("Output data will be written to {}", output_path.display());
 
-    // Run the simulation
-    crate::simulation::run(model, assets, &output_path)?;
+        // Run the simulation
+        crate::simulation::run(model, assets, &output_path)
+    };
+
+    // Once the logger is initialised, we can write fatal errors to log
+    if let Err(err) = load_and_run_model() {
+        error!("{err:?}");
+    }
 
     Ok(())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -65,6 +65,13 @@ pub fn handle_run_command(model_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Handle the `example list` command.
+pub fn handle_example_list_command() {
+    for entry in EXAMPLES_DIR.dirs() {
+        println!("{}", entry.path().display());
+    }
+}
+
 /// Handle the `example run` command.
 pub fn handle_example_run_command(name: &str) -> Result<()> {
     // Find the subdirectory in EXAMPLES_DIR whose name matches `name`.
@@ -88,12 +95,4 @@ pub fn handle_example_run_command(name: &str) -> Result<()> {
     }
 
     handle_run_command(&temp_path)
-}
-
-/// Handle the `example list` command.
-pub fn handle_example_list_command() -> Result<()> {
-    for entry in EXAMPLES_DIR.dirs() {
-        println!("{}", entry.path().display());
-    }
-    Ok(())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -67,7 +67,7 @@ pub fn handle_run_command(model_dir: &Path) -> Result<()> {
 
     // Load the model to run
     let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
-    info!("Model loaded successfully.");
+    info!("Loaded model from {}", model_dir.display());
 
     // Run the simulation
     crate::simulation::run(model, assets, &output_path)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -59,7 +59,6 @@ pub fn handle_run_command(model_dir: &Path) -> Result<()> {
     // Create output folder
     let output_path =
         create_output_directory(model_dir).context("Failed to create output directory.")?;
-    info!("Output directory created: {}", output_path.display());
 
     // Initialise program logger
     log::init(settings.log_level.as_deref(), &output_path)
@@ -68,6 +67,7 @@ pub fn handle_run_command(model_dir: &Path) -> Result<()> {
     // Load the model to run
     let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
     info!("Loaded model from {}", model_dir.display());
+    info!("Output data will be written to {}", output_path.display());
 
     // Run the simulation
     crate::simulation::run(model, assets, &output_path)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -53,15 +53,25 @@ pub enum ExampleSubcommands {
 
 /// Handle the `run` command.
 pub fn handle_run_command(model_dir: &Path) -> Result<()> {
+    // Load program settings
     let settings = Settings::from_path(model_dir).context("Failed to load settings.")?;
+
+    // Create output folder
     let output_path =
         create_output_directory(model_dir).context("Failed to create output directory.")?;
+    info!("Output directory created: {}", output_path.display());
+
+    // Initialise program logger
     log::init(settings.log_level.as_deref(), &output_path)
         .context("Failed to initialize logging.")?;
-    info!("Output directory created: {}", output_path.display());
+
+    // Load the model to run
     let (model, assets) = load_model(model_dir).context("Failed to load model.")?;
     info!("Model loaded successfully.");
+
+    // Run the simulation
     crate::simulation::run(model, assets, &output_path)?;
+
     Ok(())
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,7 +71,7 @@ where
 
 /// Format an error message to include the file path. To be used with `anyhow::Context`.
 pub fn input_err_msg<P: AsRef<Path>>(file_path: P) -> String {
-    format!("Error reading {}", file_path.as_ref().to_string_lossy())
+    format!("Error reading {}", file_path.as_ref().display())
 }
 
 /// Indicates that the struct has an ID field

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -419,7 +419,7 @@ mod tests {
         // Create a dummy demand map for the non-SED commodity
         let mut demand_map = DemandMap::new();
         for region in data.region_ids.iter() {
-            for year in milestone_years.clone() {
+            for year in milestone_years {
                 for time_slice in time_slice_info.iter_ids() {
                     demand_map.insert(region.clone(), year, time_slice.clone(), 0.5);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,12 @@ fn main() {
 
 fn execute_cli_command(command: Commands) -> Result<()> {
     match command {
-        Commands::Run { model_dir } => handle_run_command(&model_dir),
+        Commands::Run { model_dir } => handle_run_command(&model_dir)?,
         Commands::Example { subcommand } => match subcommand {
             ExampleSubcommands::List => handle_example_list_command(),
-            ExampleSubcommands::Run { name } => handle_example_run_command(&name),
+            ExampleSubcommands::Run { name } => handle_example_run_command(&name)?,
         },
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
+use anyhow::Result;
 use clap::Parser;
-use human_panic::{metadata, setup_panic};
-use muse2::commands;
-
 use commands::{
     handle_example_list_command, handle_example_run_command, handle_run_command, Cli, Commands,
     ExampleSubcommands,
 };
+use human_panic::{metadata, setup_panic};
+use muse2::commands;
 
 fn main() {
     setup_panic!(metadata!().support(format!(
@@ -14,13 +14,15 @@ fn main() {
     )));
 
     let cli = Cli::parse();
+    execute_cli_command(cli.command).unwrap_or_else(|err| eprintln!("Error: {:?}", err));
+}
 
-    match cli.command {
+fn execute_cli_command(command: Commands) -> Result<()> {
+    match command {
         Commands::Run { model_dir } => handle_run_command(&model_dir),
         Commands::Example { subcommand } => match subcommand {
             ExampleSubcommands::List => handle_example_list_command(),
             ExampleSubcommands::Run { name } => handle_example_run_command(&name),
         },
     }
-    .unwrap_or_else(|err| eprintln!("{:?}", err))
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -21,6 +21,6 @@ fn test_handle_run_command() {
             .next()
             .unwrap()
             .to_string(),
-        "Failed to initialize logging."
+        "Failed to initialise logging."
     );
 }


### PR DESCRIPTION
# Description

Currently if a fatal error occurs while running the model (e.g. failure to write to file), that message will be written to stderr but not the log file. For more details see issue description: #421 

Fix by using the `error!` macro after the logger is initialised and `eprintln!` in all other cases. I also fixed another small bug where the output folder wasn't being logged properly (we were using the `info!` macro before the logger was initialised, so it wasn't printed anywhere).

I also tidied the CLI handling code a little while I was at it.

Fixes #421.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
