### PR TITLE
Allow user to choose output directory

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,7 +28,6 @@ pub struct Cli {
 pub enum Commands {
     /// Run a simulation model.
     Run {
-        #[arg(help = "Path to the model directory")]
         /// Path to the model directory.
         model_dir: PathBuf,
     },

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 //! The command line interface for the simulation.
 use crate::input::load_model;
 use crate::log;
-use crate::output::create_output_directory;
+use crate::output::{create_output_directory, get_output_dir};
 use crate::settings::Settings;
 use ::log::{error, info};
 use anyhow::{ensure, Context, Result};
@@ -64,8 +64,8 @@ pub fn handle_run_command(model_path: &Path) -> Result<()> {
     let settings = Settings::from_path(model_path).context("Failed to load settings.")?;
 
     // Create output folder
-    let output_path =
-        create_output_directory(model_path).context("Failed to create output directory.")?;
+    let output_path = get_output_dir(model_path)?;
+    create_output_directory(&output_path).context("Failed to create output directory.")?;
 
     // Initialise program logger
     log::init(settings.log_level.as_deref(), &output_path)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,17 +14,17 @@ use tempfile::TempDir;
 /// The directory containing the example models.
 pub const EXAMPLES_DIR: Dir = include_dir!("examples");
 
+/// The command line interface for the simulation.
 #[derive(Parser)]
 #[command(version, about)]
-/// The command line interface for the simulation.
 pub struct Cli {
-    #[command(subcommand)]
     /// The available commands.
+    #[command(subcommand)]
     pub command: Commands,
 }
 
-#[derive(Subcommand)]
 /// The available commands.
+#[derive(Subcommand)]
 pub enum Commands {
     /// Run a simulation model.
     Run {
@@ -33,14 +33,14 @@ pub enum Commands {
     },
     /// Manage example models.
     Example {
-        #[command(subcommand)]
         /// The available subcommands for managing example models.
+        #[command(subcommand)]
         subcommand: ExampleSubcommands,
     },
 }
 
-#[derive(Subcommand)]
 /// The available subcommands for managing example models.
+#[derive(Subcommand)]
 pub enum ExampleSubcommands {
     /// List available examples.
     List,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,19 @@ fn main() {
 
 fn execute_cli_command(command: Commands) -> Result<()> {
     match command {
-        Commands::Run { model_dir } => handle_run_command(&model_dir)?,
+        Commands::Run {
+            model_dir,
+            output_dir,
+        } => handle_run_command(&model_dir, output_dir.as_deref())?,
         Commands::Example { subcommand } => match subcommand {
             ExampleSubcommands::List => handle_example_list_command(),
             ExampleSubcommands::Extract {
                 name,
                 new_path: dest,
             } => handle_example_extract_command(&name, dest.as_deref())?,
-            ExampleSubcommands::Run { name } => handle_example_run_command(&name)?,
+            ExampleSubcommands::Run { name, output_dir } => {
+                handle_example_run_command(&name, output_dir.as_deref())?
+            }
         },
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -25,13 +25,14 @@ const COMMODITY_PRICES_FILE_NAME: &str = "commodity_prices.csv";
 /// The output file name for assets
 const ASSETS_FILE_NAME: &str = "assets.csv";
 
-/// Create a new output directory for the model specified at `model_dir`.
-pub fn create_output_directory(model_dir: &Path) -> Result<PathBuf> {
+/// Get the model name from the specified directory path
+pub fn get_output_dir(model_dir: &Path) -> Result<PathBuf> {
     // Get the model name from the dir path. This ends up being convoluted because we need to check
     // for all possible errors. Ugh.
     let model_dir = model_dir
         .canonicalize() // canonicalise in case the user has specified "."
         .context("Could not resolve path to model")?;
+
     let model_name = model_dir
         .file_name()
         .context("Model cannot be in root folder")?
@@ -39,16 +40,20 @@ pub fn create_output_directory(model_dir: &Path) -> Result<PathBuf> {
         .context("Invalid chars in model dir name")?;
 
     // Construct path
-    let path: PathBuf = [OUTPUT_DIRECTORY_ROOT, model_name].iter().collect();
-    if path.is_dir() {
+    Ok([OUTPUT_DIRECTORY_ROOT, model_name].iter().collect())
+}
+
+/// Create a new output directory for the model specified at `model_dir`.
+pub fn create_output_directory(output_dir: &Path) -> Result<()> {
+    if output_dir.is_dir() {
         // already exists
-        return Ok(path);
+        return Ok(());
     }
 
     // Try to create the directory, with parents
-    fs::create_dir_all(&path)?;
+    fs::create_dir_all(output_dir)?;
 
-    Ok(path)
+    Ok(())
 }
 
 /// Represents a row in the assets output CSV file

--- a/tests/example_run.rs
+++ b/tests/example_run.rs
@@ -5,5 +5,5 @@ use muse2::commands::handle_example_run_command;
 #[test]
 fn test_handle_example_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
-    handle_example_run_command("simple").unwrap();
+    handle_example_run_command("simple", None).unwrap();
 }

--- a/tests/example_run.rs
+++ b/tests/example_run.rs
@@ -1,9 +1,10 @@
 /// Integration tests for the `example run` command.
 use muse2::commands::handle_example_run_command;
+use tempfile::tempdir;
 
 /// An integration test for the `example run` command.
 #[test]
 fn test_handle_example_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
-    handle_example_run_command("simple", None).unwrap();
+    handle_example_run_command("simple", Some(tempdir().unwrap().path())).unwrap();
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -11,11 +11,11 @@ fn get_model_dir() -> PathBuf {
 #[test]
 fn test_handle_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
-    handle_run_command(&get_model_dir()).unwrap();
+    handle_run_command(&get_model_dir(), None).unwrap();
 
     // Second time will fail because the logging is already initialised
     assert_eq!(
-        handle_run_command(&get_model_dir())
+        handle_run_command(&get_model_dir(), None)
             .unwrap_err()
             .chain()
             .next()

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `run` command.
 use muse2::commands::handle_run_command;
 use std::path::PathBuf;
+use tempfile::tempdir;
 
 /// Get the path to the example model.
 fn get_model_dir() -> PathBuf {
@@ -11,11 +12,11 @@ fn get_model_dir() -> PathBuf {
 #[test]
 fn test_handle_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
-    handle_run_command(&get_model_dir(), None).unwrap();
+    handle_run_command(&get_model_dir(), Some(tempdir().unwrap().path())).unwrap();
 
     // Second time will fail because the logging is already initialised
     assert_eq!(
-        handle_run_command(&get_model_dir(), None)
+        handle_run_command(&get_model_dir(), Some(tempdir().unwrap().path()))
             .unwrap_err()
             .chain()
             .next()


### PR DESCRIPTION
# Description

Currently files are written to `muse2_results/{model name}`. It would be useful in of itself for users to be able to choose the output directory, but, in addition, adding this extra argument to the `handle_run_command` function allows us to use a temporary dir for tests (#373). It'll also be useful for when we want to write regression tests (#520).

Closes #371. Closes #373.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
