### PR TITLE
Fix commodity price calculation

### DIFF
--- a/docs/model_description.md
+++ b/docs/model_description.md
@@ -16,6 +16,7 @@ transition, usually in the context of climate change mitigation.
 
 ### Model Scope
 
+<!-- markdown-link-check-disable-next-line -->
 MUSE is an [Integrated Assessment Modelling](https://unfccc.int/topics/mitigation/workstreams/response-measures/modelling-tools-to-assess-the-impact-of-the-implementation-of-response-measures/integrated-assessment-models-iams-and-energy-environment-economy-e3-models)
 framework that is designed to enable users to create and apply an agent-based model that simulates a
 market equilibrium on a set of user-defined commodities, over a user-defined time period, for a

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -49,7 +49,7 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
 
         // Dispatch optimisation
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
-        let prices = CommodityPrices::from_model_and_solution(&model, &solution);
+        let prices = CommodityPrices::from_model_and_solution(&model, &solution, &assets);
 
         // Write current commodity prices to CSV
         write_commodity_prices_to_csv(&mut file, year, &prices)?;

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -98,23 +98,10 @@ impl Solution<'_> {
             .map(|(key, flow)| (key.asset_id, &key.commodity_id, &key.time_slice, flow))
     }
 
-    /// Iterate over the newly calculated commodity prices for each time slice.
-    ///
-    /// Note that there may only be prices for a subset of the commodities; the rest will need to be
-    /// calculated in another way.
-    pub fn iter_commodity_prices(&self) -> impl Iterator<Item = (&Rc<str>, &TimeSliceID, f64)> {
-        // Calculate commodity balance duals
-        let commodity_duals = self.iter_commodity_balance_duals();
-
-        // Calculate capacity duals
-        let _capacity_duals = self.iter_capacity_duals();
-
-        // Calculate prices (for now this is just the commodity duals)
-        commodity_duals
-    }
-
     /// Keys and dual values for commodity balance constraints.
-    fn iter_commodity_balance_duals(&self) -> impl Iterator<Item = (&Rc<str>, &TimeSliceID, f64)> {
+    pub fn iter_commodity_balance_duals(
+        &self,
+    ) -> impl Iterator<Item = (&Rc<str>, &TimeSliceID, f64)> {
         // We can get the prices by looking at the dual row values for commodity balance
         // constraints. Each commodity balance constraint applies to a particular time slice
         // selection (depending on time slice level), but we want to return prices for each time
@@ -130,7 +117,7 @@ impl Solution<'_> {
     }
 
     /// Keys and dual values for capacity constraints.
-    fn iter_capacity_duals(&self) -> impl Iterator<Item = (AssetID, &TimeSliceID, f64)> {
+    pub fn iter_capacity_duals(&self) -> impl Iterator<Item = (AssetID, &TimeSliceID, f64)> {
         self.capacity_constraint_keys
             .iter()
             .zip(

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -1,5 +1,6 @@
 //! Code for updating the simulation state.
 use super::optimisation::Solution;
+use crate::agent::AssetPool;
 use crate::model::Model;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use indexmap::IndexMap;
@@ -18,9 +19,9 @@ impl CommodityPrices {
     /// Calculate commodity prices based on the result of the dispatch optimisation.
     ///
     /// Missing prices will be calculated directly from the input data
-    pub fn from_model_and_solution(model: &Model, solution: &Solution) -> Self {
+    pub fn from_model_and_solution(model: &Model, solution: &Solution, assets: &AssetPool) -> Self {
         let mut prices = CommodityPrices::default();
-        let commodities_updated = prices.add_from_solution(solution);
+        let commodities_updated = prices.add_from_solution(solution, assets);
 
         // Find commodities not updated in last step
         let remaining_commodities = model
@@ -41,11 +42,53 @@ impl CommodityPrices {
     /// # Returns
     ///
     /// The set of commodities for which prices were added.
-    fn add_from_solution(&mut self, solution: &Solution) -> HashSet<Rc<str>> {
+    fn add_from_solution(&mut self, solution: &Solution, assets: &AssetPool) -> HashSet<Rc<str>> {
         let mut commodities_updated = HashSet::new();
 
-        for (commodity_id, time_slice, price) in solution.iter_commodity_balance_duals() {
-            self.insert(commodity_id, time_slice, price);
+        // Calculate highest capacity dual for each commodity/timeslice
+        let mut highest_duals: IndexMap<CommodityPriceKey, f64> = IndexMap::new();
+        for (asset_id, time_slice, dual) in solution.iter_capacity_duals() {
+            // Get the asset
+            let asset = assets.get(asset_id).unwrap();
+
+            // Iterate over process pacs
+            let process_pacs = asset.process.iter_pacs();
+            for pac in process_pacs {
+                // Get the commodity
+                let commodity = &pac.commodity;
+
+                // If the commodity flow is positive (produced PAC)
+                if pac.flow > 0.0 {
+                    let key: CommodityPriceKey = (commodity.id.clone(), time_slice.clone());
+                    // Update the highest dual for this commodity/timeslice
+                    highest_duals
+                        .entry(key)
+                        .and_modify(|current_dual| {
+                            if dual > *current_dual {
+                                *current_dual = dual;
+                            }
+                        })
+                        .or_insert(dual);
+                }
+            }
+        }
+
+        // Insert the highest duals into the prices map
+        for ((commodity_id, time_slice), dual) in highest_duals.iter() {
+            self.insert(commodity_id, time_slice, *dual);
+            commodities_updated.insert(Rc::clone(commodity_id));
+        }
+
+        // Combine with commodity balance duals
+        for (commodity_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
+            let key = (Rc::clone(commodity_id), time_slice.clone());
+            let _combined_dual = self
+                .0
+                .entry(key)
+                .and_modify(|current_dual| {
+                    *current_dual += dual;
+                })
+                .or_insert(dual);
             commodities_updated.insert(Rc::clone(commodity_id));
         }
 

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -73,13 +73,13 @@ impl CommodityPrices {
             }
         }
 
-        // Insert the highest duals into the prices map
+        // Insert the highest capacity duals into the prices map
         for ((commodity_id, time_slice), dual) in highest_duals.iter() {
             self.insert(commodity_id, time_slice, *dual);
             commodities_updated.insert(Rc::clone(commodity_id));
         }
 
-        // Combine with commodity balance duals
+        // Sum with the commodity balance duals
         for (commodity_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
             let key = (Rc::clone(commodity_id), time_slice.clone());
             let _combined_dual = self

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -44,7 +44,7 @@ impl CommodityPrices {
     fn add_from_solution(&mut self, solution: &Solution) -> HashSet<Rc<str>> {
         let mut commodities_updated = HashSet::new();
 
-        for (commodity_id, time_slice, price) in solution.iter_commodity_prices() {
+        for (commodity_id, time_slice, price) in solution.iter_commodity_balance_duals() {
             self.insert(commodity_id, time_slice, price);
             commodities_updated.insert(Rc::clone(commodity_id));
         }


### PR DESCRIPTION
# Description

Implements the new commodity price calculation as suggested by @ahawkes in #433 

Main changes to the code:
- created `iter_capacity_duals` to retrieve the dual values for the capacity constraints
- added a check in `add_asset_capacity_constraints` to make sure these constraints are added immediately after the commodity balance constraints
- implemented the new commodity price calculation in `add_from_solution`

I still have a couple of questions:
- should we add capacity constraint duals only for PACs? (I have assumed yes, as I wouldn't think this would apply to side-products such as CO2)
- do we need to do anything different for processes with multiple output commodities? It seems to me that this would have some impact on commodity prices (see [this discussion](https://github.com/EnergySystemsModellingLab/MUSE_OS/issues/551) for MUSE1), although maybe this is already factored into the duals? I have to say I don't have a strong enough grasp on linear algebra at this stage to fully understand this.

I think it's probably ok to leave these as open questions for now, and revisit when we come to look at more complex models

I haven't added any tests, but we currently have no tests anyway for the constraints

Fixes #433 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
