### PR TITLE
Fix markdown help command in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup pages
         uses: actions/configure-pages@v5
       - name: Update CLI documentation
-        run: cargo run -- --markdown_help > docs/command_line_help.md
+        run: cargo run -- --markdown-help > docs/command_line_help.md
       - name: Install mdBook
         run: cargo install mdbook
       - name: Build docs with mdBook


### PR DESCRIPTION
The CI is currently failing to deploy the docs because the command in the workflow is subtly wrong. The flag is `--markdown-help`, but it's currently `--markdown_help`, which is causing the docs to fail to build. Fix it.