### PR TITLE
Add final missing doc comments

### DIFF
--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Commodities are substances or forms of energy that can be produced and consumed by processes.
 use crate::id::{define_id_getter, define_id_type};
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceLevel};
@@ -19,22 +19,29 @@ pub type CommodityCostMap = HashMap<(RegionID, u32, TimeSliceID), CommodityCost>
 /// A map of demand values, keyed by region ID, year and time slice ID
 pub type DemandMap = HashMap<(RegionID, u32, TimeSliceID), f64>;
 
-/// A commodity within the simulation. Represents a substance (e.g. CO2) or form of energy (e.g.
-/// electricity) that can be produced and/or consumed by technologies in the model.
+/// A commodity within the simulation.
+///
+/// Represents a substance (e.g. CO2) or form of energy (e.g. electricity) that can be produced
+/// and/or consumed by processes.
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Commodity {
     /// Unique identifier for the commodity (e.g. "ELC")
     pub id: CommodityID,
     /// Text description of commodity (e.g. "electricity")
     pub description: String,
+    /// Commodity balance type
     #[serde(rename = "type")] // NB: we can't name a field type as it's a reserved keyword
-    /// Commodity balance type. Can be supply = demand (SED), service demand (SVD), non-balance commodity (NBC).
     pub kind: CommodityType,
-    /// The time slice level for commodity balance. Can be annual, seasonal or at time slice level.
+    /// The time slice level for commodity balance
     pub time_slice_level: TimeSliceLevel,
-
+    /// Levies for this commodity for different combinations of region, year and time slice.
+    ///
+    /// May be empty if there are no levies for this commodity, otherwise there must be entries for
+    /// every combination of parameters. Note that these values can be negative, indicating an
+    /// incentive.
     #[serde(skip)]
     pub costs: CommodityCostMap,
+    /// Demand as defined in input files. Will be empty for non-service-demand commodities.
     #[serde(skip)]
     pub demand: DemandMap,
 }
@@ -43,32 +50,41 @@ define_id_getter! {Commodity, CommodityID}
 /// Type of balance for application of cost
 #[derive(PartialEq, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum BalanceType {
+    /// Applies to both consumption and production
     #[string = "net"]
     Net,
+    /// Applies to consumption only
     #[string = "cons"]
     Consumption,
+    /// Applies to production only
     #[string = "prod"]
     Production,
 }
 
-/// Represents a tax or other external cost on a commodity
+/// Represents a tax or other external cost on a commodity, as specified in input data.
+///
+/// For example, a CO2 price could be specified in input data to be applied to net CO2.
 #[derive(PartialEq, Clone, Debug)]
 pub struct CommodityCost {
-    /// Type of balance for application of cost.
+    /// Type of balance for application of cost
     pub balance_type: BalanceType,
-    /// Cost per unit commodity. For example, if a CO2 price is specified in input data, it can be applied to net CO2 via this value.
+    /// Cost per unit commodity
     pub value: f64,
 }
 
 /// Commodity balance type
 #[derive(PartialEq, Debug, DeserializeLabeledStringEnum)]
 pub enum CommodityType {
+    /// Supply and demand of this commodity must be balanced
     #[string = "sed"]
     SupplyEqualsDemand,
+    /// Specifies a demand (specified in input files) which must be met by the simulation
     #[string = "svd"]
     ServiceDemand,
+    /// Only an input to the simulation, cannot be produced by processes
     #[string = "inc"]
     InputCommodity,
+    /// Only an output for the simulation, cannot be consumed by processes
     #[string = "ouc"]
     OutputCommodity,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,4 @@
-//! Code for simulation models.
-#![allow(missing_docs)]
+//! The model represents the static input data provided by the user.
 use crate::agent::AgentMap;
 use crate::commodity::CommodityMap;
 use crate::input::{input_err_msg, read_toml};
@@ -14,23 +13,31 @@ const MODEL_FILE_NAME: &str = "model.toml";
 
 /// Model definition
 pub struct Model {
+    /// Milestone years for the simulaton. Sorted.
     pub milestone_years: Vec<u32>,
+    /// Agents for the simulation
     pub agents: AgentMap,
+    /// Commodities for the simulation
     pub commodities: CommodityMap,
+    /// Processes for the simulation
     pub processes: ProcessMap,
+    /// Information about seasons and time slices
     pub time_slice_info: TimeSliceInfo,
+    /// Regions for the simulation
     pub regions: RegionMap,
 }
 
 /// Represents the contents of the entire model file.
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct ModelFile {
+    /// Milestone years section of model file
     pub milestone_years: MilestoneYears,
 }
 
 /// Represents the "milestone_years" section of the model file.
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct MilestoneYears {
+    /// Milestone years
     pub years: Vec<u32>,
 }
 


### PR DESCRIPTION
I've added the final missing doc comments to the code. Finally, we can enable warnings about missing doc comments everywhere.

Closes #216. Closes #219. Closes #192.