### PR TITLE
Add scaffold code to select assets based on agent choice

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -238,6 +238,23 @@ impl AssetPool {
         self.iter_for_region(region_id)
             .filter(|asset| asset.process.contains_commodity_flow(commodity))
     }
+
+    /// Retain all assets whose IDs are in `assets_to_keep`.
+    ///
+    /// Other assets will be decommissioned. Assets which have not yet been commissioned will not be
+    /// affected.
+    pub fn retain(&mut self, assets_to_keep: &HashSet<AssetID>) {
+        // Sanity check: all IDs should be valid. As this check is slow, only do it for debug
+        // builds.
+        debug_assert!(
+            assets_to_keep.iter().all(|id| self.get(*id).is_some()),
+            "One or more asset IDs were invalid"
+        );
+
+        self.assets.retain(|asset| {
+            assets_to_keep.contains(&asset.id) || asset.commission_year > self.current_year
+        });
+    }
 }
 
 #[cfg(test)]
@@ -391,5 +408,28 @@ mod tests {
         assets.commission_new(2020);
         assert!(assets.get(AssetID(0)) == Some(&assets.assets[0]));
         assert!(assets.get(AssetID(1)) == Some(&assets.assets[1]));
+    }
+
+    #[test]
+    fn test_asset_pool_retain() {
+        let mut assets = create_asset_pool();
+
+        // Even though we are retaining no assets, none have been commissioned so the asset pool
+        // should not be changed
+        assets.retain(&HashSet::new());
+        assert_eq!(assets.assets.len(), 2);
+
+        // Decommission all active assets
+        assets.commission_new(2010); // Commission first asset
+        assets.retain(&HashSet::new());
+        assert_eq!(assets.assets.len(), 1);
+        assert_eq!(assets.assets[0].id, AssetID(1));
+
+        // Decommission single asset
+        let mut assets = create_asset_pool();
+        assets.commission_new(2020); // Commission all assets
+        assets.retain(&iter::once(AssetID(1)).collect());
+        assert_eq!(assets.assets.len(), 1);
+        assert_eq!(assets.assets[0].id, AssetID(1));
     }
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -4,6 +4,7 @@ use super::CommodityPrices;
 use crate::agent::AssetPool;
 use crate::model::Model;
 use log::info;
+use std::collections::HashSet;
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -15,9 +16,24 @@ use log::info;
 /// * `assets` - The asset pool
 pub fn perform_agent_investment(
     _model: &Model,
-    _solution: &Solution,
+    solution: &Solution,
     _prices: &CommodityPrices,
-    _assets: &mut AssetPool,
+    assets: &mut AssetPool,
 ) {
     info!("Performing agent investment...");
+
+    let mut assets_to_keep = HashSet::new();
+    for (asset_id, _commodity_id, _time_slice, _flow) in solution.iter_commodity_flows_for_assets()
+    {
+        if assets.get(asset_id).is_none() {
+            // Asset has been decommissioned
+            continue;
+        }
+
+        // **TODO**: Implement agent investment. For now, just keep all assets.
+        assets_to_keep.insert(asset_id);
+    }
+
+    // Decommission non-selected assets
+    assets.retain(&assets_to_keep);
 }


### PR DESCRIPTION
# Description

While we don't yet have agent investment, I thought it was still worth adding the relevant method to `AssetPool` to allow us to select/discard assets. I've added some placeholder code to `perform_agent_investment` which uses this method (currently it just retains all assets).

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
