### PR TITLE
Allow for adding new assets to pool

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 pub struct AssetID(u32);
 
 impl AssetID {
-    /// Sentinel value assigned to [`Asset`]s when they are initially created
+    /// Sentinel value assigned to [`Asset`]s when they are added to the pool
     pub const INVALID: AssetID = AssetID(u32::MAX);
 }
 
@@ -98,7 +98,8 @@ impl Asset {
             .unwrap();
         let max_act = self.maximum_activity();
 
-        // Multiply the fractional capacity in self.process by this asset's actual capacity
+        // Multiply the fractional energy limits by this asset's maximum activity to get energy
+        // limits in real units (which are user defined)
         (max_act * limits.start())..=(max_act * limits.end())
     }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -125,7 +125,7 @@ impl Asset {
 
 /// A pool of [`Asset`]s
 pub struct AssetPool {
-    /// The pool of active assets, sorted by commission year
+    /// The pool of active assets
     active: Vec<Asset>,
     /// Assets that have not yet been commissioned, sorted by commission year
     future: Vec<Asset>,
@@ -146,7 +146,25 @@ impl AssetPool {
         }
     }
 
-    /// Commission new assets for the specified milestone year
+    /// Add an asset to the active pool (i.e. commission it immediately).
+    ///
+    /// The asset's commission year is ignored by this function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the asset has already been commissioned.
+    pub fn commission(&mut self, mut asset: Asset) {
+        assert!(
+            asset.id == AssetID::INVALID,
+            "Asset has already been commissioned"
+        );
+
+        asset.id = AssetID(self.next_id);
+        self.next_id += 1;
+        self.active.push(asset);
+    }
+
+    /// Commission new assets for the specified milestone year from the input data
     pub fn commission_new(&mut self, year: u32) {
         // Count the number of assets to move
         let count = self
@@ -159,7 +177,6 @@ impl AssetPool {
         for mut asset in self.future.drain(0..count) {
             asset.id = AssetID(self.next_id);
             self.next_id += 1;
-
             self.active.push(asset);
         }
     }
@@ -388,6 +405,15 @@ mod tests {
         // Nothing to commission for this year
         asset_pool.commission_new(2000);
         assert!(asset_pool.iter().next().is_none()); // no active assets
+    }
+
+    #[rstest]
+    fn test_asset_pool_commission(mut asset_pool: AssetPool, process: Process) {
+        let mut asset =
+            Asset::new("agent2".into(), process.into(), "USA".into(), 100.0, 2015).unwrap();
+        asset_pool.commission(asset.clone());
+        asset.id = AssetID(0);
+        assert_equal(asset_pool.iter(), iter::once(&asset));
     }
 
     #[rstest]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -182,7 +182,7 @@ impl AssetPool {
     }
 
     /// Decommission old assets for the specified milestone year
-    pub fn decomission_old(&mut self, year: u32) {
+    pub fn decommission_old(&mut self, year: u32) {
         self.active.retain(|asset| asset.decommission_year() > year);
     }
 
@@ -420,13 +420,13 @@ mod tests {
     fn test_asset_pool_decommission_old(mut asset_pool: AssetPool) {
         asset_pool.commission_new(2020);
         assert!(asset_pool.active.len() == 2);
-        asset_pool.decomission_old(2020); // should decommission first asset (lifetime == 5)
+        asset_pool.decommission_old(2020); // should decommission first asset (lifetime == 5)
         assert!(asset_pool.active.len() == 1);
         assert_eq!(asset_pool.active[0].commission_year, 2020);
-        asset_pool.decomission_old(2022); // nothing to decommission
+        asset_pool.decommission_old(2022); // nothing to decommission
         assert!(asset_pool.active.len() == 1);
         assert_eq!(asset_pool.active[0].commission_year, 2020);
-        asset_pool.decomission_old(2025); // should decommission second asset
+        asset_pool.decommission_old(2025); // should decommission second asset
         assert!(asset_pool.active.is_empty());
     }
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -27,7 +27,7 @@ pub fn run(model: Model, mut assets: AssetPool, output_path: &Path) -> Result<()
         info!("Milestone year: {year}");
 
         // Assets that have been decommissioned cannot be selected by agents
-        assets.decomission_old(year);
+        assets.decommission_old(year);
 
         // NB: Agent investment is not carried out in first milestone year
         if let Some((solution, prices)) = opt_results {


### PR DESCRIPTION
# Description

I've added the functionality we need to `AssetPool` to be able to add new assets, by storing assets that have not yet been commissioned separately from those that have. Other than that, I've left the API pretty much the same as it was, except that I've added a new `Asset::commission` method.

Technically issue #486 is about adding new processes to the pool, rather than assets, but we need to work out what the capacity of the newly created asset should be in order to be able to do this. There is [a description](https://energysystemsmodellinglab.github.io/MUSE_2.0/model_description.html#iii-add-new-asset-or-confirm-asset-not-decommissioned) of how to do this in the documentation, but I think it makes sense to deal with that later.

Closes #486.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
