### PR TITLE
Convert `AgentSearchSpace` to map

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,6 @@
 //! Agents drive the economy of the MUSE 2.0 simulation, through relative investment in different
 //! assets.
-use crate::commodity::{Commodity, CommodityID};
+use crate::commodity::CommodityID;
 use crate::id::{define_id_getter, define_id_type};
 use crate::process::ProcessID;
 use crate::region::RegionID;
@@ -8,7 +8,6 @@ use indexmap::IndexMap;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::rc::Rc;
 
 define_id_type! {AgentID}
 
@@ -20,6 +19,9 @@ pub type AgentCostLimitsMap = HashMap<u32, AgentCostLimits>;
 
 /// A map of commodity portions for an agent, keyed by commodity and year
 pub type AgentCommodityPortionsMap = HashMap<(CommodityID, u32), f64>;
+
+/// A map for the agent's search space, keyed by commodity and year
+pub type AgentSearchSpaceMap = HashMap<(CommodityID, u32), Vec<ProcessID>>;
 
 /// A map of objectives for an agent, keyed by commodity and year.
 ///
@@ -37,7 +39,7 @@ pub struct Agent {
     /// The proportion of the commodity production that the agent is responsible for.
     pub commodity_portions: AgentCommodityPortionsMap,
     /// The processes that the agent will consider investing in.
-    pub search_space: Vec<AgentSearchSpace>,
+    pub search_space: AgentSearchSpaceMap,
     /// The decision rule that the agent uses to decide investment.
     pub decision_rule: DecisionRule,
     /// Cost limits (e.g. capital cost, annual operating cost)
@@ -56,17 +58,6 @@ pub struct AgentCostLimits {
     pub capex_limit: Option<f64>,
     /// The maximum annual operating cost (fuel plus var_opex etc) that the agent will pay.
     pub annual_cost_limit: Option<f64>,
-}
-
-/// Search space for an agent
-#[derive(Debug, Clone, PartialEq)]
-pub struct AgentSearchSpace {
-    /// The year the objective is relevant for
-    pub year: u32,
-    /// The commodity to apply the search space to
-    pub commodity: Rc<Commodity>,
-    /// The agent's search space
-    pub search_space: Vec<ProcessID>,
 }
 
 /// The decision rule for a particular objective

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 define_id_type! {AgentID}
 
@@ -21,7 +22,7 @@ pub type AgentCostLimitsMap = HashMap<u32, AgentCostLimits>;
 pub type AgentCommodityPortionsMap = HashMap<(CommodityID, u32), f64>;
 
 /// A map for the agent's search space, keyed by commodity and year
-pub type AgentSearchSpaceMap = HashMap<(CommodityID, u32), Vec<ProcessID>>;
+pub type AgentSearchSpaceMap = HashMap<(CommodityID, u32), Rc<Vec<ProcessID>>>;
 
 /// A map of objectives for an agent, keyed by commodity and year.
 ///

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -1,5 +1,9 @@
 //! Fixtures for tests
 
+use crate::agent::{
+    Agent, AgentCommodityPortionsMap, AgentCostLimitsMap, AgentMap, AgentObjectiveMap,
+    AgentSearchSpaceMap, DecisionRule,
+};
 use crate::process::{
     Process, ProcessEnergyLimitsMap, ProcessFlowsMap, ProcessMap, ProcessParameter,
     ProcessParameterMap,
@@ -9,6 +13,7 @@ use indexmap::indexmap;
 use itertools::Itertools;
 use rstest::fixture;
 use std::collections::HashSet;
+use std::iter;
 use std::rc::Rc;
 
 /// Assert that an error with the given message occurs
@@ -64,4 +69,22 @@ pub fn process(
 #[fixture]
 pub fn processes(process: Process) -> ProcessMap {
     indexmap! { process.id.clone() => process.into()}
+}
+
+#[fixture]
+pub fn agents() -> AgentMap {
+    iter::once((
+        "agent1".into(),
+        Agent {
+            id: "agent1".into(),
+            description: "".into(),
+            commodity_portions: AgentCommodityPortionsMap::new(),
+            search_space: AgentSearchSpaceMap::new(),
+            decision_rule: DecisionRule::Single,
+            cost_limits: AgentCostLimitsMap::new(),
+            regions: HashSet::new(),
+            objectives: AgentObjectiveMap::new(),
+        },
+    ))
+    .collect()
 }

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::agent::{
     Agent, AgentCommodityPortionsMap, AgentCostLimitsMap, AgentID, AgentMap, AgentObjectiveMap,
-    DecisionRule,
+    AgentSearchSpaceMap, DecisionRule,
 };
 use crate::commodity::CommodityMap;
 use crate::process::ProcessMap;
@@ -62,11 +62,12 @@ pub fn read_agents(
     let agent_ids = agents.keys().cloned().collect();
 
     let mut objectives = read_agent_objectives(model_dir, &agents, milestone_years)?;
+    let commodity_ids = commodities.keys().cloned().collect();
     let mut search_spaces = read_agent_search_space(
         model_dir,
         &agents,
         &process_ids,
-        commodities,
+        &commodity_ids,
         milestone_years,
     )?;
     let mut agent_commodities = read_agent_commodity_portions(
@@ -148,7 +149,7 @@ where
             id: AgentID(agent_raw.id.into()),
             description: agent_raw.description,
             commodity_portions: AgentCommodityPortionsMap::new(),
-            search_space: Vec::new(),
+            search_space: AgentSearchSpaceMap::new(),
             decision_rule,
             cost_limits: AgentCostLimitsMap::new(),
             regions,
@@ -185,7 +186,7 @@ mod tests {
             id: "agent".into(),
             description: "".into(),
             commodity_portions: AgentCommodityPortionsMap::new(),
-            search_space: Vec::new(),
+            search_space: AgentSearchSpaceMap::new(),
             decision_rule: DecisionRule::Single,
             cost_limits: AgentCostLimitsMap::new(),
             regions: HashSet::from(["GBR".into()]),

--- a/src/input/agent/commodity_portion.rs
+++ b/src/input/agent/commodity_portion.rs
@@ -194,7 +194,9 @@ fn validate_agent_commodity_portions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{Agent, AgentCostLimitsMap, AgentObjectiveMap, DecisionRule};
+    use crate::agent::{
+        Agent, AgentCostLimitsMap, AgentObjectiveMap, AgentSearchSpaceMap, DecisionRule,
+    };
     use crate::commodity::{Commodity, CommodityCostMap, CommodityID, CommodityType, DemandMap};
     use crate::time_slice::TimeSliceLevel;
     use std::rc::Rc;
@@ -209,7 +211,7 @@ mod tests {
                 id: "agent1".into(),
                 description: "An agent".into(),
                 commodity_portions: AgentCommodityPortionsMap::new(),
-                search_space: Vec::new(),
+                search_space: AgentSearchSpaceMap::new(),
                 decision_rule: DecisionRule::Single,
                 cost_limits: AgentCostLimitsMap::new(),
                 regions: region_ids.clone(),

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -143,10 +143,8 @@ fn check_objective_parameter(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        agent::{Agent, AgentCommodityPortionsMap, AgentCostLimitsMap, ObjectiveType},
-        fixture::assert_error,
-    };
+    use crate::agent::ObjectiveType;
+    use crate::fixture::{agents, assert_error};
     use rstest::{fixture, rstest};
     use std::iter;
 
@@ -196,24 +194,6 @@ mod tests {
         assert!(check_objective_parameter(&objective, &decision_rule).is_err());
         let objective = objective!(Some(1.0), None);
         assert!(check_objective_parameter(&objective, &decision_rule).is_err());
-    }
-
-    #[fixture]
-    fn agents() -> AgentMap {
-        iter::once((
-            "agent1".into(),
-            Agent {
-                id: "agent1".into(),
-                description: "".into(),
-                commodity_portions: AgentCommodityPortionsMap::new(),
-                search_space: Vec::new(),
-                decision_rule: DecisionRule::Single,
-                cost_limits: AgentCostLimitsMap::new(),
-                regions: HashSet::new(),
-                objectives: AgentObjectiveMap::new(),
-            },
-        ))
-        .collect()
     }
 
     #[fixture]

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -1,7 +1,7 @@
 //! Code for reading the agent search space CSV file.
 use super::super::*;
-use crate::agent::{AgentID, AgentMap, AgentSearchSpace};
-use crate::commodity::CommodityMap;
+use crate::agent::{AgentID, AgentMap, AgentSearchSpaceMap};
+use crate::commodity::CommodityID;
 use crate::id::IDCollection;
 use crate::process::ProcessID;
 use anyhow::{Context, Result};
@@ -9,7 +9,6 @@ use indexmap::IndexSet;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
-use std::rc::Rc;
 
 const AGENT_SEARCH_SPACE_FILE_NAME: &str = "agent_search_space.csv";
 
@@ -26,20 +25,32 @@ struct AgentSearchSpaceRaw {
     search_space: String,
 }
 
+/// Search space for an agent
+#[derive(Debug)]
+struct AgentSearchSpace {
+    /// The agent to which this search space applies
+    agent_id: AgentID,
+    /// The commodity to apply the search space to
+    commodity_id: CommodityID,
+    /// The year the objective is relevant for
+    year: u32,
+    /// The agent's search space
+    search_space: Vec<ProcessID>,
+}
+
 impl AgentSearchSpaceRaw {
-    fn to_agent_search_space(
-        &self,
+    fn into_agent_search_space(
+        self,
+        agents: &AgentMap,
         process_ids: &IndexSet<ProcessID>,
-        commodities: &CommodityMap,
+        commodity_ids: &HashSet<CommodityID>,
         milestone_years: &[u32],
     ) -> Result<AgentSearchSpace> {
         // Parse search_space string
         let search_space = parse_search_space_str(&self.search_space, process_ids)?;
 
         // Get commodity
-        let commodity = commodities
-            .get(self.commodity_id.as_str())
-            .context("Invalid commodity ID")?;
+        let commodity_id = commodity_ids.get_id_by_str(&self.commodity_id)?;
 
         // Check that the year is a valid milestone year
         ensure!(
@@ -48,10 +59,14 @@ impl AgentSearchSpaceRaw {
             self.year
         );
 
-        // Create AgentSearchSpace
+        let (agent_id, _) = agents
+            .get_key_value(self.agent_id.as_str())
+            .context("Invalid agent ID")?;
+
         Ok(AgentSearchSpace {
+            agent_id: agent_id.clone(),
+            commodity_id,
             year: self.year,
-            commodity: Rc::clone(commodity),
             search_space,
         })
     }
@@ -91,12 +106,12 @@ pub fn read_agent_search_space(
     model_dir: &Path,
     agents: &AgentMap,
     process_ids: &IndexSet<ProcessID>,
-    commodities: &CommodityMap,
+    commodity_ids: &HashSet<CommodityID>,
     milestone_years: &[u32],
-) -> Result<HashMap<AgentID, Vec<AgentSearchSpace>>> {
+) -> Result<HashMap<AgentID, AgentSearchSpaceMap>> {
     let file_path = model_dir.join(AGENT_SEARCH_SPACE_FILE_NAME);
     let iter = read_csv_optional::<AgentSearchSpaceRaw>(&file_path)?;
-    read_agent_search_space_from_iter(iter, agents, process_ids, commodities, milestone_years)
+    read_agent_search_space_from_iter(iter, agents, process_ids, commodity_ids, milestone_years)
         .with_context(|| input_err_msg(&file_path))
 }
 
@@ -104,26 +119,32 @@ fn read_agent_search_space_from_iter<I>(
     iter: I,
     agents: &AgentMap,
     process_ids: &IndexSet<ProcessID>,
-    commodities: &CommodityMap,
+    commodity_ids: &HashSet<CommodityID>,
     milestone_years: &[u32],
-) -> Result<HashMap<AgentID, Vec<AgentSearchSpace>>>
+) -> Result<HashMap<AgentID, AgentSearchSpaceMap>>
 where
     I: Iterator<Item = AgentSearchSpaceRaw>,
 {
     let mut search_spaces = HashMap::new();
     for search_space_raw in iter {
-        let search_space =
-            search_space_raw.to_agent_search_space(process_ids, commodities, milestone_years)?;
+        let search_space = search_space_raw.into_agent_search_space(
+            agents,
+            process_ids,
+            commodity_ids,
+            milestone_years,
+        )?;
 
-        let (id, _agent) = agents
-            .get_key_value(search_space_raw.agent_id.as_str())
-            .context("Invalid agent ID")?;
+        // Get or create search space map
+        let map = search_spaces
+            .entry(search_space.agent_id)
+            .or_insert_with(AgentSearchSpaceMap::new);
 
-        // Append to Vec with the corresponding key or create
-        search_spaces
-            .entry(id.clone())
-            .or_insert_with(|| Vec::with_capacity(1))
-            .push(search_space);
+        // Store process IDs
+        try_insert(
+            map,
+            (search_space.commodity_id, search_space.year),
+            search_space.search_space,
+        )?;
     }
 
     Ok(search_spaces)
@@ -132,23 +153,26 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commodity::{Commodity, CommodityCostMap, CommodityType, DemandMap};
-    use crate::time_slice::TimeSliceLevel;
+    use crate::fixture::{agents, assert_error};
+    use rstest::{fixture, rstest};
     use std::iter;
 
-    #[test]
-    fn test_search_space_raw_into_search_space() {
-        let process_ids = ["A".into(), "B".into(), "C".into()].into_iter().collect();
-        let commodity = Rc::new(Commodity {
-            id: "commodity1".into(),
-            description: "A commodity".into(),
-            kind: CommodityType::SupplyEqualsDemand,
-            time_slice_level: TimeSliceLevel::Annual,
-            costs: CommodityCostMap::new(),
-            demand: DemandMap::new(),
-        });
-        let commodities = iter::once(("commodity1".into(), Rc::clone(&commodity))).collect();
+    #[fixture]
+    fn process_ids() -> IndexSet<ProcessID> {
+        ["A".into(), "B".into(), "C".into()].into_iter().collect()
+    }
 
+    #[fixture]
+    fn commodity_ids() -> HashSet<CommodityID> {
+        iter::once("commodity1".into()).collect()
+    }
+
+    #[rstest]
+    fn test_search_space_raw_into_search_space_valid(
+        agents: AgentMap,
+        process_ids: IndexSet<ProcessID>,
+        commodity_ids: HashSet<CommodityID>,
+    ) {
         // Valid search space
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
@@ -157,9 +181,16 @@ mod tests {
             search_space: "A;B".into(),
         };
         assert!(raw
-            .to_agent_search_space(&process_ids, &commodities, &[2020])
+            .into_agent_search_space(&agents, &process_ids, &commodity_ids, &[2020])
             .is_ok());
+    }
 
+    #[rstest]
+    fn test_search_space_raw_into_search_space_invalid_commodity_id(
+        agents: AgentMap,
+        process_ids: IndexSet<ProcessID>,
+        commodity_ids: HashSet<CommodityID>,
+    ) {
         // Invalid commodity ID
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
@@ -167,10 +198,18 @@ mod tests {
             year: 2020,
             search_space: "A;B".into(),
         };
-        assert!(raw
-            .to_agent_search_space(&process_ids, &commodities, &[2020])
-            .is_err());
+        assert_error!(
+            raw.into_agent_search_space(&agents, &process_ids, &commodity_ids, &[2020]),
+            "Unknown ID invalid_commodity found"
+        );
+    }
 
+    #[rstest]
+    fn test_search_space_raw_into_search_space_invalid_process_id(
+        agents: AgentMap,
+        process_ids: IndexSet<ProcessID>,
+        commodity_ids: HashSet<CommodityID>,
+    ) {
         // Invalid process ID
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
@@ -178,8 +217,9 @@ mod tests {
             year: 2020,
             search_space: "A;D".into(),
         };
-        assert!(raw
-            .to_agent_search_space(&process_ids, &commodities, &[2020])
-            .is_err());
+        assert_error!(
+            raw.into_agent_search_space(&agents, &process_ids, &commodity_ids, &[2020]),
+            "Unknown ID D found"
+        );
     }
 }


### PR DESCRIPTION
# Description

The agent search space (optionally) constraints which processes an agent can consider for a given combindation of commodity and year. This PR converts the agent search space to be housed in a map rather than a `Vec`, which makes it easier (and faster) to look up partiular entries.

I also changed the `year` field to accept multiple years, as we've done elsewhere, and converted the test code for the agent search space stuff to use `rstest` (so we can have fixtures).

Closes #507.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
