### PR TITLE
Add config files to allow developing in a container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+    "name": "MUSE 2.0",
+    "build": {
+        "context": "..",
+        "dockerfile": "../Dockerfile"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM alpine:3.21
 
-# Build C++ code with clang
-ENV CXX=clang++
-
 # Install dependencies. We need a C++ toolchain to compile the highs crate.
-RUN apk add --no-cache cargo cmake binutils make clang clang19-libclang git mdbook
+RUN apk add --no-cache cargo cmake binutils make g++ clang19-libclang git mdbook

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.21
 
 # Install dependencies. We need a C++ toolchain to compile the highs crate.
-RUN apk add --no-cache cargo cmake binutils make g++ clang19-libclang git mdbook
+RUN apk add --no-cache cargo rustfmt cmake binutils make g++ clang19-libclang git mdbook

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.21
+
+# Build C++ code with clang
+ENV CXX=clang++
+
+# Install dependencies. We need a C++ toolchain to compile the highs crate.
+RUN apk add --no-cache cargo cmake binutils make clang clang19-libclang git mdbook


### PR DESCRIPTION
# Description

I'm currently not able to build MUSE2 on my machine because of #517. I've opened a PR upstream and hopefully that fix will trickle down to us soon. I can probably work around it, but I thought it might be useful to have some container config files to make it easy to get a working toolchain.

The container currently includes all the dependencies needed to build MUSE2 as well as `git` and `mdbook`. I couldn't get `cargo-llvm-cov` or `pre-commit` to work so left those out for now.

In future, it could be handy to add extra Python dependencies for running sample analysis scripts etc. We could also run our CI tests on this image at some point, if we can be bothered.