### PR TITLE
Add `AnnualField`, implement on `ProcessParameter`

### DIFF
--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,7 +1,7 @@
-process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity,year
-GASDRV,2020,2030,10.0,0.3,2.0,25,0.1,1.0,all
-GASPRC,2020,2030,7.0,0.21,0.5,25,0.1,1.0,all
-WNDFRM,2020,2030,1000.0,30.0,0.4,25,0.1,31.54,all
-GASCGT,2020,2030,700.0,21.0,0.55,30,0.1,31.54,all
-RGASBR,2020,2030,55.56,1.6668,0.16,15,0.1,1.0,all
-RELCHP,2020,2030,138.9,4.167,0.17,15,0.1,1.0,all
+process_id,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity,year
+GASDRV,10.0,0.3,2.0,25,0.1,1.0,all
+GASPRC,7.0,0.21,0.5,25,0.1,1.0,all
+WNDFRM,1000.0,30.0,0.4,25,0.1,31.54,all
+GASCGT,700.0,21.0,0.55,30,0.1,31.54,all
+RGASBR,55.56,1.6668,0.16,15,0.1,1.0,all
+RELCHP,138.9,4.167,0.17,15,0.1,1.0,all

--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,7 +1,7 @@
-process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity
-GASDRV,2020,2030,10.0,0.3,2.0,25,0.1,1.0
-GASPRC,2020,2030,7.0,0.21,0.5,25,0.1,1.0
-WNDFRM,2020,2030,1000.0,30.0,0.4,25,0.1,31.54
-GASCGT,2020,2030,700.0,21.0,0.55,30,0.1,31.54
-RGASBR,2020,2030,55.56,1.6668,0.16,15,0.1,1.0
-RELCHP,2020,2030,138.9,4.167,0.17,15,0.1,1.0
+process_id,start_year,end_year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity,year
+GASDRV,2020,2030,10.0,0.3,2.0,25,0.1,1.0,all
+GASPRC,2020,2030,7.0,0.21,0.5,25,0.1,1.0,all
+WNDFRM,2020,2030,1000.0,30.0,0.4,25,0.1,31.54,all
+GASCGT,2020,2030,700.0,21.0,0.55,30,0.1,31.54,all
+RGASBR,2020,2030,55.56,1.6668,0.16,15,0.1,1.0,all
+RELCHP,2020,2030,138.9,4.167,0.17,15,0.1,1.0,all

--- a/examples/simple/processes.csv
+++ b/examples/simple/processes.csv
@@ -1,7 +1,7 @@
-id,description
-GASDRV,Dry gas extraction
-GASPRC,Gas processing
-WNDFRM,Wind farm
-GASCGT,Gas combined cycle turbine
-RGASBR,Gas boiler
-RELCHP,Heat pump
+id,description,start_year,end_year
+GASDRV,Dry gas extraction,2020,2030
+GASPRC,Gas processing,2020,2030
+WNDFRM,Wind farm,2020,2030
+GASCGT,Gas combined cycle turbine,2020,2030
+RGASBR,Gas boiler,2020,2030
+RELCHP,Heat pump,2020,2030

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -56,10 +56,10 @@ impl Asset {
 
     /// The last year in which this asset should be decommissioned
     pub fn decommission_year(&self) -> u32 {
-        self.commission_year + self.process.parameter.lifetime
+        self.commission_year + self.process.parameter.get(self.commission_year).lifetime
     }
 
-    /// Get the activity limits for this asset in a particular time slice
+    /// Get the activity limits for this asset in a particular time slice and year.
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.activity_limits.get(time_slice).unwrap();
         let max_act = self.maximum_activity();
@@ -70,7 +70,12 @@ impl Asset {
 
     /// Maximum activity for this asset in a year
     pub fn maximum_activity(&self) -> f64 {
-        self.capacity * self.process.parameter.capacity_to_activity
+        self.capacity
+            * self
+                .process
+                .parameter
+                .get(self.commission_year)
+                .capacity_to_activity
     }
 }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -59,7 +59,7 @@ impl Asset {
         self.commission_year + self.process.parameter.get(self.commission_year).lifetime
     }
 
-    /// Get the activity limits for this asset in a particular time slice and year.
+    /// Get the activity limits for this asset in a particular time slice.
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.activity_limits.get(time_slice).unwrap();
         let max_act = self.maximum_activity();

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -59,7 +59,7 @@ impl Asset {
         self.commission_year + self.process.parameter.get(self.commission_year).lifetime
     }
 
-    /// Get the activity limits for this asset in a particular time slice.
+    /// Get the activity limits for this asset in a particular time slice
     pub fn get_activity_limits(&self, time_slice: &TimeSliceID) -> RangeInclusive<f64> {
         let limits = self.process.activity_limits.get(time_slice).unwrap();
         let max_act = self.maximum_activity();
@@ -192,6 +192,7 @@ mod tests {
     use crate::process::{ActivityLimitsMap, FlowType, Process, ProcessFlow, ProcessParameter};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
+    use crate::year::AnnualField;
     use itertools::{assert_equal, Itertools};
     use std::iter;
 
@@ -202,8 +203,6 @@ mod tests {
             time_of_day: "day".into(),
         };
         let process_param = ProcessParameter {
-            process_id: "process1".into(),
-            years: 2010..=2020,
             capital_cost: 5.0,
             fixed_operating_cost: 2.0,
             variable_operating_cost: 1.0,
@@ -232,9 +231,10 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits,
             flows: vec![flow.clone()],
-            parameter: process_param.clone(),
+            parameter: AnnualField::Constant(process_param),
             regions: RegionSelection::All,
         });
         let asset = Asset {
@@ -251,8 +251,6 @@ mod tests {
 
     fn create_asset_pool() -> AssetPool {
         let process_param = ProcessParameter {
-            process_id: "process1".into(),
-            years: 2010..=2020,
             capital_cost: 5.0,
             fixed_operating_cost: 2.0,
             variable_operating_cost: 1.0,
@@ -263,9 +261,10 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
-            parameter: process_param.clone(),
+            parameter: AnnualField::Constant(process_param),
             regions: RegionSelection::All,
         });
         let future = [2020, 2010]

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -94,14 +94,13 @@ mod tests {
     use super::*;
     use crate::process::{ActivityLimitsMap, Process, ProcessParameter};
     use crate::region::RegionSelection;
+    use crate::year::AnnualField;
     use itertools::assert_equal;
     use std::iter;
 
     #[test]
     fn test_read_assets_from_iter() {
         let process_param = ProcessParameter {
-            process_id: "process1".into(),
-            years: 2010..=2020,
             capital_cost: 5.0,
             fixed_operating_cost: 2.0,
             variable_operating_cost: 1.0,
@@ -112,9 +111,10 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
-            parameter: process_param.clone(),
+            parameter: AnnualField::Constant(process_param.clone()),
             regions: RegionSelection::All,
         });
         let processes = [(Rc::clone(&process.id), Rc::clone(&process))]
@@ -187,9 +187,10 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits: ActivityLimitsMap::new(),
             flows: vec![],
-            parameter: process_param,
+            parameter: AnnualField::Constant(process_param),
             regions: RegionSelection::Some(["GBR".into()].into_iter().collect()),
         });
         let asset_in = AssetRaw {

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -290,27 +290,13 @@ mod tests {
     use super::*;
 
     struct ProcessData {
-        descriptions: Vec<ProcessDescription>,
         availabilities: HashMap<Rc<str>, ActivityLimitsMap>,
-        flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
         parameters: HashMap<Rc<str>, AnnualField<ProcessParameter>>,
-        regions: HashMap<Rc<str>, RegionSelection>,
         region_ids: HashSet<Rc<str>>,
     }
 
     /// Returns example data (without errors) for processes
     fn get_process_data() -> ProcessData {
-        let descriptions = vec![
-            ProcessDescription {
-                id: Rc::from("process1"),
-                description: "Process 1".to_string(),
-            },
-            ProcessDescription {
-                id: Rc::from("process2"),
-                description: "Process 2".to_string(),
-            },
-        ];
-
         let availabilities = ["process1", "process2"]
             .into_iter()
             .map(|id| {
@@ -326,91 +312,28 @@ mod tests {
             })
             .collect();
 
-        let flows = ["process1", "process2"]
-            .into_iter()
-            .map(|id| (id.into(), vec![]))
-            .collect();
-
         let parameters = ["process1", "process2"]
             .into_iter()
             .map(|id| {
-                let parameter = ProcessParameter {
+                let parameter = AnnualField::Constant(ProcessParameter {
                     capital_cost: 0.0,
                     fixed_operating_cost: 0.0,
                     variable_operating_cost: 0.0,
                     lifetime: 1,
                     discount_rate: 1.0,
                     capacity_to_activity: 0.0,
-                };
-
+                });
                 (id.into(), parameter)
             })
-            .collect();
-
-        let regions = ["process1", "process2"]
-            .into_iter()
-            .map(|id| (id.into(), RegionSelection::All))
             .collect();
 
         let region_ids = HashSet::from_iter(iter::once("GBR".into()));
 
         ProcessData {
-            descriptions,
             availabilities,
-            flows,
             parameters,
-            regions,
             region_ids,
         }
-    }
-
-    #[test]
-    fn test_create_process_map_success() {
-        let data = get_process_data();
-        let result = create_process_map(
-            data.descriptions.into_iter(),
-            data.availabilities,
-            data.flows,
-            data.parameters,
-            data.regions,
-        )
-        .unwrap();
-
-        assert_eq!(result.len(), 2);
-        assert!(result.contains_key("process1"));
-        assert!(result.contains_key("process2"));
-    }
-
-    /// Generate code for a test with data missing for a given field
-    macro_rules! test_missing {
-        ($field:ident) => {
-            let mut data = get_process_data();
-            data.$field.remove("process1");
-
-            let result = create_process_map(
-                data.descriptions.into_iter(),
-                data.availabilities,
-                data.flows,
-                data.parameters,
-                data.regions,
-            );
-            assert!(result.is_err());
-        };
-    }
-
-    #[test]
-    fn test_create_process_map_missing_availabilities() {
-        test_missing!(availabilities);
-    }
-
-    #[test]
-    fn test_create_process_map_missing_flows() {
-        test_missing!(flows);
-    }
-
-    #[test]
-    fn test_create_process_map_missing_parameters() {
-        test_missing!(parameters);
     }
 
     #[test]

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -82,6 +82,17 @@ pub fn read_processes(
         &availabilities,
     )?;
 
+    // Check parameters cover all years of the process
+    for (id, parameter) in parameters.iter() {
+        let year_range = processes.get(id).unwrap().years.clone();
+        let reference_years: HashSet<u32> = milestone_years
+            .iter()
+            .copied()
+            .filter(|year| year_range.contains(year))
+            .collect();
+        parameter.check_reference(&reference_years)?
+    }
+
     // Add data to Process objects
     for (id, process) in processes.iter_mut() {
         process.activity_limits = availabilities.remove(id).unwrap();

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -4,6 +4,7 @@ use crate::commodity::{Commodity, CommodityMap, CommodityType};
 use crate::process::{ActivityLimitsMap, Process, ProcessFlow, ProcessMap, ProcessParameter};
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceInfo;
+use crate::year::AnnualField;
 use anyhow::{bail, ensure, Context, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -94,7 +95,7 @@ struct ValidationParams<'a> {
     region_ids: &'a HashSet<Rc<str>>,
     milestone_years: &'a [u32],
     time_slice_info: &'a TimeSliceInfo,
-    parameters: &'a HashMap<Rc<str>, ProcessParameter>,
+    parameters: &'a HashMap<Rc<str>, AnnualField<ProcessParameter>>,
     availabilities: &'a HashMap<Rc<str>, ActivityLimitsMap>,
 }
 
@@ -105,7 +106,7 @@ fn validate_commodities(
     region_ids: &HashSet<Rc<str>>,
     milestone_years: &[u32],
     time_slice_info: &TimeSliceInfo,
-    parameters: &HashMap<Rc<str>, ProcessParameter>,
+    parameters: &HashMap<Rc<str>, AnnualField<ProcessParameter>>,
     availabilities: &HashMap<Rc<str>, ActivityLimitsMap>,
 ) -> anyhow::Result<()> {
     let params = ValidationParams {
@@ -180,7 +181,6 @@ fn validate_svd_commodity(
                                 .parameters
                                 .get(&*flow.process_id)
                                 .unwrap()
-                                .years
                                 .contains(&year)
                             && params
                                 .availabilities
@@ -215,7 +215,7 @@ fn create_process_map<I>(
     descriptions: I,
     mut availabilities: HashMap<Rc<str>, ActivityLimitsMap>,
     mut flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
-    mut parameters: HashMap<Rc<str>, ProcessParameter>,
+    mut parameters: HashMap<Rc<str>, AnnualField<ProcessParameter>>,
     mut regions: HashMap<Rc<str>, RegionSelection>,
 ) -> Result<ProcessMap>
 where
@@ -265,7 +265,7 @@ mod tests {
         descriptions: Vec<ProcessDescription>,
         availabilities: HashMap<Rc<str>, ActivityLimitsMap>,
         flows: HashMap<Rc<str>, Vec<ProcessFlow>>,
-        parameters: HashMap<Rc<str>, ProcessParameter>,
+        parameters: HashMap<Rc<str>, AnnualField<ProcessParameter>>,
         regions: HashMap<Rc<str>, RegionSelection>,
         region_ids: HashSet<Rc<str>>,
     }
@@ -307,7 +307,6 @@ mod tests {
             .into_iter()
             .map(|id| {
                 let parameter = ProcessParameter {
-                    process_id: id.to_string(),
                     years: 2010..=2020,
                     capital_cost: 0.0,
                     fixed_operating_cost: 0.0,

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -7,7 +7,6 @@ use ::log::warn;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use std::ops::RangeInclusive;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -16,8 +15,6 @@ const PROCESS_PARAMETERS_FILE_NAME: &str = "process_parameters.csv";
 #[derive(PartialEq, Debug, Deserialize)]
 struct ProcessParameterRaw {
     process_id: String,
-    start_year: Option<u32>,
-    end_year: Option<u32>,
     capital_cost: f64,
     fixed_operating_cost: f64,
     variable_operating_cost: f64,
@@ -30,21 +27,10 @@ struct ProcessParameterRaw {
 define_process_id_getter! {ProcessParameterRaw}
 
 impl ProcessParameterRaw {
-    fn into_parameter(self, year_range: &RangeInclusive<u32>) -> Result<ProcessParameter> {
-        let start_year = self.start_year.unwrap_or(*year_range.start());
-        let end_year = self.end_year.unwrap_or(*year_range.end());
-
-        // Check year range is valid
-        ensure!(
-            start_year <= end_year,
-            "Error in parameter for process {}: start_year > end_year",
-            self.process_id
-        );
-
+    fn into_parameter(self) -> Result<ProcessParameter> {
         self.validate()?;
 
         Ok(ProcessParameter {
-            years: start_year..=end_year,
             capital_cost: self.capital_cost,
             fixed_operating_cost: self.fixed_operating_cost,
             variable_operating_cost: self.variable_operating_cost,
@@ -111,18 +97,15 @@ impl ProcessParameterRaw {
 pub fn read_process_parameters(
     model_dir: &Path,
     process_ids: &HashSet<Rc<str>>,
-    year_range: &RangeInclusive<u32>,
 ) -> Result<HashMap<Rc<str>, AnnualField<ProcessParameter>>> {
     let file_path = model_dir.join(PROCESS_PARAMETERS_FILE_NAME);
     let iter = read_csv::<ProcessParameterRaw>(&file_path)?;
-    read_process_parameters_from_iter(iter, process_ids, year_range)
-        .with_context(|| input_err_msg(&file_path))
+    read_process_parameters_from_iter(iter, process_ids).with_context(|| input_err_msg(&file_path))
 }
 
 fn read_process_parameters_from_iter<I>(
     iter: I,
     process_ids: &HashSet<Rc<str>>,
-    year_range: &RangeInclusive<u32>,
 ) -> Result<HashMap<Rc<str>, AnnualField<ProcessParameter>>>
 where
     I: Iterator<Item = ProcessParameterRaw>,
@@ -131,7 +114,7 @@ where
     for param_raw in iter {
         let id = process_ids.get_id(&param_raw.process_id)?;
         let year = param_raw.year;
-        let param = param_raw.into_parameter(year_range)?;
+        let param = param_raw.into_parameter()?;
 
         // Create AnnualField
         let annual_field = match year {
@@ -154,16 +137,12 @@ mod tests {
     use super::*;
 
     fn create_param_raw(
-        start_year: Option<u32>,
-        end_year: Option<u32>,
         lifetime: u32,
         discount_rate: Option<f64>,
         capacity_to_activity: Option<f64>,
     ) -> ProcessParameterRaw {
         ProcessParameterRaw {
             process_id: "id".to_string(),
-            start_year,
-            end_year,
             capital_cost: 0.0,
             fixed_operating_cost: 0.0,
             variable_operating_cost: 0.0,
@@ -174,13 +153,8 @@ mod tests {
         }
     }
 
-    fn create_param(
-        years: RangeInclusive<u32>,
-        discount_rate: f64,
-        capacity_to_activity: f64,
-    ) -> ProcessParameter {
+    fn create_param(discount_rate: f64, capacity_to_activity: f64) -> ProcessParameter {
         ProcessParameter {
-            years,
             capital_cost: 0.0,
             fixed_operating_cost: 0.0,
             variable_operating_cost: 0.0,
@@ -192,116 +166,50 @@ mod tests {
 
     #[test]
     fn test_param_raw_into_param_ok() {
-        let year_range = 2000..=2100;
-
         // No missing values
-        let raw = create_param_raw(Some(2010), Some(2020), 1, Some(1.0), Some(0.0));
-        assert_eq!(
-            raw.into_parameter(&year_range).unwrap(),
-            create_param(2010..=2020, 1.0, 0.0)
-        );
-
-        // Missing years
-        let raw = create_param_raw(None, None, 1, Some(1.0), Some(0.0));
-        assert_eq!(
-            raw.into_parameter(&year_range).unwrap(),
-            create_param(2000..=2100, 1.0, 0.0)
-        );
+        let raw = create_param_raw(1, Some(1.0), Some(0.0));
+        assert_eq!(raw.into_parameter().unwrap(), create_param(1.0, 0.0));
 
         // Missing discount_rate
-        let raw = create_param_raw(Some(2010), Some(2020), 1, None, Some(0.0));
-        assert_eq!(
-            raw.into_parameter(&year_range).unwrap(),
-            create_param(2010..=2020, 0.0, 0.0)
-        );
+        let raw = create_param_raw(1, None, Some(0.0));
+        assert_eq!(raw.into_parameter().unwrap(), create_param(0.0, 0.0));
 
         // Missing capacity_to_activity
-        let raw = create_param_raw(Some(2010), Some(2020), 1, Some(1.0), None);
-        assert_eq!(
-            raw.into_parameter(&year_range).unwrap(),
-            create_param(2010..=2020, 1.0, 1.0)
-        );
-    }
-
-    #[test]
-    fn test_param_raw_into_param_good_years() {
-        let year_range = 2000..=2100;
-
-        // Normal case
-        assert!(
-            create_param_raw(Some(2000), Some(2100), 1, Some(1.0), Some(0.0))
-                .into_parameter(&year_range)
-                .is_ok()
-        );
-
-        // start_year out of range - this is permitted
-        assert!(
-            create_param_raw(Some(1999), Some(2100), 1, Some(1.0), Some(0.0))
-                .into_parameter(&year_range)
-                .is_ok()
-        );
-
-        // end_year out of range - this is permitted
-        assert!(
-            create_param_raw(Some(2000), Some(2101), 1, Some(1.0), Some(0.0))
-                .into_parameter(&year_range)
-                .is_ok()
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_param_raw_into_param_bad_years() {
-        let year_range = 2000..=2100;
-
-        // start_year after end_year
-        assert!(
-            create_param_raw(Some(2001), Some(2000), 1, Some(1.0), Some(0.0))
-                .into_parameter(&year_range)
-                .is_ok()
-        );
+        let raw = create_param_raw(1, Some(1.0), None);
+        assert_eq!(raw.into_parameter().unwrap(), create_param(1.0, 1.0));
     }
 
     #[test]
     fn test_param_raw_validate_bad_lifetime() {
         // lifetime = 0
-        assert!(
-            create_param_raw(Some(2000), Some(2100), 0, Some(1.0), Some(0.0))
-                .validate()
-                .is_err()
-        );
+        assert!(create_param_raw(0, Some(1.0), Some(0.0))
+            .validate()
+            .is_err());
     }
 
     #[test]
     fn test_param_raw_validate_bad_discount_rate() {
         // discount rate = -1
-        assert!(
-            create_param_raw(Some(2000), Some(2100), 0, Some(-1.0), Some(0.0))
-                .validate()
-                .is_err()
-        );
+        assert!(create_param_raw(0, Some(-1.0), Some(0.0))
+            .validate()
+            .is_err());
     }
 
     #[test]
     fn test_param_raw_validate_bad_capt2act() {
         // capt2act = -1
-        assert!(
-            create_param_raw(Some(2000), Some(2100), 0, Some(1.0), Some(-1.0))
-                .validate()
-                .is_err()
-        );
+        assert!(create_param_raw(0, Some(1.0), Some(-1.0))
+            .validate()
+            .is_err());
     }
 
     #[test]
     fn test_read_process_parameters_from_iter_good() {
-        let year_range = 2000..=2100;
         let process_ids = ["A".into(), "B".into()].into_iter().collect();
 
         let params_raw = [
             ProcessParameterRaw {
                 process_id: "A".into(),
-                start_year: Some(2010),
-                end_year: Some(2020),
                 capital_cost: 1.0,
                 fixed_operating_cost: 1.0,
                 variable_operating_cost: 1.0,
@@ -312,8 +220,6 @@ mod tests {
             },
             ProcessParameterRaw {
                 process_id: "B".into(),
-                start_year: Some(2015),
-                end_year: Some(2020),
                 capital_cost: 1.0,
                 fixed_operating_cost: 1.0,
                 variable_operating_cost: 1.0,
@@ -328,7 +234,6 @@ mod tests {
             (
                 "A".into(),
                 AnnualField::Constant(ProcessParameter {
-                    years: 2010..=2020,
                     capital_cost: 1.0,
                     fixed_operating_cost: 1.0,
                     variable_operating_cost: 1.0,
@@ -340,7 +245,6 @@ mod tests {
             (
                 "B".into(),
                 AnnualField::Constant(ProcessParameter {
-                    years: 2015..=2020,
                     capital_cost: 1.0,
                     fixed_operating_cost: 1.0,
                     variable_operating_cost: 1.0,
@@ -353,21 +257,17 @@ mod tests {
         .into_iter()
         .collect();
         let actual =
-            read_process_parameters_from_iter(params_raw.into_iter(), &process_ids, &year_range)
-                .unwrap();
+            read_process_parameters_from_iter(params_raw.into_iter(), &process_ids).unwrap();
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn test_read_process_parameters_from_iter_bad_multiple_params() {
-        let year_range = 2000..=2100;
         let process_ids = ["A".into(), "B".into()].into_iter().collect();
 
         let params_raw = [
             ProcessParameterRaw {
                 process_id: "A".into(),
-                start_year: Some(2010),
-                end_year: Some(2020),
                 capital_cost: 1.0,
                 fixed_operating_cost: 1.0,
                 variable_operating_cost: 1.0,
@@ -378,8 +278,6 @@ mod tests {
             },
             ProcessParameterRaw {
                 process_id: "B".into(),
-                start_year: Some(2015),
-                end_year: Some(2020),
                 capital_cost: 1.0,
                 fixed_operating_cost: 1.0,
                 variable_operating_cost: 1.0,
@@ -390,8 +288,6 @@ mod tests {
             },
             ProcessParameterRaw {
                 process_id: "A".into(),
-                start_year: Some(2015),
-                end_year: Some(2020),
                 capital_cost: 1.0,
                 fixed_operating_cost: 1.0,
                 variable_operating_cost: 1.0,
@@ -402,11 +298,6 @@ mod tests {
             },
         ];
 
-        assert!(read_process_parameters_from_iter(
-            params_raw.into_iter(),
-            &process_ids,
-            &year_range
-        )
-        .is_err());
+        assert!(read_process_parameters_from_iter(params_raw.into_iter(), &process_ids,).is_err());
     }
 }

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -113,13 +113,18 @@ where
     let mut params: HashMap<Rc<str>, AnnualField<ProcessParameter>> = HashMap::new();
     for param_raw in iter {
         let id = process_ids.get_id(&param_raw.process_id)?;
-        let year = param_raw.year;
+        let year = param_raw.year.clone();
         let param = param_raw.into_parameter()?;
 
         // Create AnnualField
         let annual_field = match year {
             Year::All => AnnualField::Constant(param),
-            Year::Single(year) => AnnualField::Variable([(year, param)].into_iter().collect()),
+            Year::Single(year) => {
+                AnnualField::Variable([(year, param.clone())].into_iter().collect())
+            }
+            Year::Some(years) => {
+                AnnualField::Variable(years.iter().map(|y| (*y, param.clone())).collect())
+            }
         };
 
         // Insert into the map

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub mod region;
 pub mod settings;
 pub mod simulation;
 pub mod time_slice;
+pub mod year;

--- a/src/output.rs
+++ b/src/output.rs
@@ -179,6 +179,7 @@ mod tests {
     use crate::process::{Process, ProcessParameter};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceID;
+    use crate::year::AnnualField;
     use itertools::{assert_equal, Itertools};
     use std::{collections::HashMap, iter};
     use tempfile::tempdir;
@@ -189,8 +190,6 @@ mod tests {
         let agent_id = "agent1".into();
         let commission_year = 2015;
         let process_param = ProcessParameter {
-            process_id: "process1".to_string(),
-            years: 2010..=2020,
             capital_cost: 5.0,
             fixed_operating_cost: 2.0,
             variable_operating_cost: 1.0,
@@ -201,9 +200,10 @@ mod tests {
         let process = Rc::new(Process {
             id: Rc::clone(&process_id),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits: HashMap::new(),
             flows: vec![],
-            parameter: process_param.clone(),
+            parameter: AnnualField::Constant(process_param),
             regions: RegionSelection::All,
         });
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,6 +3,7 @@
 use crate::commodity::Commodity;
 use crate::region::RegionSelection;
 use crate::time_slice::TimeSliceID;
+use crate::year::AnnualField;
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
@@ -25,7 +26,7 @@ pub struct Process {
     /// Commodity flows for this process
     pub flows: Vec<ProcessFlow>,
     /// Additional parameters for this process
-    pub parameter: ProcessParameter,
+    pub parameter: AnnualField<ProcessParameter>,
     /// The regions in which this process can operate
     pub regions: RegionSelection,
 }
@@ -93,8 +94,6 @@ pub enum FlowType {
 /// Additional parameters for a process
 #[derive(PartialEq, Clone, Debug, Deserialize)]
 pub struct ProcessParameter {
-    /// A unique identifier for the process
-    pub process_id: String,
     /// The years in which this process is available for investment
     pub years: RangeInclusive<u32>,
     /// Overnight capital cost per unit capacity

--- a/src/process.rs
+++ b/src/process.rs
@@ -21,6 +21,8 @@ pub struct Process {
     pub id: Rc<str>,
     /// A human-readable description for the process (e.g. dry gas extraction)
     pub description: String,
+    /// The years in which this process is available for investment
+    pub years: RangeInclusive<u32>,
     /// The activity limits for each time slice (as a fraction of maximum)
     pub activity_limits: ActivityLimitsMap,
     /// Commodity flows for this process
@@ -94,8 +96,6 @@ pub enum FlowType {
 /// Additional parameters for a process
 #[derive(PartialEq, Clone, Debug, Deserialize)]
 pub struct ProcessParameter {
-    /// The years in which this process is available for investment
-    pub years: RangeInclusive<u32>,
     /// Overnight capital cost per unit capacity
     pub capital_cost: f64,
     /// Annual operating cost per unit capacity

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -250,7 +250,11 @@ fn calculate_cost_coefficient(
 
     // Only applies if commodity is PAC
     if flow.is_pac {
-        coeff += asset.process.parameter.get(year).variable_operating_cost
+        coeff += asset
+            .process
+            .parameter
+            .get(asset.commission_year)
+            .variable_operating_cost
     }
 
     // If there is a user-provided commodity cost for this combination of parameters, include it
@@ -282,6 +286,7 @@ mod tests {
     use crate::process::{ActivityLimitsMap, FlowType, Process, ProcessParameter};
     use crate::region::RegionSelection;
     use crate::time_slice::TimeSliceLevel;
+    use crate::year::AnnualField;
     use float_cmp::assert_approx_eq;
     use std::rc::Rc;
 
@@ -291,8 +296,6 @@ mod tests {
         costs: CommodityCostMap,
     ) -> (Asset, ProcessFlow) {
         let process_param = ProcessParameter {
-            process_id: "process1".into(),
-            years: 2010..=2020,
             capital_cost: 5.0,
             fixed_operating_cost: 2.0,
             variable_operating_cost: 1.0,
@@ -319,9 +322,10 @@ mod tests {
         let process = Rc::new(Process {
             id: "process1".into(),
             description: "Description".into(),
+            years: 2010..=2020,
             activity_limits: ActivityLimitsMap::new(),
             flows: vec![flow.clone()],
-            parameter: process_param.clone(),
+            parameter: AnnualField::Constant(process_param),
             regions: RegionSelection::All,
         });
         let asset = Asset::new(

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -250,7 +250,7 @@ fn calculate_cost_coefficient(
 
     // Only applies if commodity is PAC
     if flow.is_pac {
-        coeff += asset.process.parameter.variable_operating_cost
+        coeff += asset.process.parameter.get(year).variable_operating_cost
     }
 
     // If there is a user-provided commodity cost for this combination of parameters, include it

--- a/src/year.rs
+++ b/src/year.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub enum AnnualField<T> {
+    Empty,
     Constant(T),
     Variable(HashMap<u32, T>),
 }
@@ -13,6 +14,7 @@ pub enum AnnualField<T> {
 impl<T: Clone> AnnualField<T> {
     pub fn get(&self, year: u32) -> &T {
         match self {
+            AnnualField::Empty => panic!("AnnualField is empty."),
             AnnualField::Constant(value) => value,
             AnnualField::Variable(values) => values.get(&year).unwrap(),
         }
@@ -29,6 +31,10 @@ impl<T: Clone> AnnualField<T> {
                 }
                 values.insert(year, value);
                 Ok(())
+            }
+            AnnualField::Empty => {
+                *self = AnnualField::Variable(HashMap::new());
+                self.insert(year, value)
             }
         }
     }
@@ -53,6 +59,7 @@ impl<T: Clone> AnnualField<T> {
 
     pub fn contains(&self, year: &u32) -> bool {
         match self {
+            AnnualField::Empty => false,
             AnnualField::Constant(_) => true,
             AnnualField::Variable(values) => values.contains_key(year),
         }
@@ -60,6 +67,9 @@ impl<T: Clone> AnnualField<T> {
 
     pub fn check_reference(&self, reference_years: &HashSet<u32>) -> Result<()> {
         match self {
+            AnnualField::Empty => {
+                bail!("AnnualField is empty. Cannot check reference years.");
+            }
             AnnualField::Constant(_) => Ok(()),
             AnnualField::Variable(_) => {
                 for year in reference_years.iter() {

--- a/src/year.rs
+++ b/src/year.rs
@@ -83,10 +83,11 @@ impl<T: Clone> AnnualField<T> {
     }
 }
 
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Year {
     All,
     Single(u32),
+    Some(HashSet<u32>),
 }
 
 pub fn deserialize_year<'de, D>(deserialiser: D) -> Result<Year, D::Error>
@@ -95,10 +96,18 @@ where
 {
     let value = String::deserialize(deserialiser)?;
     if value == "all" {
+        // "all" years specified
         Ok(Year::All)
     } else if let Ok(n) = value.parse::<u32>() {
+        // Single year specified
         Ok(Year::Single(n))
     } else {
-        Err(serde::de::Error::custom("Invalid year format"))
+        // Semicolon-separated list of years
+        let years: Result<HashSet<u32>, _> =
+            value.split(';').map(|s| s.trim().parse::<u32>()).collect();
+        match years {
+            Ok(years_set) if !years_set.is_empty() => Ok(Year::Some(years_set)),
+            _ => Err(serde::de::Error::custom("Invalid year format")),
+        }
     }
 }

--- a/src/year.rs
+++ b/src/year.rs
@@ -1,0 +1,94 @@
+#![allow(missing_docs)]
+use anyhow::{bail, Result};
+use serde::de::Deserializer;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub enum AnnualField<T> {
+    Constant(T),
+    Variable(HashMap<u32, T>),
+}
+
+impl<T: Clone> AnnualField<T> {
+    pub fn get(&self, year: u32) -> &T {
+        match self {
+            AnnualField::Constant(value) => value,
+            AnnualField::Variable(values) => values.get(&year).unwrap(),
+        }
+    }
+
+    pub fn insert(&mut self, year: u32, value: T) -> Result<()> {
+        match self {
+            AnnualField::Constant(_) => {
+                bail!("Cannot insert into a constant field.");
+            }
+            AnnualField::Variable(values) => {
+                if values.contains_key(&year) {
+                    bail!("Year {} already exists in variable field.", year);
+                }
+                values.insert(year, value);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn merge(&mut self, other: &Self) -> Result<()> {
+        match (self, other) {
+            (AnnualField::Variable(values), AnnualField::Variable(other_values)) => {
+                for (year, value) in other_values.iter() {
+                    if values.contains_key(year) {
+                        bail!("Year {} already exists in variable field.", year);
+                    }
+                    values.insert(*year, value.clone());
+                }
+                Ok(())
+            }
+            (AnnualField::Constant(_), AnnualField::Constant(_)) => {
+                bail!("Cannot merge two constant fields.")
+            }
+            _ => bail!("Cannot merge constant and variable fields."),
+        }
+    }
+
+    pub fn contains(&self, year: &u32) -> bool {
+        match self {
+            AnnualField::Constant(_) => true,
+            AnnualField::Variable(values) => values.contains_key(year),
+        }
+    }
+
+    pub fn check_reference(&self, reference_years: &HashSet<u32>) -> Result<()> {
+        match self {
+            AnnualField::Constant(_) => Ok(()),
+            AnnualField::Variable(_) => {
+                for year in reference_years.iter() {
+                    if !self.contains(year) {
+                        bail!("Missing data for year {}.", year);
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum Year {
+    All,
+    Single(u32),
+}
+
+pub fn deserialize_year<'de, D>(deserialiser: D) -> Result<Year, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserialiser)?;
+    if value == "all" {
+        Ok(Year::All)
+    } else if let Ok(n) = value.parse::<u32>() {
+        Ok(Year::Single(n))
+    } else {
+        Err(serde::de::Error::custom("Invalid year format"))
+    }
+}


### PR DESCRIPTION
# Description

To do:
- need an informative error message if parameter/flows etc. are not specified for a process (currently just panics without a helpful message). This was the job of `create_process_map`, but it's possible that we do this instead when reading in the respective tables. Also need tests for this
- possibly get rid of `Year::Single` as `Year::Some` can work for single years
- rename `Year` to `YearSelection`
- `AnnualQuantity.check_reference()` should also complain if it contains data not found in the reference
- Add tests to `year.rs`
- Add tests where parameters are specified outside the years of the process, or incomplete years specified
- Possibly replace `Process.years` with a set of years rather than `RangeInclusive` - might make some of the other code easier
- Add docstrings to `year.rs`
- Audit privacy of all new/modified objects/functions
- Error messages in `year.rs` are not very helpful as they give no context. Need to propagate the error upwards and add context
- Possibly store a set of permissible keys when creating the object, then make sure that only these keys can be inserted, and then don't need to pass anything when calling `check_reference`

Fixes #444 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
