### PR TITLE
Store agent objectives as a map

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,7 +5,6 @@ use crate::id::{define_id_getter, define_id_type};
 use crate::process::ProcessID;
 use crate::region::RegionID;
 use indexmap::IndexMap;
-use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -21,6 +20,12 @@ pub type AgentCostLimitsMap = HashMap<u32, AgentCostLimits>;
 
 /// A map of commodity portions for an agent, keyed by commodity and year
 pub type AgentCommodityPortionsMap = HashMap<(CommodityID, u32), f64>;
+
+/// A map of objectives for an agent, keyed by commodity and year.
+///
+/// NB: As we currently only support the "single" decision rule, the only parameter we need for
+/// objectives is the type.
+pub type AgentObjectiveMap = HashMap<u32, ObjectiveType>;
 
 /// An agent in the simulation
 #[derive(Debug, Clone, PartialEq)]
@@ -40,7 +45,7 @@ pub struct Agent {
     /// The regions in which this agent operates.
     pub regions: HashSet<RegionID>,
     /// The agent's objectives.
-    pub objectives: Vec<AgentObjective>,
+    pub objectives: AgentObjectiveMap,
 }
 define_id_getter! {Agent, AgentID}
 
@@ -76,21 +81,6 @@ pub enum DecisionRule {
         /// The tolerance around the main objective to consider secondary objectives. This is an absolute value of maximum deviation in the units of the main objective.
         tolerance: f64,
     },
-}
-
-/// An objective for an agent with associated parameters
-#[derive(Debug, Clone, Deserialize, PartialEq)]
-pub struct AgentObjective {
-    /// Unique agent id identifying the agent this objective belongs to
-    pub agent_id: AgentID,
-    /// The year the objective is relevant for
-    pub year: u32,
-    /// Acronym identifying the objective (e.g. LCOX)
-    pub objective_type: ObjectiveType,
-    /// For the weighted sum decision rule, the set of weights to apply to each objective.
-    pub decision_weight: Option<f64>,
-    /// For the lexico decision rule, the order in which to consider objectives.
-    pub decision_lexico_order: Option<u32>,
 }
 
 /// The type of objective for the agent

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -94,7 +94,7 @@ pub struct AgentObjective {
 }
 
 /// The type of objective for the agent
-#[derive(Debug, Clone, PartialEq, DeserializeLabeledStringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, DeserializeLabeledStringEnum)]
 pub enum ObjectiveType {
     /// Average cost of one unit of output commodity over its lifetime
     #[string = "lcox"]

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -138,6 +138,11 @@ where
             invalid_rule => bail!("Invalid decision rule: {}", invalid_rule),
         };
 
+        ensure!(
+            decision_rule == DecisionRule::Single,
+            "Currently only the \"single\" decision rule is supported"
+        );
+
         let agent = Agent {
             id: AgentID(agent_raw.id.into()),
             description: agent_raw.description,

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -1,7 +1,8 @@
 //! Code for reading in agent-related data from CSV files.
 use super::*;
 use crate::agent::{
-    Agent, AgentCommodityPortionsMap, AgentCostLimitsMap, AgentID, AgentMap, DecisionRule,
+    Agent, AgentCommodityPortionsMap, AgentCostLimitsMap, AgentID, AgentMap, AgentObjectiveMap,
+    DecisionRule,
 };
 use crate::commodity::CommodityMap;
 use crate::process::ProcessMap;
@@ -151,7 +152,7 @@ where
             decision_rule,
             cost_limits: AgentCostLimitsMap::new(),
             regions,
-            objectives: Vec::new(),
+            objectives: AgentObjectiveMap::new(),
         };
 
         ensure!(
@@ -188,7 +189,7 @@ mod tests {
             decision_rule: DecisionRule::Single,
             cost_limits: AgentCostLimitsMap::new(),
             regions: HashSet::from(["GBR".into()]),
-            objectives: Vec::new(),
+            objectives: AgentObjectiveMap::new(),
         };
         let expected = AgentMap::from_iter(iter::once(("agent".into(), agent_out)));
         let actual = read_agents_file_from_iter(iter::once(agent), &region_ids).unwrap();

--- a/src/input/agent/commodity_portion.rs
+++ b/src/input/agent/commodity_portion.rs
@@ -194,7 +194,7 @@ fn validate_agent_commodity_portions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{Agent, AgentCostLimitsMap, DecisionRule};
+    use crate::agent::{Agent, AgentCostLimitsMap, AgentObjectiveMap, DecisionRule};
     use crate::commodity::{Commodity, CommodityCostMap, CommodityID, CommodityType, DemandMap};
     use crate::time_slice::TimeSliceLevel;
     use std::rc::Rc;
@@ -213,7 +213,7 @@ mod tests {
                 decision_rule: DecisionRule::Single,
                 cost_limits: AgentCostLimitsMap::new(),
                 regions: region_ids.clone(),
-                objectives: Vec::new(),
+                objectives: AgentObjectiveMap::new(),
             },
         )]);
         let mut commodities = IndexMap::from([(

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -80,12 +80,16 @@ where
             .get(agent_id)
             .with_context(|| format!("Agent {} has no objectives", agent_id))?;
 
-        for year in milestone_years.iter() {
-            ensure!(
-                agent_objectives.contains_key(year),
-                "Agent {agent_id} is missing objectives for year {year}"
-            );
-        }
+        let missing_years = milestone_years
+            .iter()
+            .filter(|year| !agent_objectives.contains_key(year))
+            .collect_vec();
+        ensure!(
+            missing_years.is_empty(),
+            "Agent {} is missing objectives for the following milestone years: {:?}",
+            agent_id,
+            missing_years
+        );
     }
 
     Ok(all_objectives)


### PR DESCRIPTION
# Description

As we're only currently supporting the "single" objective type (and likely won't support anything else for the forseeable future) I was able to write this in a more simplified way than planned. I've written a check to disable the other objective types for now.

I'm opening this as draft because this might not be uncontroversial :stuck_out_tongue:. I haven't added commodity IDs as keys to the map yet (#542) because I wanted to run this by you before building on top of it, plus I think it can wait till later anyway.

Instead of a `HashMap<u32, Vec<AgentObjective>>`, I've gone with `HashMap<u32, ObjectiveType>`, as a) we will only have one objective per year and b) that objective won't have any additional parameters. Writing things this way made the validation checks simpler and it should be slightly simpler to use too.

Now the `check_agent_objectives` function is unused outside of the unit tests. I'd be inclined to delete it with the tests for now (we can leave a note somewhere saying we've done this) -- but it's also probably pretty harmless so we could just leave it.

If you're happy with all this, I was planning on refactoring the tests a bit to use `rstest` fixtures, like elsewhere.

Closes #506.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
