### PR TITLE
Dockerfile: Include `rust-src` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.21
 
 # Install dependencies. We need a C++ toolchain to compile the highs crate.
-RUN apk add --no-cache cargo rustfmt cmake binutils make g++ clang19-libclang git mdbook
+RUN apk add --no-cache cargo rust-src rustfmt cmake binutils make g++ clang19-libclang git mdbook


### PR DESCRIPTION
# Description

@dalonsoa: We've added a devcontainer since you last looked at MUSE 2.0, which may be handy if it turns out your toolchain isn't working for whatever reason. This PR just adds a missing dependency for it.

While the `rust-src` package isn't necessary to build MUSE 2.0, it is useful as it's required by the VS Code Rust extension (for example). Let's just include it.