### PR TITLE
Remove unused CSV files

### DIFF
--- a/examples/simple/commodity_constraints.csv
+++ b/examples/simple/commodity_constraints.csv
@@ -1,1 +1,0 @@
-commodity_constraint,commodity_id,region_id,limit_type,balance_type,year,time_slice,value

--- a/examples/simple/process_flow_share_constraints.csv
+++ b/examples/simple/process_flow_share_constraints.csv
@@ -1,1 +1,0 @@
-process_id,commodity_id,limit_type,time_slice,value

--- a/examples/simple/process_investment_constraints.csv
+++ b/examples/simple/process_investment_constraints.csv
@@ -1,1 +1,0 @@
-process_investment_constraint,process_id,region_id,limit_type,constraint_type,year,growth_seed_value,value


### PR DESCRIPTION
There are three CSV files in the example model that are currently empty and unused anywhere in the code. Support for them will not be added in this milestone (maybe not the engagement). Let's remove them for now.

The rationale for removing them is that a) leaving them in the example model is misleading (changing them won't affect anything) and b) if/when we *do* add support, attempting to run MUSE2 on the old version of the model might not work as the files will be empty (and may have the wrong column headings etc.).

Closes #496.