### PR TITLE
Write active assets and commodity flows to CSV

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 /// The root folder in which model-specific output folders will be created
 const OUTPUT_DIRECTORY_ROOT: &str = "muse2_results";
@@ -43,7 +44,7 @@ pub fn create_output_directory(model_dir: &Path) -> Result<PathBuf> {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CommodityPriceRow {
     milestone_year: u32,
-    commodity_id: String,
+    commodity_id: Rc<str>,
     time_slice: String,
     price: f64,
 }
@@ -63,7 +64,7 @@ impl CommodityPricesWriter {
         for (commodity_id, time_slice, price) in prices.iter() {
             let row = CommodityPriceRow {
                 milestone_year,
-                commodity_id: commodity_id.to_string(),
+                commodity_id: Rc::clone(commodity_id),
                 time_slice: time_slice.to_string(),
                 price,
             };
@@ -111,7 +112,7 @@ mod tests {
 
         // Read back and compare
         let expected = CommodityPriceRow {
-            commodity_id: commodity_id.to_string(),
+            commodity_id,
             milestone_year,
             time_slice: time_slice.to_string(),
             price,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -42,6 +42,10 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         // year before agents have the option of decommissioning them
         assets.commission_new(year);
 
+        // Write current assets to CSV. This indicates the set of assets fed into the dispatch
+        // optimisation, so we *must* do it after agent investment and new assets are commissioned
+        writer.write_assets(year, assets.iter())?;
+
         // Dispatch optimisation
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,7 +1,7 @@
 //! Functionality for running the MUSE 2.0 simulation.
 use crate::agent::AssetPool;
 use crate::model::Model;
-use crate::output::CommodityPricesWriter;
+use crate::output::DataWriter;
 use anyhow::{bail, Result};
 use log::info;
 use std::path::Path;
@@ -20,7 +20,7 @@ pub use prices::CommodityPrices;
 /// * `model` - The model to run
 /// * `assets` - The asset pool
 pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()> {
-    let mut prices_wtr = CommodityPricesWriter::create(output_path)?;
+    let mut writer = DataWriter::create(output_path)?;
 
     let mut opt_results = None; // all results of dispatch optimisation
     for year in model.iter_years() {
@@ -47,12 +47,12 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);
 
         // Write current commodity prices to CSV
-        prices_wtr.write(year, &prices)?;
+        writer.write_prices(year, &prices)?;
 
         opt_results = Some((solution, prices));
     }
 
-    prices_wtr.flush()?;
+    writer.flush()?;
 
     Ok(())
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -50,7 +50,8 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);
 
-        // Write current commodity prices to CSV
+        // Write result of dispatch optimisation to file
+        writer.write_flows(year, &assets, solution.iter_commodity_flows_for_assets())?;
         writer.write_prices(year, &prices)?;
 
         opt_results = Some((solution, prices));


### PR DESCRIPTION
# Description

I thought about breaking this into two PRs, but figured it would probably be less hassle to review in one go.

This PR adds code to write the active assets and commodity flows from the dispatch optimisation for the current milestone year to CSV files. I decided to wrap all the CSV writers (including the existing code for writing prices) in a single `DataWriter` struct rather than having them as separate structs or just leaving them as the underlying `csv::Writer`s and adding functions to work with them. I mostly just did this so that we can have single functions for creating the streams and flushing them rather than having separate calls dotted all over the place.

It's hard to disambiguate different assets because they don't have different string IDs (we give them a numerical ID internally, but that's not useful information for the user). Accordingly, the `assets.csv` and `commodity_flows.csv` files have lots of columns just so we can tell assets apart, but this feels a bit ugly. Do we think it would be worth making the user give each asset a name in the input data?

I didn't notice that we weren't breaking commodity prices down by region (#431) otherwise I'd have fixed that first. So there isn't a region column in the `prices.csv` file currently, but there should be. It's not a problem for the `simple` example because that only has one region, but we should fix it at some point.

Closes #409. Closes #377. Closes #412.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
