### PR TITLE
`parse_year_str`: Handle out-of-order and duplicate years

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -338,8 +338,10 @@ mod tests {
     #[case(&[], true)]
     #[case(&[1], true)]
     #[case(&[1,2], true)]
+    #[case(&[1,2,3,4], true)]
     #[case(&[2,1],false)]
     #[case(&[1,1],false)]
+    #[case(&[1,3,2,4], false)]
     fn test_is_sorted_and_unique(#[case] values: &[u32], #[case] expected: bool) {
         assert_eq!(is_sorted_and_unique(values), expected)
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -138,6 +138,15 @@ where
     Ok(())
 }
 
+/// Check whether an iterator contains values that are sorted and unique
+pub fn is_sorted_and_unique<T, I>(iter: I) -> bool
+where
+    T: PartialOrd + Clone,
+    I: IntoIterator<Item = T>,
+{
+    iter.into_iter().tuple_windows().all(|(a, b)| a < b)
+}
+
 /// Inserts a key-value pair into a HashMap if the key does not already exist.
 ///
 /// If the key already exists, it returns an error with a message indicating the key's existence.
@@ -200,9 +209,9 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::id::GenericID;
-
     use super::*;
+    use crate::id::GenericID;
+    use rstest::rstest;
     use serde::de::value::{Error as ValueError, F64Deserializer};
     use serde::de::IntoDeserializer;
     use serde::Deserialize;
@@ -323,5 +332,15 @@ mod tests {
         // Edge cases
         assert!(check_fractions_sum_to_one([f64::INFINITY].into_iter()).is_err());
         assert!(check_fractions_sum_to_one([f64::NAN].into_iter()).is_err());
+    }
+
+    #[rstest]
+    #[case(&[], true)]
+    #[case(&[1], true)]
+    #[case(&[1,2], true)]
+    #[case(&[2,1],false)]
+    #[case(&[1,1],false)]
+    fn test_is_sorted_and_unique(#[case] values: &[u32], #[case] expected: bool) {
+        assert_eq!(is_sorted_and_unique(values), expected)
     }
 }

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -115,15 +115,15 @@ where
             .with_context(|| format!("Process {id} not found"))?;
 
         // Get regions
-        let process_regions = process.regions.clone();
+        let process_regions = &process.regions;
         let record_regions =
-            parse_region_str(&record.regions, &process_regions).with_context(|| {
+            parse_region_str(&record.regions, process_regions).with_context(|| {
                 format!("Invalid region for process {id}. Valid regions are {process_regions:?}")
             })?;
 
         // Get years
-        let process_years = process.years.clone();
-        let record_years = parse_year_str(&record.years, &process_years).with_context(|| {
+        let process_years = &process.years;
+        let record_years = parse_year_str(&record.years, process_years).with_context(|| {
             format!("Invalid year for process {id}. Valid years are {process_years:?}")
         })?;
 

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -88,15 +88,15 @@ where
             .with_context(|| format!("Process {id} not found"))?;
 
         // Get regions
-        let process_regions = process.regions.clone();
+        let process_regions = &process.regions;
         let record_regions =
-            parse_region_str(&record.regions, &process_regions).with_context(|| {
+            parse_region_str(&record.regions, process_regions).with_context(|| {
                 format!("Invalid region for process {id}. Valid regions are {process_regions:?}")
             })?;
 
         // Get years
-        let process_years = process.years.clone();
-        let record_years = parse_year_str(&record.years, &process_years).with_context(|| {
+        let process_years = &process.years;
+        let record_years = parse_year_str(&record.years, process_years).with_context(|| {
             format!("Invalid year for process {id}. Valid years are {process_years:?}")
         })?;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 //! The model represents the static input data provided by the user.
 use crate::agent::AgentMap;
 use crate::commodity::CommodityMap;
-use crate::input::{input_err_msg, read_toml};
+use crate::input::{input_err_msg, is_sorted_and_unique, read_toml};
 use crate::process::ProcessMap;
 use crate::region::{RegionID, RegionMap};
 use crate::time_slice::TimeSliceInfo;
@@ -54,10 +54,7 @@ fn check_milestone_years(years: &[u32]) -> Result<()> {
     ensure!(!years.is_empty(), "`milestone_years` is empty");
 
     ensure!(
-        years[..years.len() - 1]
-            .iter()
-            .zip(years[1..].iter())
-            .all(|(y1, y2)| y1 < y2),
+        is_sorted_and_unique(years),
         "`milestone_years` must be composed of unique values in order"
     );
 

--- a/src/year.rs
+++ b/src/year.rs
@@ -1,5 +1,6 @@
 //! Code for working with years.
 use anyhow::{ensure, Result};
+use itertools::Itertools;
 
 /// Parse a string of years separated by semicolons into a vector of u32 years.
 ///
@@ -13,7 +14,8 @@ pub fn parse_year_str(s: &str, milestone_years: &[u32]) -> Result<Vec<u32>> {
         return Ok(Vec::from_iter(milestone_years.iter().copied()));
     }
 
-    s.split(";")
+    let mut years: Vec<_> = s
+        .split(";")
         .map(|y| {
             let year = y.trim().parse::<u32>()?;
             ensure!(
@@ -22,5 +24,11 @@ pub fn parse_year_str(s: &str, milestone_years: &[u32]) -> Result<Vec<u32>> {
             );
             Ok(year)
         })
-        .collect()
+        .try_collect()?;
+
+    // Sort years and remove duplicates
+    years.sort_unstable();
+    years.dedup();
+
+    Ok(years)
 }


### PR DESCRIPTION
# Description

We have no guarantees that users won't enter the same year twice or supply years out of order (e.g. "2010;2005"). It would be useful if the code could rely on the years being unique, sorted values, so let's enforce it.

I wrote some tests while I was at it.

Unrelated change: I was looking to see where we were using these parsed years and came across a few unnecessary `clone`s, which I've removed.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
