### PR TITLE
Disallow certain values for IDs

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -150,3 +150,39 @@ impl<ID: IDLike> IDCollection<ID> for HashSet<ID> {
 impl<ID: IDLike> IDCollection<ID> for IndexSet<ID> {
     define_id_methods!();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct Record {
+        id: GenericID,
+    }
+
+    fn deserialise_id(id: &str) -> Result<Record> {
+        Ok(toml::from_str(&format!("id = \"{id}\""))?)
+    }
+
+    #[rstest]
+    #[case("commodity1")]
+    #[case("some commodity")]
+    #[case("PROCESS")]
+    #[case("café")] // unicode supported
+    fn test_deserialise_id_valid(#[case] id: &str) {
+        assert_eq!(deserialise_id(id).unwrap().id.to_string(), id);
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case("all")]
+    #[case("annual")]
+    #[case("ALL")]
+    #[case(" ALL ")]
+    fn test_deserialise_id_invalid(#[case] id: &str) {
+        assert!(deserialise_id(id).is_err());
+    }
+}


### PR DESCRIPTION
# Description

We don't want users to name their proceses `all` or whatever as it'll break things, so let's prohibit it. I've currently prohibited empty strings, `all` and `annual` (could cause issues if a user names a season this).

Closes #548.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
