### PR TITLE
Reorder simulation loop

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -197,19 +197,20 @@ impl AssetPool {
         self.assets.retain(|asset| asset.decommission_year() > year);
     }
 
-    /// Get an asset with the specified ID
+    /// Get an asset with the specified ID.
     ///
-    /// # Panics
+    /// # Returns
     ///
-    /// Panics if `id` is not in pool.
-    pub fn get(&self, id: AssetID) -> &Asset {
+    /// Reference to an [`Asset`] if found, else `None`. The asset may not be found if it has
+    /// already been decommissioned.
+    pub fn get(&self, id: AssetID) -> Option<&Asset> {
         // The assets in `active` are in order of ID
         let idx = self
             .assets
             .binary_search_by(|asset| asset.id.cmp(&id))
-            .expect("id not found");
+            .ok()?;
 
-        &self.assets[idx]
+        Some(&self.assets[idx])
     }
 
     /// Iterate over active assets
@@ -388,7 +389,7 @@ mod tests {
     fn test_asset_pool_get() {
         let mut assets = create_asset_pool();
         assets.commission_new(2020);
-        assert!(*assets.get(AssetID(0)) == assets.assets[0]);
-        assert!(*assets.get(AssetID(1)) == assets.assets[1]);
+        assert!(assets.get(AssetID(0)) == Some(&assets.assets[0]));
+        assert!(assets.get(AssetID(1)) == Some(&assets.assets[1]));
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -27,19 +27,26 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         .create(true)
         .open(file_path)?;
 
+    let mut opt_solution = None;
     for year in model.iter_years() {
         info!("Milestone year: {year}");
 
-        // Commission and decommission assets for this milestone year
+        // Assets that have been decommissioned cannot be selected by agents
         assets.decomission_old(year);
+
+        // NB: Agent investment is not carried out in first milestone year
+        if let Some(solution) = opt_solution {
+            perform_agent_investment(&model, &solution, &mut assets);
+        }
+
+        // Newly commissioned assets will be included in optimisation for at least one milestone
+        // year before agents have the option of decommissioning them
         assets.commission_new(year);
 
         // Dispatch optimisation
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);
-
-        // Agent investment
-        perform_agent_investment(&model, &solution, &mut assets);
+        opt_solution = Some(solution);
 
         // Write current commodity prices to CSV
         write_commodity_prices_to_csv(&mut file, year, &prices)?;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -2,7 +2,7 @@
 use crate::agent::AssetPool;
 use crate::model::Model;
 use crate::output::write_commodity_prices_to_csv;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use log::info;
 use std::fs::OpenOptions;
 use std::path::Path;
@@ -37,6 +37,10 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         // NB: Agent investment is not carried out in first milestone year
         if let Some(solution) = opt_solution {
             perform_agent_investment(&model, &solution, &mut assets);
+
+            // **TODO:** Remove this when we implement at least some of the agent investment code
+            //   See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/304
+            bail!("Agent investment is not yet implemented. Exiting...");
         }
 
         // Newly commissioned assets will be included in optimisation for at least one milestone

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -39,7 +39,7 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);
 
         // Agent investment
-        perform_agent_investment(&model, &mut assets);
+        perform_agent_investment(&model, &solution, &mut assets);
 
         // Write current commodity prices to CSV
         write_commodity_prices_to_csv(&mut file, year, &prices)?;

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -1,4 +1,5 @@
 //! Code for performing agent investment.
+use super::optimisation::Solution;
 use crate::agent::AssetPool;
 use crate::model::Model;
 use log::info;
@@ -8,7 +9,8 @@ use log::info;
 /// # Arguments
 ///
 /// * `model` - The model
+/// * `solution` - The solution to the dispatch optimisation
 /// * `assets` - The asset pool
-pub fn perform_agent_investment(_model: &Model, _assets: &mut AssetPool) {
+pub fn perform_agent_investment(_model: &Model, _solution: &Solution, _assets: &mut AssetPool) {
     info!("Performing agent investment...");
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -1,5 +1,6 @@
 //! Code for performing agent investment.
 use super::optimisation::Solution;
+use super::CommodityPrices;
 use crate::agent::AssetPool;
 use crate::model::Model;
 use log::info;
@@ -10,7 +11,13 @@ use log::info;
 ///
 /// * `model` - The model
 /// * `solution` - The solution to the dispatch optimisation
+/// * `prices` - Commodity prices
 /// * `assets` - The asset pool
-pub fn perform_agent_investment(_model: &Model, _solution: &Solution, _assets: &mut AssetPool) {
+pub fn perform_agent_investment(
+    _model: &Model,
+    _solution: &Solution,
+    _prices: &CommodityPrices,
+    _assets: &mut AssetPool,
+) {
     info!("Performing agent investment...");
 }


### PR DESCRIPTION
# Description

Agent investment currently takes place immediately after the dispatch optimisation in the simulation loop. It doesn't really matter as things stand, because it's just a no-op, but I think it will affect things once agents can actually commission/decommission assets. It will also have an effect on the data we write: we want to make sure we attibute things to the correct milestone year.

I *believe* that agent investment should happen at the start of the milestone year, after old assets have been decommissioned, but before new ones have been commissioned (apart from anything, newly commissioned assets will by definition not have been included in the previous run of the dispatch optimisation, so agents won't have information about them yet).

One slightly odd consequence of this is that some of the data in the solution to the dispatch optimisation will relate to assets that have just been decommissioned, so agents cannot select them, even though there will be data for them. I changed `AssetPool::get` to return `None` for missing assets so the agent investment code can skip these ones.

Here's what I think the simulation loop should look like for each milestone year (there are some parts not yet implemented that I've put in brackets):

- Decommission old assets
- Perform agent investment **unless** in the first milestone year
- Commission new assets
- (Write active assets to file: #377)
- Perform dispatch optimisation
- (Write commodity flows to file: #412)
- Calculate commodity prices
- Write commodity prices to file

This means that the assets will be recorded for every year *after* agent investment and any new assets have been commissioned (except for the first year, where it'll just be the initial assets).

Does all this sound sane?

Closes #413.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
