### PR TITLE
Use ID types for parts of time slice + implement `Serialize`/`Deserialize`

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -1,4 +1,4 @@
-//! Code for handing IDs
+//! Code for handling IDs
 use anyhow::{Context, Result};
 use indexmap::IndexSet;
 use std::collections::HashSet;

--- a/src/id.rs
+++ b/src/id.rs
@@ -5,11 +5,11 @@ use std::collections::HashSet;
 
 /// A trait alias for ID types
 pub trait IDLike:
-    Eq + std::hash::Hash + std::borrow::Borrow<str> + Clone + std::fmt::Display
+    Eq + std::hash::Hash + std::borrow::Borrow<str> + Clone + std::fmt::Display + From<String>
 {
 }
 impl<T> IDLike for T where
-    T: Eq + std::hash::Hash + std::borrow::Borrow<str> + Clone + std::fmt::Display
+    T: Eq + std::hash::Hash + std::borrow::Borrow<str> + Clone + std::fmt::Display + From<String>
 {
 }
 

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -18,7 +18,9 @@ struct TimeSliceRaw {
     fraction: f64,
 }
 
-/// Get the specified `String` from `set` or insert if it doesn't exist
+/// Get the specified ID from `set` or insert if it doesn't exist.
+///
+/// The purpose of returning an ID is so that we can dedup memory.
 fn get_or_insert<T: IDLike>(id: T, set: &mut IndexSet<T>) -> T {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
     match set.get_id(&id) {

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -19,7 +19,7 @@ struct TimeSliceRaw {
 }
 
 /// Get the specified `String` from `set` or insert if it doesn't exist
-fn get_or_insert<T: IDLike + From<String>>(value: String, set: &mut IndexSet<T>) -> T {
+fn get_or_insert<T: IDLike>(value: String, set: &mut IndexSet<T>) -> T {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
     match set.get_id_by_str(&value) {
         Ok(id) => id.clone(),

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,11 +1,11 @@
 //! Code for reading in time slice info from a CSV file.
 use super::*;
+use crate::id::IDCollection;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use anyhow::{ensure, Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 use std::path::Path;
-use std::rc::Rc;
 
 const TIME_SLICES_FILE_NAME: &str = "time_slices.csv";
 
@@ -19,14 +19,14 @@ struct TimeSliceRaw {
 }
 
 /// Get the specified `String` from `set` or insert if it doesn't exist
-fn get_or_insert(value: String, set: &mut IndexSet<Rc<str>>) -> Rc<str> {
+fn get_or_insert<T: IDLike + From<String>>(value: String, set: &mut IndexSet<T>) -> T {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
-    match set.get(value.as_str()) {
-        Some(value) => Rc::clone(value),
-        None => {
-            let value = Rc::from(value);
-            set.insert(Rc::clone(&value));
-            value
+    match set.get_id_by_str(&value) {
+        Ok(id) => id.clone(),
+        Err(_) => {
+            let id: T = value.into();
+            set.insert(id.clone());
+            id
         }
     }
 }

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,7 +1,7 @@
 //! Code for reading in time slice info from a CSV file.
 use super::*;
 use crate::id::IDCollection;
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
+use crate::time_slice::{Season, TimeOfDay, TimeSliceID, TimeSliceInfo};
 use anyhow::{ensure, Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
@@ -12,19 +12,18 @@ const TIME_SLICES_FILE_NAME: &str = "time_slices.csv";
 /// A time slice record retrieved from a CSV file
 #[derive(PartialEq, Debug, Deserialize)]
 struct TimeSliceRaw {
-    season: String,
-    time_of_day: String,
+    season: Season,
+    time_of_day: TimeOfDay,
     #[serde(deserialize_with = "deserialise_proportion_nonzero")]
     fraction: f64,
 }
 
 /// Get the specified `String` from `set` or insert if it doesn't exist
-fn get_or_insert<T: IDLike>(value: String, set: &mut IndexSet<T>) -> T {
+fn get_or_insert<T: IDLike>(id: T, set: &mut IndexSet<T>) -> T {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
-    match set.get_id_by_str(&value) {
+    match set.get_id(&id) {
         Ok(id) => id.clone(),
         Err(_) => {
-            let id: T = value.into();
             set.insert(id.clone());
             id
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -84,7 +84,7 @@ impl AssetRow {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CommodityFlowRow {
     commodity_id: CommodityID,
-    time_slice: String,
+    time_slice: TimeSliceID,
     flow: f64,
 }
 
@@ -94,7 +94,7 @@ struct CommodityPriceRow {
     milestone_year: u32,
     commodity_id: CommodityID,
     region_id: RegionID,
-    time_slice: String,
+    time_slice: TimeSliceID,
     price: f64,
 }
 
@@ -148,7 +148,7 @@ impl DataWriter {
             let asset_row = AssetRow::new(milestone_year, asset);
             let flow_row = CommodityFlowRow {
                 commodity_id: commodity_id.clone(),
-                time_slice: time_slice.to_string(),
+                time_slice: time_slice.clone(),
                 flow,
             };
             self.flows_writer.serialize((asset_row, flow_row))?;
@@ -164,7 +164,7 @@ impl DataWriter {
                 milestone_year,
                 commodity_id: commodity_id.clone(),
                 region_id: region_id.clone(),
-                time_slice: time_slice.to_string(),
+                time_slice: time_slice.clone(),
                 price,
             };
             self.prices_writer.serialize(row)?;
@@ -256,7 +256,7 @@ mod tests {
         // Read back and compare
         let expected = CommodityFlowRow {
             commodity_id,
-            time_slice: time_slice.to_string(),
+            time_slice,
             flow: 42.0,
         };
         let records: Vec<CommodityFlowRow> =
@@ -295,7 +295,7 @@ mod tests {
             milestone_year,
             commodity_id,
             region_id,
-            time_slice: time_slice.to_string(),
+            time_slice,
             price,
         };
         let records: Vec<CommodityPriceRow> =

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -36,10 +36,12 @@ impl<'de> Deserialize<'de> for TimeSliceID {
         D: serde::Deserializer<'de>,
     {
         let s: &str = Deserialize::deserialize(deserialiser)?;
-        let (season, time_of_day) = s
-            .split(".")
-            .collect_tuple()
-            .ok_or_else(|| D::Error::custom(format!("Invalid input '{}': Should be in form season.time_of_day", s)))?;
+        let (season, time_of_day) = s.split(".").collect_tuple().ok_or_else(|| {
+            D::Error::custom(format!(
+                "Invalid input '{}': Should be in form season.time_of_day",
+                s
+            ))
+        })?;
         Ok(Self {
             season: season.into(),
             time_of_day: time_of_day.into(),

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -6,7 +6,8 @@ use crate::id::{define_id_type, IDCollection};
 use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
-use serde::Serialize;
+use serde::de::Error;
+use serde::{Deserialize, Serialize};
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::fmt::Display;
 use std::iter;
@@ -26,6 +27,23 @@ pub struct TimeSliceID {
 impl Display for TimeSliceID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.season, self.time_of_day)
+    }
+}
+
+impl<'de> Deserialize<'de> for TimeSliceID {
+    fn deserialize<D>(deserialiser: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserialiser)?;
+        let (season, time_of_day) = s
+            .split(".")
+            .collect_tuple()
+            .ok_or_else(|| D::Error::custom("Should be in form season.time_of_day"))?;
+        Ok(Self {
+            season: season.into(),
+            time_of_day: time_of_day.into(),
+        })
     }
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -2,21 +2,24 @@
 //!
 //! Time slices provide a mechanism for users to indicate production etc. varies with the time of
 //! day and time of year.
+use crate::id::{define_id_type, IDCollection};
 use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::fmt::Display;
 use std::iter;
-use std::rc::Rc;
+
+define_id_type! {Season}
+define_id_type! {TimeOfDay}
 
 /// An ID describing season and time of day
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub struct TimeSliceID {
     /// The name of each season.
-    pub season: Rc<str>,
+    pub season: Season,
     /// The name of each time slice within a day.
-    pub time_of_day: Rc<str>,
+    pub time_of_day: TimeOfDay,
 }
 
 impl Display for TimeSliceID {
@@ -31,7 +34,7 @@ pub enum TimeSliceSelection {
     /// All year and all day
     Annual,
     /// Only applies to one season
-    Season(Rc<str>),
+    Season(Season),
     /// Only applies to a single time slice
     Single(TimeSliceID),
 }
@@ -54,9 +57,9 @@ pub enum TimeSliceLevel {
 #[derive(PartialEq, Debug)]
 pub struct TimeSliceInfo {
     /// Names of seasons
-    pub seasons: IndexSet<Rc<str>>,
+    pub seasons: IndexSet<Season>,
     /// Names of times of day (e.g. "evening")
-    pub times_of_day: IndexSet<Rc<str>>,
+    pub times_of_day: IndexSet<TimeOfDay>,
     /// The fraction of the year that this combination of season and time of day occupies
     pub fractions: IndexMap<TimeSliceID, f64>,
 }
@@ -71,8 +74,8 @@ impl Default for TimeSliceInfo {
         let fractions = [(id.clone(), 1.0)].into_iter().collect();
 
         Self {
-            seasons: [id.season].into_iter().collect(),
-            times_of_day: [id.time_of_day].into_iter().collect(),
+            seasons: iter::once(id.season).collect(),
+            times_of_day: iter::once(id.time_of_day).collect(),
             fractions,
         }
     }
@@ -89,18 +92,16 @@ impl TimeSliceInfo {
             .context("Time slice must be in the form season.time_of_day")?;
         let season = self
             .seasons
-            .iter()
-            .find(|item| item.eq_ignore_ascii_case(season))
+            .get_id_by_str(season)
             .with_context(|| format!("{} is not a known season", season))?;
         let time_of_day = self
             .times_of_day
-            .iter()
-            .find(|item| item.eq_ignore_ascii_case(time_of_day))
+            .get_id_by_str(time_of_day)
             .with_context(|| format!("{} is not a known time of day", time_of_day))?;
 
         Ok(TimeSliceID {
-            season: Rc::clone(season),
-            time_of_day: Rc::clone(time_of_day),
+            season: season.clone(),
+            time_of_day: time_of_day.clone(),
         })
     }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for TimeSliceID {
         let (season, time_of_day) = s
             .split(".")
             .collect_tuple()
-            .ok_or_else(|| D::Error::custom("Should be in form season.time_of_day"))?;
+            .ok_or_else(|| D::Error::custom(format!("Invalid input '{}': Should be in form season.time_of_day", s)))?;
         Ok(Self {
             season: season.into(),
             time_of_day: time_of_day.into(),

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -6,6 +6,7 @@ use crate::id::{define_id_type, IDCollection};
 use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
+use serde::Serialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::fmt::Display;
 use std::iter;
@@ -25,6 +26,15 @@ pub struct TimeSliceID {
 impl Display for TimeSliceID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.season, self.time_of_day)
+    }
+}
+
+impl Serialize for TimeSliceID {
+    fn serialize<S>(&self, serialiser: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serialiser.collect_str(self)
     }
 }
 


### PR DESCRIPTION
# Description

We have bespoke types for e.g. commodity ID, region ID etc. The two parts of time slices -- seasons and time of day -- are effectively ID types too, so let's enforce this with the type system for type safety and readability. Also implement `Serialize` and `Deserialize` for `TimeSliceID` (composed of a season + time of day) so that we can read/write these values directly without converting to/from strings.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
