### PR TITLE
Extra validation for demand data

### DIFF
--- a/src/input/commodity.rs
+++ b/src/input/commodity.rs
@@ -46,7 +46,7 @@ pub fn read_commodities(
 
     let mut demand = read_demand(
         model_dir,
-        &commodity_ids,
+        &commodities,
         region_ids,
         time_slice_info,
         milestone_years,

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -154,13 +154,12 @@ where
                 }
             }
         }
-        if !missing_keys.is_empty() {
-            return Err(anyhow::anyhow!(
-                "Commodity {} is missing demand data for {:?}",
-                commodity_id,
-                missing_keys
-            ));
-        }
+        ensure!(
+            missing_keys.is_empty(),
+            "Commodity {} is missing demand data for {:?}",
+            commodity_id,
+            missing_keys
+        );
     }
 
     Ok(map)

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -210,7 +210,6 @@ fn compute_demand_maps(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use itertools::iproduct;
     use std::fs::File;
     use std::io::Write;
     use std::iter;
@@ -413,11 +412,8 @@ COM1,West,2020,13"
             (("COM1".into(), "East".into(), 2020), 12.0),
             (("COM1".into(), "West".into(), 2020), 13.0),
         ]);
-        let (demand, commodity_regions) =
+        let demand =
             read_demand_file(dir.path(), &commodity_ids, &region_ids, &milestone_years).unwrap();
-        let commodity_regions_expected =
-            iproduct!(commodity_ids.iter().cloned(), region_ids.iter().cloned()).collect();
         assert_eq!(demand, expected);
-        assert_eq!(commodity_regions, commodity_regions_expected);
     }
 }

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -113,7 +113,7 @@ where
             .get_id_by_str(&demand.commodity_id)
             .with_context(|| {
                 format!(
-                    "Can only provide demand for SVD commodities. Found entry for '{}'",
+                    "Can only provide demand data for SVD commodities. Found entry for '{}'",
                     demand.commodity_id
                 )
             })?;

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -139,7 +139,6 @@ fn validate_demand_slices(
 mod tests {
     use super::*;
     use crate::time_slice::TimeSliceID;
-    use itertools::iproduct;
     use std::iter;
 
     #[test]
@@ -159,8 +158,6 @@ mod tests {
         };
         let commodity_ids = HashSet::from_iter(iter::once("COM1".into()));
         let region_ids = HashSet::from_iter(iter::once("GBR".into()));
-        let commodity_regions =
-            iproduct!(commodity_ids.iter().cloned(), region_ids.iter().cloned()).collect();
 
         // Valid
         let demand_slice = DemandSlice {
@@ -179,7 +176,6 @@ mod tests {
                 iter::once(demand_slice.clone()),
                 &commodity_ids,
                 &region_ids,
-                &commodity_regions,
                 &time_slice_info,
             )
             .unwrap(),
@@ -289,7 +285,6 @@ mod tests {
                     demand_slices.into_iter(),
                     &commodity_ids,
                     &region_ids,
-                    &commodity_regions,
                     &time_slice_info,
                 )
                 .unwrap(),
@@ -302,7 +297,6 @@ mod tests {
             iter::empty(),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -318,7 +312,6 @@ mod tests {
             iter::once(demand_slice.clone()),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -334,7 +327,6 @@ mod tests {
             iter::once(demand_slice.clone()),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -350,7 +342,6 @@ mod tests {
             iter::once(demand_slice.clone()),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -389,7 +380,6 @@ mod tests {
                 iter::once(demand_slice.clone()),
                 &commodity_ids,
                 &region_ids,
-                &commodity_regions,
                 &time_slice_info,
             )
             .is_err());
@@ -406,7 +396,6 @@ mod tests {
             iter::repeat_n(demand_slice.clone(), 2),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -422,7 +411,6 @@ mod tests {
             [demand_slice, demand_slice_season].into_iter(),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
             &time_slice_info,
         )
         .is_err());
@@ -438,23 +426,6 @@ mod tests {
             iter::once(demand_slice),
             &commodity_ids,
             &region_ids,
-            &commodity_regions,
-            &time_slice_info,
-        )
-        .is_err());
-
-        // No corresponding entry for commodity + region in demand CSV file
-        let demand_slice = DemandSlice {
-            commodity_id: "COM1".into(),
-            region_id: "GBR".into(),
-            time_slice: "winter".into(),
-            fraction: 1.0,
-        };
-        assert!(read_demand_slices_from_iter(
-            iter::once(demand_slice),
-            &commodity_ids,
-            &region_ids,
-            &HashSet::new(),
             &time_slice_info,
         )
         .is_err());

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -1,6 +1,5 @@
 //! Demand slicing determines how annual demand is distributed across the year.
 use super::super::*;
-use super::demand::*;
 use crate::commodity::CommodityID;
 use crate::id::IDCollection;
 use crate::region::RegionID;
@@ -36,18 +35,16 @@ pub type DemandSliceMap = HashMap<(CommodityID, RegionID, TimeSliceID), f64>;
 /// * `time_slice_info` - Information about seasons and times of day
 pub fn read_demand_slices(
     model_dir: &Path,
-    commodity_ids: &HashSet<CommodityID>,
+    svd_commodity_ids: &HashSet<CommodityID>,
     region_ids: &HashSet<RegionID>,
-    commodity_regions: &CommodityRegionPairs,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap> {
     let file_path = model_dir.join(DEMAND_SLICING_FILE_NAME);
     let demand_slices_csv = read_csv(&file_path)?;
     read_demand_slices_from_iter(
         demand_slices_csv,
-        commodity_ids,
+        svd_commodity_ids,
         region_ids,
-        commodity_regions,
         time_slice_info,
     )
     .with_context(|| input_err_msg(file_path))
@@ -56,9 +53,8 @@ pub fn read_demand_slices(
 /// Read demand slices from an iterator
 fn read_demand_slices_from_iter<I>(
     iter: I,
-    commodity_ids: &HashSet<CommodityID>,
+    svd_commodity_ids: &HashSet<CommodityID>,
     region_ids: &HashSet<RegionID>,
-    commodity_regions: &CommodityRegionPairs,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap>
 where
@@ -67,13 +63,8 @@ where
     let mut demand_slices = DemandSliceMap::new();
 
     for slice in iter {
-        let commodity_id = commodity_ids.get_id_by_str(&slice.commodity_id)?;
+        let commodity_id = svd_commodity_ids.get_id_by_str(&slice.commodity_id)?;
         let region_id = region_ids.get_id_by_str(&slice.region_id)?;
-        ensure!(
-            commodity_regions.contains(&(commodity_id.clone(), region_id.clone())),
-            "Demand slicing provided for commodity {commodity_id} in region {region_id} \
-            without a corresponding entry in demand CSV file"
-        );
 
         // We need to know how many time slices are covered by the current demand slice entry and
         // how long they are relative to one another so that we can divide up the demand for this
@@ -89,7 +80,12 @@ where
         }
     }
 
-    validate_demand_slices(commodity_regions, &demand_slices, time_slice_info)?;
+    validate_demand_slices(
+        svd_commodity_ids,
+        region_ids,
+        &demand_slices,
+        time_slice_info,
+    )?;
 
     Ok(demand_slices)
 }
@@ -99,14 +95,18 @@ where
 /// Specifically, check:
 ///
 /// * It is non-empty
-/// * If an entry is provided for any commodity + region pair, there must be entries covering every
-///   time slice
+/// * For every commodity + region pair, there must be entries covering every time slice
 /// * The demand fractions for all entries related to a commodity + region pair sum to one
 fn validate_demand_slices(
-    commodity_regions: &CommodityRegionPairs,
+    svd_commodity_ids: &HashSet<CommodityID>,
+    region_ids: &HashSet<RegionID>,
     demand_slices: &DemandSliceMap,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<()> {
+    let commodity_regions = svd_commodity_ids
+        .iter()
+        .cartesian_product(region_ids.iter())
+        .collect::<HashSet<_>>();
     for (commodity_id, region_id) in commodity_regions {
         time_slice_info
             .iter_ids()

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -63,7 +63,14 @@ where
     let mut demand_slices = DemandSliceMap::new();
 
     for slice in iter {
-        let commodity_id = svd_commodity_ids.get_id_by_str(&slice.commodity_id)?;
+        let commodity_id = svd_commodity_ids
+            .get_id_by_str(&slice.commodity_id)
+            .with_context(|| {
+                format!(
+                    "Can only provide demand slice data for SVD commodities. Found entry for '{}'",
+                    slice.commodity_id
+                )
+            })?;
         let region_id = region_ids.get_id_by_str(&slice.region_id)?;
 
         // We need to know how many time slices are covered by the current demand slice entry and


### PR DESCRIPTION
# Description

Making sure that all SVD commodities have demand data provided, and ensuring that demand is not provided for non-SVD commodities.

I'm mandating that all SVD commodities have demand data for every region, year and time slice. We can maybe revisit this later as a user experience thing if users get frustrated having to add a load of zeros into their files, but I think this is the safest option for now. Will be easier once we've added "all" options for year and region

Fixes #365 
Fixes #366 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
