### PR TITLE
Rename `year` to `years` for fields that can be multiple years

### DIFF
--- a/examples/simple/agent_commodity_portions.csv
+++ b/examples/simple/agent_commodity_portions.csv
@@ -1,4 +1,4 @@
-agent_id,commodity_id,year,commodity_portion
+agent_id,commodity_id,years,commodity_portion
 A0_GEX,GASPRD,all,1
 A0_GPR,GASNAT,all,1
 A0_ELC,ELCTRI,all,1

--- a/examples/simple/agent_cost_limits.csv
+++ b/examples/simple/agent_cost_limits.csv
@@ -1,4 +1,4 @@
-agent_id,year,capex_limit,annual_cost_limit
+agent_id,years,capex_limit,annual_cost_limit
 A0_GEX,all,,
 A0_GPR,all,,
 A0_ELC,all,,

--- a/examples/simple/agent_objectives.csv
+++ b/examples/simple/agent_objectives.csv
@@ -1,4 +1,4 @@
-agent_id,year,objective_type,decision_weight,decision_lexico_order
+agent_id,years,objective_type,decision_weight,decision_lexico_order
 A0_GEX,2020,lcox,,
 A0_GEX,2030,lcox,,
 A0_GPR,2020,lcox,,

--- a/examples/simple/agent_search_space.csv
+++ b/examples/simple/agent_search_space.csv
@@ -1,1 +1,1 @@
-agent_id,commodity_id,year,search_space
+agent_id,commodity_id,years,search_space

--- a/examples/simple/commodity_costs.csv
+++ b/examples/simple/commodity_costs.csv
@@ -1,2 +1,2 @@
-commodity_id,regions,year,time_slice,balance_type,value
+commodity_id,regions,years,time_slice,balance_type,value
 CO2EMT,GBR,all,annual,net,0.04

--- a/examples/simple/process_availabilities.csv
+++ b/examples/simple/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,year,time_slice,limit_type,value
+process_id,regions,years,time_slice,limit_type,value
 GASDRV,all,all,,up,0.9
 GASPRC,all,all,,up,0.9
 GASCGT,all,all,,up,0.9

--- a/examples/simple/process_flows.csv
+++ b/examples/simple/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,year,flow,flow_type,flow_cost,is_pac
+process_id,commodity_id,regions,years,flow,flow_type,flow_cost,is_pac
 GASDRV,GASPRD,all,all,1.0,fixed,,true
 GASPRC,GASPRD,all,all,-1.05,fixed,,false
 GASPRC,GASNAT,all,all,1.0,fixed,,true

--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,year,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity
+process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate,capacity_to_activity
 GASDRV,GBR,all,10.0,0.3,2.0,25,0.1,1.0
 GASPRC,GBR,all,7.0,0.21,0.5,25,0.1,1.0
 WNDFRM,GBR,all,1000.0,30.0,0.4,25,0.1,31.54

--- a/src/input/agent/commodity_portion.rs
+++ b/src/input/agent/commodity_portion.rs
@@ -17,8 +17,8 @@ struct AgentCommodityPortionRaw {
     agent_id: String,
     /// The commodity that the agent is responsible for.
     commodity_id: String,
-    /// The year the commodity portion applies to.
-    year: String,
+    /// The year(s) the commodity portion applies to.
+    years: String,
     /// The proportion of the commodity production that the agent is responsible for.
     #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     commodity_portion: f64,
@@ -80,7 +80,7 @@ where
         let (commodity_id, _commodity) = commodities
             .get_key_value(commodity_id_raw)
             .with_context(|| format!("Invalid commodity ID {commodity_id_raw}"))?;
-        let years = parse_year_str(&agent_commodity_portion_raw.year, milestone_years)?;
+        let years = parse_year_str(&agent_commodity_portion_raw.years, milestone_years)?;
         for year in years {
             try_insert(
                 entry,

--- a/src/input/agent/cost_limit.rs
+++ b/src/input/agent/cost_limit.rs
@@ -13,7 +13,7 @@ const AGENT_COST_LIMITS_FILE_NAME: &str = "agent_cost_limits.csv";
 #[derive(PartialEq, Debug, Deserialize)]
 struct AgentCostLimitsRaw {
     agent_id: String,
-    year: String,
+    years: String,
     capex_limit: Option<f64>,
     annual_cost_limit: Option<f64>,
 }
@@ -58,7 +58,7 @@ where
     let mut map: HashMap<AgentID, AgentCostLimitsMap> = HashMap::new();
     for agent_cost_limits_raw in iter {
         let cost_limits = agent_cost_limits_raw.to_agent_cost_limits();
-        let years = parse_year_str(&agent_cost_limits_raw.year, milestone_years)?;
+        let years = parse_year_str(&agent_cost_limits_raw.years, milestone_years)?;
 
         // Get agent ID
         let agent_id = agent_ids.get_id_by_str(&agent_cost_limits_raw.agent_id)?;
@@ -99,7 +99,7 @@ mod tests {
     ) -> AgentCostLimitsRaw {
         AgentCostLimitsRaw {
             agent_id: agent_id.to_string(),
-            year: year.to_string(),
+            years: year.to_string(),
             capex_limit,
             annual_cost_limit,
         }

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -15,7 +15,7 @@ struct AgentObjectiveRaw {
     /// Unique agent id identifying the agent this objective belongs to
     agent_id: AgentID,
     /// The year(s) the objective is relevant for
-    year: String,
+    years: String,
     /// Acronym identifying the objective (e.g. LCOX)
     objective_type: ObjectiveType,
     /// For the weighted sum decision rule, the set of weights to apply to each objective.
@@ -64,7 +64,7 @@ where
         let agent_objectives = all_objectives
             .entry(id.clone())
             .or_insert_with(AgentObjectiveMap::new);
-        for year in parse_year_str(&objective.year, milestone_years)? {
+        for year in parse_year_str(&objective.years, milestone_years)? {
             try_insert(agent_objectives, year, objective.objective_type).with_context(|| {
                 format!(
                     "Duplicate agent objective entry for agent {} and year {}",
@@ -152,7 +152,7 @@ mod tests {
         ($decision_weight:expr, $decision_lexico_order:expr) => {
             AgentObjectiveRaw {
                 agent_id: "agent".into(),
-                year: "2020".into(),
+                years: "2020".into(),
                 objective_type: ObjectiveType::LevelisedCostOfX,
                 decision_weight: $decision_weight,
                 decision_lexico_order: $decision_lexico_order,
@@ -200,7 +200,7 @@ mod tests {
     fn objective_raw() -> AgentObjectiveRaw {
         AgentObjectiveRaw {
             agent_id: "agent1".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             objective_type: ObjectiveType::LevelisedCostOfX,
             decision_weight: None,
             decision_lexico_order: None,
@@ -253,7 +253,7 @@ mod tests {
         // Bad parameter
         let bad_objective = AgentObjectiveRaw {
             agent_id: "agent1".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             objective_type: ObjectiveType::LevelisedCostOfX,
             decision_weight: Some(1.0), // Should only accept None for DecisionRule::Single
             decision_lexico_order: None,

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -21,7 +21,7 @@ struct AgentSearchSpaceRaw {
     /// The commodity to apply the search space to.
     commodity_id: String,
     /// The year(s) to apply the search space to.
-    year: String,
+    years: String,
     /// The processes that the agent will consider investing in. Expressed as process IDs separated
     /// by semicolons or `None`, meaning all processes.
     search_space: String,
@@ -35,7 +35,7 @@ struct AgentSearchSpace {
     /// The commodity to apply the search space to
     commodity_id: CommodityID,
     /// The year(s) the objective is relevant for
-    year: Vec<u32>,
+    years: Vec<u32>,
     /// The agent's search space
     search_space: Rc<Vec<ProcessID>>,
 }
@@ -55,7 +55,7 @@ impl AgentSearchSpaceRaw {
         let commodity_id = commodity_ids.get_id_by_str(&self.commodity_id)?;
 
         // Check that the year is a valid milestone year
-        let year = parse_year_str(&self.year, milestone_years)?;
+        let year = parse_year_str(&self.years, milestone_years)?;
 
         let (agent_id, _) = agents
             .get_key_value(self.agent_id.as_str())
@@ -64,7 +64,7 @@ impl AgentSearchSpaceRaw {
         Ok(AgentSearchSpace {
             agent_id: agent_id.clone(),
             commodity_id,
-            year,
+            years: year,
             search_space,
         })
     }
@@ -138,7 +138,7 @@ where
             .or_insert_with(AgentSearchSpaceMap::new);
 
         // Store process IDs
-        for year in search_space.year {
+        for year in search_space.years {
             try_insert(
                 map,
                 (search_space.commodity_id.clone(), year),
@@ -177,7 +177,7 @@ mod tests {
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
             commodity_id: "commodity1".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             search_space: "A;B".into(),
         };
         assert!(raw
@@ -195,7 +195,7 @@ mod tests {
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
             commodity_id: "invalid_commodity".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             search_space: "A;B".into(),
         };
         assert_error!(
@@ -214,7 +214,7 @@ mod tests {
         let raw = AgentSearchSpaceRaw {
             agent_id: "agent1".into(),
             commodity_id: "commodity1".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             search_space: "A;D".into(),
         };
         assert_error!(

--- a/src/input/commodity/cost.rs
+++ b/src/input/commodity/cost.rs
@@ -22,7 +22,7 @@ struct CommodityCostRaw {
     /// Type of balance for application of cost.
     balance_type: BalanceType,
     /// The year(s) to which the cost applies.
-    year: String,
+    years: String,
     /// The time slice to which the cost applies.
     time_slice: String,
     /// Cost per unit commodity. For example, if a CO2 price is specified in input data, it can be applied to net CO2 via this value.
@@ -80,7 +80,7 @@ where
     for cost in iter {
         let commodity_id = commodity_ids.get_id_by_str(&cost.commodity_id)?;
         let regions = parse_region_str(&cost.regions, region_ids)?;
-        let years = parse_year_str(&cost.year, milestone_years)?;
+        let years = parse_year_str(&cost.years, milestone_years)?;
         let ts_selection = time_slice_info.get_selection(&cost.time_slice)?;
 
         // Get or create CommodityCostMap for this commodity

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -20,7 +20,7 @@ const PROCESS_AVAILABILITIES_FILE_NAME: &str = "process_availabilities.csv";
 struct ProcessAvailabilityRaw {
     process_id: String,
     regions: String,
-    year: String,
+    years: String,
     time_slice: String,
     limit_type: LimitType,
     value: f64,
@@ -123,7 +123,7 @@ where
 
         // Get years
         let process_years = process.years.clone();
-        let record_years = parse_year_str(&record.year, &process_years).with_context(|| {
+        let record_years = parse_year_str(&record.years, &process_years).with_context(|| {
             format!("Invalid year for process {id}. Valid years are {process_years:?}")
         })?;
 
@@ -195,7 +195,7 @@ mod tests {
         ProcessAvailabilityRaw {
             process_id: "process".into(),
             regions: "region".into(),
-            year: "2010".into(),
+            years: "2010".into(),
             time_slice: "day".into(),
             limit_type,
             value,

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -18,7 +18,7 @@ const PROCESS_FLOWS_FILE_NAME: &str = "process_flows.csv";
 struct ProcessFlowRaw {
     process_id: String,
     commodity_id: String,
-    year: String,
+    years: String,
     regions: String,
     flow: f64,
     #[serde(default)]
@@ -96,7 +96,7 @@ where
 
         // Get years
         let process_years = process.years.clone();
-        let record_years = parse_year_str(&record.year, &process_years).with_context(|| {
+        let record_years = parse_year_str(&record.years, &process_years).with_context(|| {
             format!("Invalid year for process {id}. Valid years are {process_years:?}")
         })?;
 
@@ -204,7 +204,7 @@ mod tests {
         ProcessFlowRaw {
             process_id: "process".into(),
             commodity_id: "commodity".into(),
-            year: "2020".into(),
+            years: "2020".into(),
             regions: "region".into(),
             flow,
             flow_type,

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -18,7 +18,7 @@ const PROCESS_PARAMETERS_FILE_NAME: &str = "process_parameters.csv";
 struct ProcessParameterRaw {
     process_id: String,
     regions: String,
-    year: String,
+    years: String,
     capital_cost: f64,
     fixed_operating_cost: f64,
     variable_operating_cost: f64,
@@ -125,7 +125,7 @@ where
         // Get years
         let process_years = &process.years;
         let parameter_years =
-            parse_year_str(&param_raw.year, process_years).with_context(|| {
+            parse_year_str(&param_raw.years, process_years).with_context(|| {
                 format!("Invalid year for process {id}. Valid years are {process_years:?}")
             })?;
 
@@ -188,7 +188,7 @@ mod tests {
             lifetime,
             discount_rate,
             capacity_to_activity,
-            year: "all".to_string(),
+            years: "all".to_string(),
             regions: "all".to_string(),
         }
     }


### PR DESCRIPTION
This is a really boring PR... Sorry!

We have a bunch of fields called `year` in both the CSV files and the code that can actually take multiple years as an input. Let's rename them to `years` for consistency with other fields (e.g. `regions`).