### PR TITLE
Add year field to objectives

### DIFF
--- a/examples/simple/agent_objectives.csv
+++ b/examples/simple/agent_objectives.csv
@@ -1,5 +1,9 @@
-agent_id,objective_type,decision_weight,decision_lexico_tolerance
-A0_GEX,lcox,,
-A0_GPR,lcox,,
-A0_ELC,lcox,,
-A0_RES,eac,,
+agent_id,year,objective_type,decision_weight,decision_lexico_tolerance
+A0_GEX,2020,lcox,,
+A0_GEX,2030,lcox,,
+A0_GPR,2020,lcox,,
+A0_GPR,2030,lcox,,
+A0_ELC,2020,lcox,,
+A0_ELC,2030,lcox,,
+A0_RES,2020,eac,,
+A0_RES,2030,eac,,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -67,6 +67,8 @@ pub enum DecisionRule {
 pub struct AgentObjective {
     /// Unique agent id identifying the agent this objective belongs to
     pub agent_id: String,
+    /// The year the objective is relevant for
+    pub year: u32,
     /// Acronym identifying the objective (e.g. LCOX)
     pub objective_type: ObjectiveType,
     /// For the weighted sum objective, the set of weights to apply to each objective.

--- a/src/input.rs
+++ b/src/input.rs
@@ -214,7 +214,13 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
         &time_slice_info,
         years,
     )?;
-    let agents = read_agents(model_dir.as_ref(), &commodities, &processes, &region_ids)?;
+    let agents = read_agents(
+        model_dir.as_ref(),
+        &commodities,
+        &processes,
+        &region_ids,
+        years,
+    )?;
     let agent_ids = agents.keys().cloned().collect();
     let assets = read_assets(model_dir.as_ref(), &agent_ids, &processes, &region_ids)?;
 

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -57,13 +57,14 @@ pub fn read_agents(
     commodities: &CommodityMap,
     processes: &ProcessMap,
     region_ids: &HashSet<Rc<str>>,
+    milestone_years: &[u32],
 ) -> Result<AgentMap> {
     let process_ids = processes.keys().cloned().collect();
     let mut agents = read_agents_file(model_dir, commodities, &process_ids)?;
     let agent_ids = agents.keys().cloned().collect();
 
     let mut agent_regions = read_agent_regions(model_dir, &agent_ids, region_ids)?;
-    let mut objectives = read_agent_objectives(model_dir, &agents)?;
+    let mut objectives = read_agent_objectives(model_dir, &agents, milestone_years)?;
 
     for (id, agent) in agents.iter_mut() {
         agent.regions = agent_regions.remove(id).unwrap();

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -49,7 +49,7 @@ where
 
         // Check that the year is a valid milestone year
         ensure!(
-            milestone_years.contains(&objective.year),
+            milestone_years.binary_search(&objective.year).is_ok(),
             "Invalid milestone year {}",
             objective.year
         );
@@ -67,13 +67,12 @@ where
             .get(agent_id)
             .with_context(|| format!("Agent {} has no objectives", agent_id))?;
         for &year in milestone_years {
-            if !agent_objectives.iter().any(|obj| obj.year == year) {
-                return Err(anyhow::anyhow!(
-                    "Agent {} is missing objectives for milestone year {}",
-                    agent_id,
-                    year
-                ));
-            }
+            ensure!(
+                agent_objectives.iter().any(|obj| obj.year == year),
+                "Agent {} is missing objectives for milestone year {}",
+                agent_id,
+                year
+            );
         }
     }
 


### PR DESCRIPTION
# Description

This is a nice easy, self-contained change to kick off the plans described in #442 

All I'm doing here is adding a year field to the existing agent_objectives table. The actual work of adding the field is tiny, I just added a `year` attribute to the `AgentObjective` struct, a year column to the csv, and I believe the process of reading in the new data is all automatic.

Most of the work here is to do with validation:
- checking that the year is a valid milestone year
- checking that all agents have at least one objective for each year

I've copied each objective in the table to apply to both 2020 and 2030, but long run we want a better approach (see #444)

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
