### PR TITLE
Represent agent search space with `Rc<Process>`

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,7 +2,7 @@
 //! assets.
 use crate::commodity::CommodityID;
 use crate::id::{define_id_getter, define_id_type};
-use crate::process::ProcessID;
+use crate::process::Process;
 use crate::region::RegionID;
 use indexmap::IndexMap;
 use serde_string_enum::DeserializeLabeledStringEnum;
@@ -22,7 +22,7 @@ pub type AgentCostLimitsMap = HashMap<u32, AgentCostLimits>;
 pub type AgentCommodityPortionsMap = HashMap<(CommodityID, u32), f64>;
 
 /// A map for the agent's search space, keyed by commodity and year
-pub type AgentSearchSpaceMap = HashMap<(CommodityID, u32), Rc<Vec<ProcessID>>>;
+pub type AgentSearchSpaceMap = HashMap<(CommodityID, u32), Rc<Vec<Rc<Process>>>>;
 
 /// A map of objectives for an agent, keyed by commodity and year.
 ///

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -57,7 +57,6 @@ pub fn read_agents(
     region_ids: &HashSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<AgentMap> {
-    let process_ids = processes.keys().cloned().collect();
     let mut agents = read_agents_file(model_dir, region_ids)?;
     let agent_ids = agents.keys().cloned().collect();
 
@@ -66,7 +65,7 @@ pub fn read_agents(
     let mut search_spaces = read_agent_search_space(
         model_dir,
         &agents,
-        &process_ids,
+        processes,
         &commodity_ids,
         milestone_years,
     )?;

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -156,17 +156,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixture::{agents, assert_error, process_parameter_map, region_ids};
+    use crate::fixture::{agents, assert_error, region_ids};
     use crate::process::{ProcessEnergyLimitsMap, ProcessFlowsMap, ProcessID, ProcessParameterMap};
     use crate::region::RegionID;
     use rstest::{fixture, rstest};
     use std::iter;
 
     #[fixture]
-    pub fn processes(
-        region_ids: HashSet<RegionID>,
-        process_parameter_map: ProcessParameterMap,
-    ) -> ProcessMap {
+    pub fn processes(region_ids: HashSet<RegionID>) -> ProcessMap {
         ["A", "B", "C"]
             .map(|id| {
                 let id: ProcessID = id.into();
@@ -176,7 +173,7 @@ mod tests {
                     years: vec![2010, 2020],
                     energy_limits: ProcessEnergyLimitsMap::new(),
                     flows: ProcessFlowsMap::new(),
-                    parameters: process_parameter_map.clone(),
+                    parameters: ProcessParameterMap::new(),
                     regions: region_ids.clone(),
                 };
                 (id, process.into())


### PR DESCRIPTION
# Description

While working on #483, I was looking at using the agent search space and realised it's probably easier if we just store the processes (as `Rc<Process>`) in the `AgentSearchSpaceMap` directly, rather than just the process IDs, so I've changed that.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
