### PR TITLE
Ensure assets have capacity >0

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -69,8 +69,8 @@ impl Asset {
             .clone();
 
         ensure!(
-            capacity.is_normal() && capacity > 0.0,
-            "Capacity must be a number >0"
+            capacity.is_finite() && capacity > 0.0,
+            "Capacity must be a finite, positive number"
         );
 
         Ok(Self {
@@ -300,7 +300,7 @@ mod tests {
         let region_id = RegionID("GBR".into());
         assert_error!(
             Asset::new(agent_id, process.into(), region_id, capacity, 2015),
-            "Capacity must be a number >0"
+            "Capacity must be a finite, positive number"
         );
     }
 


### PR DESCRIPTION
# Description

I noticed we're currently not enforcing that asset capacity is a number >0, so fixed that. This is mostly for when assets are created in the input layer, to make sure the user hasn't entered some dubious value, but it will also be useful as a sanity check when we come to creating assets within the simulation too.

There may be cases where we want to temporarily create assets within the simulation with a capacity of zero, but I figure we can fiddle with the interface at that point if needed. In any case, I don't think we want *users* creating assets with capacities of zero, so let's just forbid it for now.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
