### PR TITLE
Fix: Return correct cost coefficient if commodity cost is negative

### DIFF
--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -232,7 +232,11 @@ fn calculate_cost_coefficient(
 
     // If flow is negative (representing an input), we multiply by -1 to ensure impact of
     // coefficient on objective function is a positive cost
-    coeff.copysign(flow.flow)
+    if flow.flow > 0.0 {
+        coeff
+    } else {
+        -coeff
+    }
 }
 
 /// Add asset-level constraints


### PR DESCRIPTION
# Description

It turns out that users can supply a negative commodity cost indicating an incentive, however, the code currently doesn't handle this case correctly. See [discussion here](https://github.com/EnergySystemsModellingLab/MUSE_2.0/pull/410#discussion_r1983102926).

I also noticed that we're not validating commodity cost in any way, so users can currently give a value of `inf` or `NaN`, which doesn't make a lot of sense. I considered adding a check for this, but as it's actually a broader problem (there are lots of input values that we're not checking), I opened a separate issue for it: #426 

Fixes #423.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
