### PR TITLE
Fix naming of some activity/capacity-related things

### DIFF
--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,cap2act
+process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity
 GASDRV,2020,2030,10.0,0.3,2.0,25,0.1,1.0
 GASPRC,2020,2030,7.0,0.21,0.5,25,0.1,1.0
 WNDFRM,2020,2030,1000.0,30.0,0.4,25,0.1,31.54

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -144,7 +144,7 @@ impl Asset {
     /// Get the activity limits for this asset in a particular time slice
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.capacity_fractions.get(time_slice).unwrap();
-        let capacity_a = self.capacity * self.process.parameter.cap2act;
+        let capacity_a = self.capacity * self.process.parameter.capacity_to_activity;
 
         // Multiply the fractional capacity in self.process by this asset's actual capacity
         (capacity_a * limits.start())..=(capacity_a * limits.end())
@@ -263,7 +263,7 @@ mod tests {
             variable_operating_cost: 1.0,
             lifetime: 5,
             discount_rate: 0.9,
-            cap2act: 3.0,
+            capacity_to_activity: 3.0,
         };
         let commodity = Rc::new(Commodity {
             id: "commodity1".into(),
@@ -312,7 +312,7 @@ mod tests {
             variable_operating_cost: 1.0,
             lifetime: 5,
             discount_rate: 0.9,
-            cap2act: 1.0,
+            capacity_to_activity: 1.0,
         };
         let process = Rc::new(Process {
             id: "process1".into(),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -144,10 +144,17 @@ impl Asset {
     /// Get the activity limits for this asset in a particular time slice
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.capacity_fractions.get(time_slice).unwrap();
-        let capacity_a = self.capacity * self.process.parameter.capacity_to_activity;
+        let max_act = self.maximum_activity();
 
         // Multiply the fractional capacity in self.process by this asset's actual capacity
-        (capacity_a * limits.start())..=(capacity_a * limits.end())
+        (max_act * limits.start())..=(max_act * limits.end())
+    }
+
+    /// Maximum activity for this asset in a year.
+    ///
+    /// This was referred to as `capacity_a` in MUSE 1.0.
+    pub fn maximum_activity(&self) -> f64 {
+        self.capacity * self.process.parameter.capacity_to_activity
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -143,7 +143,7 @@ impl Asset {
 
     /// Get the activity limits for this asset in a particular time slice
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
-        let limits = self.process.capacity_fractions.get(time_slice).unwrap();
+        let limits = self.process.activity_limits.get(time_slice).unwrap();
         let max_act = self.maximum_activity();
 
         // Multiply the fractional capacity in self.process by this asset's actual capacity
@@ -251,7 +251,7 @@ impl AssetPool {
 mod tests {
     use super::*;
     use crate::commodity::{CommodityCostMap, CommodityType, DemandMap};
-    use crate::process::{FlowType, Process, ProcessCapacityMap, ProcessFlow, ProcessParameter};
+    use crate::process::{ActivityLimitsMap, FlowType, Process, ProcessFlow, ProcessParameter};
     use crate::time_slice::TimeSliceLevel;
     use itertools::{assert_equal, Itertools};
     use std::iter;
@@ -289,11 +289,11 @@ mod tests {
             is_pac: true,
         };
         let fraction_limits = 1.0..=f64::INFINITY;
-        let capacity_fractions = iter::once((time_slice.clone(), fraction_limits)).collect();
+        let activity_limits = iter::once((time_slice.clone(), fraction_limits)).collect();
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            capacity_fractions,
+            activity_limits,
             flows: vec![flow.clone()],
             parameter: process_param.clone(),
             regions: RegionSelection::All,
@@ -324,7 +324,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            capacity_fractions: ProcessCapacityMap::new(),
+            activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
             parameter: process_param.clone(),
             regions: RegionSelection::All,

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -107,7 +107,7 @@ mod tests {
             variable_operating_cost: 1.0,
             lifetime: 5,
             discount_rate: 0.9,
-            cap2act: 1.0,
+            capacity_to_activity: 1.0,
         };
         let process = Rc::new(Process {
             id: "process1".into(),

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -92,7 +92,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::process::{Process, ProcessCapacityMap, ProcessParameter};
+    use crate::process::{ActivityLimitsMap, Process, ProcessParameter};
     use crate::region::RegionSelection;
     use itertools::assert_equal;
     use std::iter;
@@ -112,7 +112,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            capacity_fractions: ProcessCapacityMap::new(),
+            activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
             parameter: process_param.clone(),
             regions: RegionSelection::All,
@@ -187,7 +187,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            capacity_fractions: ProcessCapacityMap::new(),
+            activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
             parameter: process_param,
             regions: RegionSelection::Some(["GBR".into()].into_iter().collect()),

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -314,7 +314,7 @@ mod tests {
                     variable_operating_cost: 0.0,
                     lifetime: 1,
                     discount_rate: 1.0,
-                    cap2act: 0.0,
+                    capacity_to_activity: 0.0,
                 };
 
                 (id.into(), parameter)

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -1,7 +1,7 @@
 //! Code for reading process-related information from CSV files.
 use crate::commodity::{Commodity, CommodityMap, CommodityType};
 use crate::input::*;
-use crate::process::{Process, ProcessCapacityMap, ProcessFlow, ProcessMap, ProcessParameter};
+use crate::process::{ActivityLimitsMap, Process, ProcessFlow, ProcessMap, ProcessParameter};
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
@@ -95,7 +95,7 @@ struct ValidationParams<'a> {
     milestone_years: &'a [u32],
     time_slice_info: &'a TimeSliceInfo,
     parameters: &'a HashMap<Rc<str>, ProcessParameter>,
-    availabilities: &'a HashMap<Rc<str>, ProcessCapacityMap>,
+    availabilities: &'a HashMap<Rc<str>, ActivityLimitsMap>,
 }
 
 /// Perform consistency checks for commodity flows.
@@ -106,7 +106,7 @@ fn validate_commodities(
     milestone_years: &[u32],
     time_slice_info: &TimeSliceInfo,
     parameters: &HashMap<Rc<str>, ProcessParameter>,
-    availabilities: &HashMap<Rc<str>, ProcessCapacityMap>,
+    availabilities: &HashMap<Rc<str>, ActivityLimitsMap>,
 ) -> anyhow::Result<()> {
     let params = ValidationParams {
         flows,
@@ -213,7 +213,7 @@ fn validate_svd_commodity(
 
 fn create_process_map<I>(
     descriptions: I,
-    mut availabilities: HashMap<Rc<str>, ProcessCapacityMap>,
+    mut availabilities: HashMap<Rc<str>, ActivityLimitsMap>,
     mut flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
     mut parameters: HashMap<Rc<str>, ProcessParameter>,
     mut regions: HashMap<Rc<str>, RegionSelection>,
@@ -240,7 +240,7 @@ where
             let process = Process {
                 id: Rc::clone(id),
                 description: description.description,
-                capacity_fractions: availabilities,
+                activity_limits: availabilities,
                 flows,
                 parameter,
                 regions,
@@ -263,7 +263,7 @@ mod tests {
 
     struct ProcessData {
         descriptions: Vec<ProcessDescription>,
-        availabilities: HashMap<Rc<str>, ProcessCapacityMap>,
+        availabilities: HashMap<Rc<str>, ActivityLimitsMap>,
         flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
         parameters: HashMap<Rc<str>, ProcessParameter>,
         regions: HashMap<Rc<str>, RegionSelection>,
@@ -286,7 +286,7 @@ mod tests {
         let availabilities = ["process1", "process2"]
             .into_iter()
             .map(|id| {
-                let mut map = ProcessCapacityMap::new();
+                let mut map = ActivityLimitsMap::new();
                 map.insert(
                     TimeSliceID {
                         season: "winter".into(),

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -22,7 +22,7 @@ struct ProcessParameterRaw {
     pub variable_operating_cost: f64,
     pub lifetime: u32,
     pub discount_rate: Option<f64>,
-    pub cap2act: Option<f64>,
+    pub capacity_to_activity: Option<f64>,
 }
 define_process_id_getter! {ProcessParameterRaw}
 
@@ -48,7 +48,7 @@ impl ProcessParameterRaw {
             variable_operating_cost: self.variable_operating_cost,
             lifetime: self.lifetime,
             discount_rate: self.discount_rate.unwrap_or(0.0),
-            cap2act: self.cap2act.unwrap_or(1.0),
+            capacity_to_activity: self.capacity_to_activity.unwrap_or(1.0),
         })
     }
 }
@@ -61,7 +61,7 @@ impl ProcessParameterRaw {
     /// Returns an error if:
     /// - `lifetime` is 0.
     /// - `discount_rate` is present and less than 0.0.
-    /// - `cap2act` is present and less than 0.0.
+    /// - `capacity_to_activity` is present and less than 0.0.
     ///
     /// # Warnings
     ///
@@ -93,7 +93,7 @@ impl ProcessParameterRaw {
             }
         }
 
-        if let Some(c2a) = self.cap2act {
+        if let Some(c2a) = self.capacity_to_activity {
             ensure!(
                 c2a >= 0.0,
                 "Error in parameter for process {}: Cap2act must be positive",
@@ -146,7 +146,7 @@ mod tests {
         end_year: Option<u32>,
         lifetime: u32,
         discount_rate: Option<f64>,
-        cap2act: Option<f64>,
+        capacity_to_activity: Option<f64>,
     ) -> ProcessParameterRaw {
         ProcessParameterRaw {
             process_id: "id".to_string(),
@@ -157,14 +157,14 @@ mod tests {
             variable_operating_cost: 0.0,
             lifetime,
             discount_rate,
-            cap2act,
+            capacity_to_activity,
         }
     }
 
     fn create_param(
         years: RangeInclusive<u32>,
         discount_rate: f64,
-        cap2act: f64,
+        capacity_to_activity: f64,
     ) -> ProcessParameter {
         ProcessParameter {
             process_id: "id".to_string(),
@@ -174,7 +174,7 @@ mod tests {
             variable_operating_cost: 0.0,
             lifetime: 1,
             discount_rate,
-            cap2act,
+            capacity_to_activity,
         }
     }
 
@@ -203,7 +203,7 @@ mod tests {
             create_param(2010..=2020, 0.0, 0.0)
         );
 
-        // Missing cap2act
+        // Missing capacity_to_activity
         let raw = create_param_raw(Some(2010), Some(2020), 1, Some(1.0), None);
         assert_eq!(
             raw.into_parameter(&year_range).unwrap(),
@@ -295,7 +295,7 @@ mod tests {
                 variable_operating_cost: 1.0,
                 lifetime: 10,
                 discount_rate: Some(1.0),
-                cap2act: Some(1.0),
+                capacity_to_activity: Some(1.0),
             },
             ProcessParameterRaw {
                 process_id: "B".into(),
@@ -306,7 +306,7 @@ mod tests {
                 variable_operating_cost: 1.0,
                 lifetime: 10,
                 discount_rate: Some(1.0),
-                cap2act: Some(1.0),
+                capacity_to_activity: Some(1.0),
             },
         ];
 
@@ -321,7 +321,7 @@ mod tests {
                     variable_operating_cost: 1.0,
                     lifetime: 10,
                     discount_rate: 1.0,
-                    cap2act: 1.0,
+                    capacity_to_activity: 1.0,
                 },
             ),
             (
@@ -334,7 +334,7 @@ mod tests {
                     variable_operating_cost: 1.0,
                     lifetime: 10,
                     discount_rate: 1.0,
-                    cap2act: 1.0,
+                    capacity_to_activity: 1.0,
                 },
             ),
         ]
@@ -361,7 +361,7 @@ mod tests {
                 variable_operating_cost: 1.0,
                 lifetime: 10,
                 discount_rate: Some(1.0),
-                cap2act: Some(1.0),
+                capacity_to_activity: Some(1.0),
             },
             ProcessParameterRaw {
                 process_id: "B".into(),
@@ -372,7 +372,7 @@ mod tests {
                 variable_operating_cost: 1.0,
                 lifetime: 10,
                 discount_rate: Some(1.0),
-                cap2act: Some(1.0),
+                capacity_to_activity: Some(1.0),
             },
             ProcessParameterRaw {
                 process_id: "A".into(),
@@ -383,7 +383,7 @@ mod tests {
                 variable_operating_cost: 1.0,
                 lifetime: 10,
                 discount_rate: Some(1.0),
-                cap2act: Some(1.0),
+                capacity_to_activity: Some(1.0),
             },
         ];
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -107,10 +107,11 @@ pub struct ProcessParameter {
     pub lifetime: u32,
     /// Process-specific discount rate
     pub discount_rate: f64,
-    /// Factor for calculating the maximum PAC output over a year ("capacity to activity").
+    /// Factor for calculating the maximum PAC output over a year.
     ///
     /// Used for converting one unit of capacity to maximum activity of the PAC per year. For
-    /// example, if capacity is measured in GW and activity is measured in PJ, the cap2act for the
-    /// process is 31.536 because 1 GW of capacity can produce 31.536 PJ energy output in a year.
-    pub cap2act: f64,
+    /// example, if capacity is measured in GW and activity is measured in PJ, the
+    /// capacity_to_activity for the process is 31.536 because 1 GW of capacity can produce 31.536
+    /// PJ energy output in a year.
+    pub capacity_to_activity: f64,
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -20,8 +20,8 @@ pub struct Process {
     pub id: Rc<str>,
     /// A human-readable description for the process (e.g. dry gas extraction)
     pub description: String,
-    /// The capacity limits for each time slice (as a fraction of maximum)
-    pub capacity_fractions: ProcessCapacityMap,
+    /// The activity limits for each time slice (as a fraction of maximum)
+    pub activity_limits: ActivityLimitsMap,
     /// Commodity flows for this process
     pub flows: Vec<ProcessFlow>,
     /// Additional parameters for this process
@@ -44,15 +44,15 @@ impl Process {
     }
 }
 
-/// A map indicating capacity limits for a [`Process`] throughout the year.
+/// A map indicating activity limits for a [`Process`] throughout the year.
 ///
-/// The capacity value is calculated as availability multiplied by time slice length. Note that it
-/// is a *fraction* of capacity for the year; to calculate *actual* capacity for a given time slice
-/// you need to know the maximum capacity for the specific instance of a [`Process`] in use.
+/// The value is calculated as availability multiplied by time slice length. Note that it is a
+/// **fraction** of activity for the year; to calculate **actual** activity for a given time slice
+/// you need to know the maximum activity for the specific instance of a [`Process`] in use.
 ///
-/// The capacity is given as a range, depending on the user-specified limit type and value for
+/// The limits are given as ranges, depending on the user-specified limit type and value for
 /// availability.
-pub type ProcessCapacityMap = HashMap<TimeSliceID, RangeInclusive<f64>>;
+pub type ActivityLimitsMap = HashMap<TimeSliceID, RangeInclusive<f64>>;
 
 /// Represents a commodity flow for a given process
 #[derive(PartialEq, Debug, Deserialize, Clone)]

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -465,7 +465,7 @@ mod tests {
             variable_operating_cost: 1.0,
             lifetime: 5,
             discount_rate: 0.9,
-            cap2act: 1.0,
+            capacity_to_activity: 1.0,
         };
         let commodity = Rc::new(Commodity {
             id: "commodity1".into(),

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -446,7 +446,7 @@ fn add_asset_capacity_constraints(
 mod tests {
     use super::*;
     use crate::commodity::{Commodity, CommodityCost, CommodityCostMap, CommodityType, DemandMap};
-    use crate::process::{FlowType, Process, ProcessCapacityMap, ProcessParameter};
+    use crate::process::{ActivityLimitsMap, FlowType, Process, ProcessParameter};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
     use float_cmp::assert_approx_eq;
@@ -486,7 +486,7 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
-            capacity_fractions: ProcessCapacityMap::new(),
+            activity_limits: ActivityLimitsMap::new(),
             flows: vec![flow.clone()],
             parameter: process_param.clone(),
             regions: RegionSelection::All,


### PR DESCRIPTION
# Description

I've a renamed a couple of activity-related things for consistency/clarity:

1. I renamed the `cap2act` field and CSV column to `capacity_to_activity`. We've previously expanded out these kinds of abbreviations elsewhere and I think it makes things more readable. (I suppose we could name it something else, like `activity_per_capacity` instead)
2. For the map which we use to work out capacity/availability constraints, I think we should be talking about "activity limits" rather than "capacity limits". I've renamed some data structures and fields to reflect this. This makes sense to me, but please let me know if you think I'm not using the term activity correctly.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
