### PR TITLE
Calculate commodity prices per region

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -89,6 +89,7 @@ struct CommodityPriceRow {
     milestone_year: u32,
     commodity_id: CommodityID,
     time_slice: String,
+    region_id: RegionID,
     price: f64,
 }
 
@@ -153,11 +154,12 @@ impl DataWriter {
 
     /// Write commodity prices to a CSV file
     pub fn write_prices(&mut self, milestone_year: u32, prices: &CommodityPrices) -> Result<()> {
-        for (commodity_id, time_slice, price) in prices.iter() {
+        for (commodity_id, time_slice, region_id, price) in prices.iter() {
             let row = CommodityPriceRow {
                 milestone_year,
                 commodity_id: commodity_id.clone(),
                 time_slice: time_slice.to_string(),
+                region_id: region_id.clone(),
                 price,
             };
             self.prices_writer.serialize(row)?;

--- a/src/output.rs
+++ b/src/output.rs
@@ -286,6 +286,7 @@ mod tests {
     #[test]
     fn test_write_prices() {
         let commodity_id = "commodity1".into();
+        let region_id = "GBR".into();
         let time_slice = TimeSliceID {
             season: "winter".into(),
             time_of_day: "day".into(),
@@ -293,7 +294,7 @@ mod tests {
         let milestone_year = 2020;
         let price = 42.0;
         let mut prices = CommodityPrices::default();
-        prices.insert(&commodity_id, &time_slice, price);
+        prices.insert(&commodity_id, &time_slice, &region_id, price);
 
         let dir = tempdir().unwrap();
 
@@ -309,6 +310,7 @@ mod tests {
             commodity_id,
             milestone_year,
             time_slice: time_slice.to_string(),
+            region_id,
             price,
         };
         let records: Vec<CommodityPriceRow> =

--- a/src/output.rs
+++ b/src/output.rs
@@ -88,8 +88,8 @@ struct CommodityFlowRow {
 struct CommodityPriceRow {
     milestone_year: u32,
     commodity_id: CommodityID,
-    time_slice: String,
     region_id: RegionID,
+    time_slice: String,
     price: f64,
 }
 
@@ -154,12 +154,12 @@ impl DataWriter {
 
     /// Write commodity prices to a CSV file
     pub fn write_prices(&mut self, milestone_year: u32, prices: &CommodityPrices) -> Result<()> {
-        for (commodity_id, time_slice, region_id, price) in prices.iter() {
+        for (commodity_id, region_id, time_slice, price) in prices.iter() {
             let row = CommodityPriceRow {
                 milestone_year,
                 commodity_id: commodity_id.clone(),
-                time_slice: time_slice.to_string(),
                 region_id: region_id.clone(),
+                time_slice: time_slice.to_string(),
                 price,
             };
             self.prices_writer.serialize(row)?;
@@ -294,7 +294,7 @@ mod tests {
         let milestone_year = 2020;
         let price = 42.0;
         let mut prices = CommodityPrices::default();
-        prices.insert(&commodity_id, &time_slice, &region_id, price);
+        prices.insert(&commodity_id, &region_id, &time_slice, price);
 
         let dir = tempdir().unwrap();
 
@@ -307,10 +307,10 @@ mod tests {
 
         // Read back and compare
         let expected = CommodityPriceRow {
-            commodity_id,
             milestone_year,
-            time_slice: time_slice.to_string(),
+            commodity_id,
             region_id,
+            time_slice: time_slice.to_string(),
             price,
         };
         let records: Vec<CommodityPriceRow> =

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -5,6 +5,7 @@ use crate::asset::{Asset, AssetID, AssetPool};
 use crate::commodity::{BalanceType, CommodityID};
 use crate::model::Model;
 use crate::process::ProcessFlow;
+use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use anyhow::{anyhow, Result};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
@@ -81,17 +82,17 @@ impl Solution<'_> {
     /// Keys and dual values for commodity balance constraints.
     pub fn iter_commodity_balance_duals(
         &self,
-    ) -> impl Iterator<Item = (&CommodityID, &TimeSliceID, f64)> {
+    ) -> impl Iterator<Item = (&CommodityID, &TimeSliceID, &RegionID, f64)> {
         // Each commodity balance constraint applies to a particular time slice
         // selection (depending on time slice level). Where this covers multiple timeslices,
         // we return the same dual for each individual timeslice.
         self.commodity_balance_constraint_keys
             .iter()
             .zip(self.solution.dual_rows())
-            .flat_map(|((commodity_id, ts_selection), price)| {
+            .flat_map(|((commodity_id, ts_selection, region_id), price)| {
                 self.time_slice_info
                     .iter_selection(ts_selection)
-                    .map(move |(ts, _)| (commodity_id, ts, *price))
+                    .map(move |(ts, _)| (commodity_id, ts, region_id, *price))
             })
     }
 

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -82,17 +82,17 @@ impl Solution<'_> {
     /// Keys and dual values for commodity balance constraints.
     pub fn iter_commodity_balance_duals(
         &self,
-    ) -> impl Iterator<Item = (&CommodityID, &TimeSliceID, &RegionID, f64)> {
+    ) -> impl Iterator<Item = (&CommodityID, &RegionID, &TimeSliceID, f64)> {
         // Each commodity balance constraint applies to a particular time slice
         // selection (depending on time slice level). Where this covers multiple timeslices,
         // we return the same dual for each individual timeslice.
         self.commodity_balance_constraint_keys
             .iter()
             .zip(self.solution.dual_rows())
-            .flat_map(|((commodity_id, ts_selection, region_id), price)| {
+            .flat_map(|((commodity_id, region_id, ts_selection), price)| {
                 self.time_slice_info
                     .iter_selection(ts_selection)
-                    .map(move |(ts, _)| (commodity_id, ts, region_id, *price))
+                    .map(move |(ts, _)| (commodity_id, region_id, ts, *price))
             })
     }
 

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use super::VariableMap;
 
 /// Indicates the commodity ID and time slice selection covered by each commodity balance constraint
-pub type CommodityBalanceConstraintKeys = Vec<(CommodityID, TimeSliceSelection, RegionID)>;
+pub type CommodityBalanceConstraintKeys = Vec<(CommodityID, RegionID, TimeSliceSelection)>;
 
 /// Indicates the asset ID and time slice covered by each capacity constraint
 pub type CapacityConstraintKeys = Vec<(AssetID, TimeSliceID)>;
@@ -137,7 +137,7 @@ fn add_commodity_balance_constraints(
                 problem.add_row(rhs..=rhs, terms.drain(0..));
 
                 // Keep track of the order in which constraints were added
-                keys.push((commodity.id.clone(), ts_selection, region_id.clone()));
+                keys.push((commodity.id.clone(), region_id.clone(), ts_selection));
             }
         }
     }

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -2,6 +2,7 @@
 use crate::asset::{AssetID, AssetPool};
 use crate::commodity::{CommodityID, CommodityType};
 use crate::model::Model;
+use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceSelection};
 use highs::RowProblem as Problem;
 use std::rc::Rc;
@@ -9,7 +10,7 @@ use std::rc::Rc;
 use super::VariableMap;
 
 /// Indicates the commodity ID and time slice selection covered by each commodity balance constraint
-pub type CommodityBalanceConstraintKeys = Vec<(CommodityID, TimeSliceSelection)>;
+pub type CommodityBalanceConstraintKeys = Vec<(CommodityID, TimeSliceSelection, RegionID)>;
 
 /// Indicates the asset ID and time slice covered by each capacity constraint
 pub type CapacityConstraintKeys = Vec<(AssetID, TimeSliceID)>;
@@ -136,7 +137,7 @@ fn add_commodity_balance_constraints(
                 problem.add_row(rhs..=rhs, terms.drain(0..));
 
                 // Keep track of the order in which constraints were added
-                keys.push((commodity.id.clone(), ts_selection));
+                keys.push((commodity.id.clone(), ts_selection, region_id.clone()));
             }
         }
     }

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -112,7 +112,7 @@ impl CommodityPrices {
         }
     }
 
-    /// Insert a price for the given commodity and time slice
+    /// Insert a price for the given commodity, time slice and region
     pub fn insert(
         &mut self,
         commodity_id: &CommodityID,


### PR DESCRIPTION
# Description

Small change to the commodity price calculation so that prices are now calculated separately for each region. I _think_ this is correct, but good to get a second pair of eyes. The results for the example model are unchanged (as this model only has one region anyway)

Fixes #431 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
