### PR TITLE
Store assets as reference counted values and rework `AssetPool` API

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -286,16 +286,32 @@ impl AssetPool {
     where
         I: IntoIterator<Item = Rc<Asset>>,
     {
-        let new_pool = assets.into_iter().map(|asset| {
+        let new_pool = assets.into_iter().map(|mut asset| {
             if asset.id.is_some() {
                 // Already commissioned
                 asset.into()
             } else {
-                // Newly created from process. We need to assign an ID.
-                let mut asset = asset.as_ref().clone();
-                asset.id = Some(AssetID(self.next_id));
-                self.next_id += 1;
-                asset.into()
+                let mut update_id = |asset: &mut Asset| {
+                    // We need to assign an ID
+                    asset.id = Some(AssetID(self.next_id));
+                    self.next_id += 1;
+                };
+
+                // Asset is newly created from process. We use `get_mut` to avoid a clone in the
+                // (likely) case that there is only one reference to `asset`
+                let rc_asset = match Rc::get_mut(&mut asset) {
+                    Some(asset_inner) => {
+                        update_id(asset_inner);
+                        asset
+                    }
+                    None => {
+                        let mut asset = asset.as_ref().clone();
+                        update_id(&mut asset);
+                        asset.into()
+                    }
+                };
+
+                rc_asset.into()
             }
         });
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -23,7 +23,7 @@ impl AssetID {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Asset {
     /// A unique identifier for the asset
-    pub id: AssetID,
+    id: AssetID,
     /// A unique identifier for the agent
     pub agent_id: AgentID,
     /// The [`Process`] that this asset corresponds to

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -161,24 +161,6 @@ impl AssetPool {
         }
     }
 
-    /// Add an asset to the active pool (i.e. commission it immediately).
-    ///
-    /// The asset's commission year is ignored by this function.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the asset has already been commissioned.
-    pub fn commission(&mut self, mut asset: Asset) {
-        assert!(
-            asset.id == AssetID::INVALID,
-            "Asset has already been commissioned"
-        );
-
-        asset.id = AssetID(self.next_id);
-        self.next_id += 1;
-        self.active.push(asset.into());
-    }
-
     /// Commission new assets for the specified milestone year from the input data
     pub fn commission_new(&mut self, year: u32) {
         // Count the number of assets to move
@@ -447,15 +429,6 @@ mod tests {
         // Nothing to commission for this year
         asset_pool.commission_new(2000);
         assert!(asset_pool.iter().next().is_none()); // no active assets
-    }
-
-    #[rstest]
-    fn test_asset_pool_commission(mut asset_pool: AssetPool, process: Process) {
-        let mut asset =
-            Asset::new("agent2".into(), process.into(), "USA".into(), 100.0, 2015).unwrap();
-        asset_pool.commission(asset.clone());
-        asset.id = AssetID(0);
-        assert_equal(asset_pool.iter(), iter::once(&asset.into()));
     }
 
     #[rstest]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -138,6 +138,9 @@ impl Asset {
 ///
 /// An [`AssetRef`] is guaranteed to have been commissioned at some point, though it may
 /// subsequently have been decommissioned.
+///
+/// [`AssetRef`]s must be created from `Rc<Asset>`s. If the asset has not been commissioned, this
+/// will panic.
 #[derive(Clone, Debug)]
 pub struct AssetRef(Rc<Asset>);
 
@@ -177,9 +180,7 @@ impl PartialEq for AssetRef {
 impl Eq for AssetRef {}
 
 impl Hash for AssetRef {
-    /// Hash asset based purely on its ID.
-    ///
-    /// Panics if the asset has not been commissioned (and therefore has no ID).
+    /// Hash asset based purely on its ID
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.id.unwrap().hash(state);
     }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -148,12 +148,6 @@ impl From<Rc<Asset>> for AssetRef {
     }
 }
 
-impl From<&Rc<Asset>> for AssetRef {
-    fn from(value: &Rc<Asset>) -> Self {
-        Self::from(Rc::clone(value))
-    }
-}
-
 impl From<Asset> for AssetRef {
     fn from(value: Asset) -> Self {
         Self::from(Rc::new(value))

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -455,12 +455,12 @@ mod tests {
     #[rstest]
     fn test_asset_pool_decommission_old(mut asset_pool: AssetPool) {
         asset_pool.commission_new(2020);
-        assert!(asset_pool.active.len() == 2);
+        assert_eq!(asset_pool.active.len(), 2);
         asset_pool.decommission_old(2020); // should decommission first asset (lifetime == 5)
-        assert!(asset_pool.active.len() == 1);
+        assert_eq!(asset_pool.active.len(), 1);
         assert_eq!(asset_pool.active[0].commission_year, 2020);
         asset_pool.decommission_old(2022); // nothing to decommission
-        assert!(asset_pool.active.len() == 1);
+        assert_eq!(asset_pool.active.len(), 1);
         assert_eq!(asset_pool.active[0].commission_year, 2020);
         asset_pool.decommission_old(2025); // should decommission second asset
         assert!(asset_pool.active.is_empty());

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,6 @@
 //! The module responsible for writing output data to disk.
 use crate::agent::AgentID;
-use crate::asset::{Asset, AssetID, AssetPool, AssetRef};
+use crate::asset::{Asset, AssetRef};
 use crate::commodity::CommodityID;
 use crate::process::ProcessID;
 use crate::region::RegionID;
@@ -165,13 +165,8 @@ impl DebugDataWriter {
     }
 
     /// Write all debug info to output files
-    fn write_debug_info(
-        &mut self,
-        milestone_year: u32,
-        solution: &Solution,
-        assets: &AssetPool,
-    ) -> Result<()> {
-        self.write_capacity_duals(milestone_year, solution.iter_capacity_duals(), assets)?;
+    fn write_debug_info(&mut self, milestone_year: u32, solution: &Solution) -> Result<()> {
+        self.write_capacity_duals(milestone_year, solution.iter_capacity_duals())?;
         self.write_commodity_balance_duals(
             milestone_year,
             solution.iter_commodity_balance_duals(),
@@ -180,17 +175,11 @@ impl DebugDataWriter {
     }
 
     /// Write capacity duals to file
-    fn write_capacity_duals<'a, I>(
-        &mut self,
-        milestone_year: u32,
-        iter: I,
-        assets: &AssetPool,
-    ) -> Result<()>
+    fn write_capacity_duals<'a, I>(&mut self, milestone_year: u32, iter: I) -> Result<()>
     where
-        I: Iterator<Item = (AssetID, &'a TimeSliceID, f64)>,
+        I: Iterator<Item = (&'a AssetRef, &'a TimeSliceID, f64)>,
     {
-        for (asset_id, time_slice, value) in iter {
-            let asset = assets.get(asset_id).unwrap();
+        for (asset, time_slice, value) in iter {
             let asset_row = AssetRow::new(milestone_year, asset);
             let dual_row = CapacityDualsRow {
                 time_slice: time_slice.clone(),
@@ -315,14 +304,9 @@ impl DataWriter {
     }
 
     /// Write debug information to CSV files
-    pub fn write_debug_info(
-        &mut self,
-        milestone_year: u32,
-        solution: &Solution,
-        assets: &AssetPool,
-    ) -> Result<()> {
+    pub fn write_debug_info(&mut self, milestone_year: u32, solution: &Solution) -> Result<()> {
         if let Some(ref mut wtr) = &mut self.debug_writer {
-            wtr.write_debug_info(milestone_year, solution, assets)?;
+            wtr.write_debug_info(milestone_year, solution)?;
         }
 
         Ok(())
@@ -344,6 +328,7 @@ impl DataWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::asset::AssetPool;
     use crate::fixture::{asset, assets, commodity_id, region_id, time_slice};
     use crate::time_slice::TimeSliceID;
     use itertools::{assert_equal, Itertools};
@@ -484,16 +469,13 @@ mod tests {
         let milestone_year = 2020;
         let value = 0.5;
         let dir = tempdir().unwrap();
+        let asset = assets.iter().next().unwrap().into();
 
         // Write capacity dual
         {
             let mut writer = DebugDataWriter::create(dir.path()).unwrap();
             writer
-                .write_capacity_duals(
-                    milestone_year,
-                    iter::once((assets.iter().next().unwrap().id, &time_slice, value)),
-                    &assets,
-                )
+                .write_capacity_duals(milestone_year, iter::once((&asset, &time_slice, value)))
                 .unwrap();
             writer.flush().unwrap();
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 /// The root folder in which model-specific output folders will be created
 const OUTPUT_DIRECTORY_ROOT: &str = "muse2_results";
@@ -269,7 +270,7 @@ impl DataWriter {
     /// Write assets to a CSV file
     pub fn write_assets<'a, I>(&mut self, milestone_year: u32, assets: I) -> Result<()>
     where
-        I: Iterator<Item = &'a Asset>,
+        I: Iterator<Item = &'a Rc<Asset>>,
     {
         for asset in assets {
             let row = AssetRow::new(milestone_year, asset);
@@ -358,6 +359,7 @@ mod tests {
 
     #[rstest]
     fn test_write_assets(asset: Asset) {
+        let asset = asset.into();
         let milestone_year = 2020;
         let dir = tempdir().unwrap();
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -59,7 +59,7 @@ pub fn run(
 
         // Write result of dispatch optimisation to file
         writer.write_debug_info(year, &solution, &assets)?;
-        writer.write_flows(year, &assets, solution.iter_commodity_flows_for_assets())?;
+        writer.write_flows(year, solution.iter_commodity_flows_for_assets())?;
         writer.write_prices(year, &prices)?;
 
         opt_results = Some((solution, prices));

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -58,7 +58,7 @@ pub fn run(
         let prices = CommodityPrices::from_model_and_solution(&model, &solution, &assets);
 
         // Write result of dispatch optimisation to file
-        writer.write_debug_info(year, &solution, &assets)?;
+        writer.write_debug_info(year, &solution)?;
         writer.write_flows(year, solution.iter_commodity_flows_for_assets())?;
         writer.write_prices(year, &prices)?;
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -4,7 +4,6 @@ use super::CommodityPrices;
 use crate::asset::AssetPool;
 use crate::model::Model;
 use log::info;
-use std::collections::HashSet;
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -22,18 +21,17 @@ pub fn perform_agent_investment(
 ) {
     info!("Performing agent investment...");
 
-    let mut assets_to_keep = HashSet::new();
+    let mut new_pool = Vec::new();
     for (asset_id, _commodity_id, _time_slice, _flow) in solution.iter_commodity_flows_for_assets()
     {
-        if assets.get(asset_id).is_none() {
+        let Some(asset) = assets.get(asset_id) else {
             // Asset has been decommissioned
             continue;
-        }
+        };
 
         // **TODO**: Implement agent investment. For now, just keep all assets.
-        assets_to_keep.insert(asset_id);
+        new_pool.push(asset.clone());
     }
 
-    // Decommission non-selected assets
-    assets.retain(&assets_to_keep);
+    assets.replace_active_pool(new_pool);
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -24,7 +24,7 @@ pub fn perform_agent_investment(
     let mut new_pool = Vec::new();
     for asset in assets.iter() {
         // **TODO**: Implement agent investment. For now, just keep all assets.
-        new_pool.push(asset.clone());
+        new_pool.push(asset.clone().into());
     }
 
     assets.replace_active_pool(new_pool);

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -15,20 +15,14 @@ use log::info;
 /// * `assets` - The asset pool
 pub fn perform_agent_investment(
     _model: &Model,
-    solution: &Solution,
+    _solution: &Solution,
     _prices: &CommodityPrices,
     assets: &mut AssetPool,
 ) {
     info!("Performing agent investment...");
 
     let mut new_pool = Vec::new();
-    for (asset_id, _commodity_id, _time_slice, _flow) in solution.iter_commodity_flows_for_assets()
-    {
-        let Some(asset) = assets.get(asset_id) else {
-            // Asset has been decommissioned
-            continue;
-        };
-
+    for asset in assets.iter() {
         // **TODO**: Implement agent investment. For now, just keep all assets.
         new_pool.push(asset.clone());
     }

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -64,7 +64,7 @@ impl Solution<'_> {
     /// An iterator of tuples containing an asset ID, commodity, time slice and flow.
     pub fn iter_commodity_flows_for_assets(
         &self,
-    ) -> impl Iterator<Item = (AssetID, &CommodityID, &TimeSliceID, f64)> {
+    ) -> impl Iterator<Item = (&AssetRef, &CommodityID, &TimeSliceID, f64)> {
         // **TODO:** Need to calculate flows by multiplying coeffs by asset activity:
         //  https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/593
         std::iter::empty()

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -184,7 +184,7 @@ fn add_variables(
         for time_slice in model.time_slice_info.iter_ids() {
             let coeff = calculate_cost_coefficient(asset, year, time_slice);
             let var = problem.add_column(coeff, 0.0..);
-            let key = (asset.into(), time_slice.clone());
+            let key = (asset.clone(), time_slice.clone());
             let existing = variables.0.insert(key, var).is_some();
             assert!(!existing, "Duplicate entry for var");
         }

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -35,8 +35,8 @@ impl VariableMap {
     /// Get the [`Variable`] corresponding to the given parameters.
     // **TODO:** Remove line below when we're using this
     #[allow(dead_code)]
-    fn get(&self, asset: AssetRef, time_slice: TimeSliceID) -> Variable {
-        let key = (asset, time_slice);
+    fn get(&self, asset: &AssetRef, time_slice: &TimeSliceID) -> Variable {
+        let key = (asset.clone(), time_slice.clone());
 
         *self
             .0

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -1,7 +1,7 @@
 //! Code for performing dispatch optimisation.
 //!
 //! This is used to calculate commodity flows and prices.
-use crate::asset::{Asset, AssetID, AssetPool, AssetRef};
+use crate::asset::{Asset, AssetPool, AssetRef};
 use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
@@ -88,11 +88,11 @@ impl Solution<'_> {
     }
 
     /// Keys and dual values for capacity constraints.
-    pub fn iter_capacity_duals(&self) -> impl Iterator<Item = (AssetID, &TimeSliceID, f64)> {
+    pub fn iter_capacity_duals(&self) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, f64)> {
         self.constraint_keys
             .capacity_keys
             .zip_duals(self.solution.dual_rows())
-            .map(|((asset_id, time_slice), dual)| (*asset_id, time_slice, dual))
+            .map(|((asset, time_slice), dual)| (asset, time_slice, dual))
     }
 }
 

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -1,6 +1,6 @@
 //! Code for adding constraints to the dispatch optimisation problem.
 use super::VariableMap;
-use crate::asset::{AssetID, AssetPool};
+use crate::asset::{AssetPool, AssetRef};
 use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
@@ -29,7 +29,7 @@ impl<T> KeysWithOffset<T> {
 pub type CommodityBalanceKeys = KeysWithOffset<(CommodityID, RegionID, TimeSliceSelection)>;
 
 /// Indicates the asset ID and time slice covered by each capacity constraint
-pub type CapacityKeys = KeysWithOffset<(AssetID, TimeSliceID)>;
+pub type CapacityKeys = KeysWithOffset<(AssetRef, TimeSliceID)>;
 
 /// The keys for different constraints
 pub struct ConstraintKeys {


### PR DESCRIPTION
# Description

I've reworked the `AssetPool` API as suggested in #591 to store assets as reference counted values. This has a couple of advantages over the current approach, namely:

1. We can store a representation of assets as (part of) the keys for the `VariableMap` as well as in the constraints keys data structures, which means we don't have to pass around the `AssetPool` all over the place
2. When we come to writing the dispatch code, we can store both retained assets and new assets to be commissioned in the same `Vec` (or whatever)

I've started on 1 by updating the existing data structures and functions. I made a small wrapper (`AssetRef`) around `Rc<Asset>` to be used for keys in maps etc. so that we can have custom `Eq` and `Hash` methods (just using the ID, otherwise performance would be crap). The reason for not just defining these methods for `Rc<Asset>` is because I thought it would be confusing and/or break tests if two different assets with the same ID came out as non-equal (this shouldn't happen in the main code, but could be a gotcha in unit tests). Plus, assets that haven't been commissioned yet don't have IDs, so can't be compared in this way.

I've also changed `Asset::id`s to be `Option`s rather than using a sentinel value for the not-commissioned ones, as that seems cleaner and safer.

Closes #591.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
