### PR TITLE
Enable logging for HiGHS solver

### DIFF
--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -143,7 +143,8 @@ pub fn perform_dispatch_optimisation<'a>(
         add_asset_contraints(&mut problem, &variables, model, assets, year);
 
     // Solve problem
-    let solution = problem.optimise(Sense::Minimise).solve();
+    let highs_model = problem.optimise(Sense::Minimise);
+    let solution = highs_model.solve();
 
     match solution.status() {
         HighsModelStatus::Optimal => Ok(Solution {


### PR DESCRIPTION
# Description

This is a temporary hack until we can implement #428 properly, which will require (small) changes to the upstream `highs` crate.

The problem is that Adam wants the objective value for the optimisation (seemingly a scalar value -- I'm honestly not sure of its significance) and there is no way to get that information using the `highs` crate as it stands. You can, however, see this information along with various other stats if you enable logging for the solver. This is a pretty gross hack -- the output is just dumped to `stdout` rather than going through our logger so it won't be written to the log file -- but it should at least allow us to see what this value is in the short term.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
