### PR TITLE
Allow user to specify demand at level of season or whole year

### DIFF
--- a/examples/simple/process_availabilities.csv
+++ b/examples/simple/process_availabilities.csv
@@ -1,9 +1,9 @@
 process_id,regions,years,time_slice,limit_type,value
-GASDRV,all,all,,up,0.9
-GASPRC,all,all,,up,0.9
-GASCGT,all,all,,up,0.9
-RGASBR,all,all,,up,1.0
-RELCHP,all,all,,up,1.0
+GASDRV,all,all,annual,up,0.9
+GASPRC,all,all,annual,up,0.9
+GASCGT,all,all,annual,up,0.9
+RGASBR,all,all,annual,up,1.0
+RELCHP,all,all,annual,up,1.0
 WNDFRM,all,all,winter.night,up,0.486418015
 WNDFRM,all,all,winter.day,up,0.543166784
 WNDFRM,all,all,winter.peak,up,0.504433498

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -139,8 +139,8 @@ pub fn time_slice() -> TimeSliceID {
 #[fixture]
 pub fn time_slice_info() -> TimeSliceInfo {
     TimeSliceInfo {
-        seasons: iter::once("winter".into()).collect(),
         times_of_day: iter::once("day".into()).collect(),
+        seasons: iter::once(("winter".into(), 1.0)).collect(),
         time_slices: [(
             TimeSliceID {
                 season: "winter".into(),

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -5,17 +5,17 @@ use crate::agent::{
     AgentSearchSpaceMap, DecisionRule,
 };
 use crate::asset::{Asset, AssetPool};
-use crate::commodity::CommodityID;
+use crate::commodity::{Commodity, CommodityCostMap, CommodityID, CommodityType, DemandMap};
 use crate::process::{
     Process, ProcessEnergyLimitsMap, ProcessFlowsMap, ProcessMap, ProcessParameter,
     ProcessParameterMap,
 };
 use crate::region::RegionID;
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
+use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
 use indexmap::indexmap;
 use itertools::Itertools;
 use rstest::fixture;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::rc::Rc;
 
@@ -53,6 +53,22 @@ pub fn agent_id() -> AgentID {
 #[fixture]
 pub fn commodity_id() -> CommodityID {
     "commodity1".into()
+}
+
+#[fixture]
+pub fn svd_commodity() -> Commodity {
+    Commodity {
+        id: "commodity1".into(),
+        description: "".into(),
+        kind: CommodityType::ServiceDemand,
+        time_slice_level: TimeSliceLevel::DayNight,
+        costs: CommodityCostMap::new(),
+        demand: DemandMap::new(),
+    }
+}
+
+pub fn get_svd_map(commodity: &Commodity) -> HashMap<CommodityID, &Commodity> {
+    iter::once((commodity.id.clone(), commodity)).collect()
 }
 
 #[fixture]

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -141,7 +141,7 @@ pub fn time_slice_info() -> TimeSliceInfo {
     TimeSliceInfo {
         seasons: iter::once("winter".into()).collect(),
         times_of_day: iter::once("day".into()).collect(),
-        fractions: [(
+        time_slices: [(
             TimeSliceID {
                 season: "winter".into(),
                 time_of_day: "day".into(),

--- a/src/input/commodity/cost.rs
+++ b/src/input/commodity/cost.rs
@@ -219,7 +219,7 @@ mod tests {
             time_of_day: "night".into(),
         };
         let time_slice_info = TimeSliceInfo {
-            seasons: ["winter".into()].into(),
+            seasons: [("winter".into(), 1.0)].into(),
             times_of_day: ["day".into(), "night".into()].into(),
             time_slices: [(time_slice.clone(), 0.5), (time_slice.clone(), 0.5)].into(),
         };

--- a/src/input/commodity/cost.rs
+++ b/src/input/commodity/cost.rs
@@ -159,7 +159,7 @@ mod tests {
         let ts_info = TimeSliceInfo {
             seasons: ["winter".into()].into(),
             times_of_day: ["day".into()].into(),
-            fractions: [(slice.clone(), 1.0)].into(),
+            time_slices: [(slice.clone(), 1.0)].into(),
         };
 
         let regions = HashSet::from(["UK".into()]);
@@ -189,7 +189,7 @@ mod tests {
         let ts_info2 = TimeSliceInfo {
             seasons: ["winter".into()].into(),
             times_of_day: ["day".into(), "night".into()].into(),
-            fractions: [(slice.clone(), 0.5), (slice2.clone(), 0.5)].into(),
+            time_slices: [(slice.clone(), 0.5), (slice2.clone(), 0.5)].into(),
         };
         assert!(validate_commodity_cost_map(&map, &regions, &milestone_years, &ts_info2).is_err());
     }

--- a/src/input/commodity/cost.rs
+++ b/src/input/commodity/cost.rs
@@ -101,7 +101,7 @@ where
                 .or_default()
                 .insert(region.clone());
             for year in years.iter() {
-                for (time_slice, _) in time_slice_info.iter_selection(&ts_selection) {
+                for (time_slice, _) in ts_selection.iter(time_slice_info) {
                     try_insert(
                         map,
                         (region.clone(), *year, time_slice.clone()),

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -243,52 +243,31 @@ mod tests {
                 fraction: 0.5,
             },
         ];
+
+        fn demand_slice_entry(
+            season: &str,
+            time_of_day: &str,
+            demand: f64,
+        ) -> ((CommodityID, RegionID, TimeSliceID), f64) {
+            (
+                (
+                    "commodity1".into(),
+                    "GBR".into(),
+                    TimeSliceID {
+                        season: season.into(),
+                        time_of_day: time_of_day.into(),
+                    },
+                ),
+                demand,
+            )
+        }
         let expected = DemandSliceMap::from_iter([
-            (
-                (
-                    "commodity1".into(),
-                    "GBR".into(),
-                    TimeSliceID {
-                        season: "summer".into(),
-                        time_of_day: "day".into(),
-                    },
-                ),
-                3.0 / 16.0,
-            ),
-            (
-                (
-                    "commodity1".into(),
-                    "GBR".into(),
-                    TimeSliceID {
-                        season: "summer".into(),
-                        time_of_day: "night".into(),
-                    },
-                ),
-                5.0 / 16.0,
-            ),
-            (
-                (
-                    "commodity1".into(),
-                    "GBR".into(),
-                    TimeSliceID {
-                        season: "winter".into(),
-                        time_of_day: "day".into(),
-                    },
-                ),
-                3.0 / 16.0,
-            ),
-            (
-                (
-                    "commodity1".into(),
-                    "GBR".into(),
-                    TimeSliceID {
-                        season: "winter".into(),
-                        time_of_day: "night".into(),
-                    },
-                ),
-                5.0 / 16.0,
-            ),
+            demand_slice_entry("summer", "day", 3.0 / 16.0),
+            demand_slice_entry("summer", "night", 5.0 / 16.0),
+            demand_slice_entry("winter", "day", 3.0 / 16.0),
+            demand_slice_entry("winter", "night", 5.0 / 16.0),
         ]);
+
         assert_eq!(
             read_demand_slices_from_iter(
                 demand_slices.into_iter(),

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -184,7 +184,9 @@ mod tests {
     ) {
         // Valid, multiple time slices
         let time_slice_info = TimeSliceInfo {
-            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            seasons: [("winter".into(), 0.5), ("summer".into(), 0.5)]
+                .into_iter()
+                .collect(),
             times_of_day: ["day".into(), "night".into()].into_iter().collect(),
             time_slices: [
                 (
@@ -388,7 +390,9 @@ mod tests {
     ) {
         // Some time slices uncovered
         let time_slice_info = TimeSliceInfo {
-            seasons: ["winter".into(), "summer".into()].into_iter().collect(),
+            seasons: [("winter".into(), 0.5), ("summer".into(), 0.5)]
+                .into_iter()
+                .collect(),
             times_of_day: iter::once("day".into()).collect(),
             time_slices: [
                 (

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -186,7 +186,7 @@ mod tests {
         let time_slice_info = TimeSliceInfo {
             seasons: ["winter".into(), "summer".into()].into_iter().collect(),
             times_of_day: ["day".into(), "night".into()].into_iter().collect(),
-            fractions: [
+            time_slices: [
                 (
                     TimeSliceID {
                         season: "summer".into(),
@@ -390,7 +390,7 @@ mod tests {
         let time_slice_info = TimeSliceInfo {
             seasons: ["winter".into(), "summer".into()].into_iter().collect(),
             times_of_day: iter::once("day".into()).collect(),
-            fractions: [
+            time_slices: [
                 (
                     TimeSliceID {
                         season: "winter".into(),

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -2,10 +2,11 @@
 use super::super::*;
 use crate::commodity::CommodityID;
 use crate::id::IDCollection;
+use crate::input::commodity::demand::BorrowedCommodityMap;
 use crate::region::RegionID;
-use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel, TimeSliceSelection};
+use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use anyhow::{ensure, Context, Result};
-use itertools::Itertools;
+use itertools::{iproduct, Itertools};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -21,21 +22,21 @@ struct DemandSlice {
     fraction: f64,
 }
 
-/// A map relating commodity, region and time slice to the fraction of annual demand
-pub type DemandSliceMap = HashMap<(CommodityID, RegionID, TimeSliceID), f64>;
+/// A map relating commodity, region and time slice selection to the fraction of annual demand
+pub type DemandSliceMap = HashMap<(CommodityID, RegionID, TimeSliceSelection), f64>;
 
 /// Read demand slices from specified model directory.
 ///
 /// # Arguments
 ///
 /// * `model_dir` - Folder containing model configuration files
-/// * `commodity_ids` - All possible IDs of commodities
+/// * `svd_commodities` - Map of service demand commodities
 /// * `region_ids` - All possible IDs for regions
 /// * `commodity_regions` - Pairs of commodities + regions listed in demand CSV file
 /// * `time_slice_info` - Information about seasons and times of day
 pub fn read_demand_slices(
     model_dir: &Path,
-    svd_commodity_ids: &HashSet<CommodityID>,
+    svd_commodities: &BorrowedCommodityMap,
     region_ids: &HashSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap> {
@@ -43,7 +44,7 @@ pub fn read_demand_slices(
     let demand_slices_csv = read_csv(&file_path)?;
     read_demand_slices_from_iter(
         demand_slices_csv,
-        svd_commodity_ids,
+        svd_commodities,
         region_ids,
         time_slice_info,
     )
@@ -53,7 +54,7 @@ pub fn read_demand_slices(
 /// Read demand slices from an iterator
 fn read_demand_slices_from_iter<I>(
     iter: I,
-    svd_commodity_ids: &HashSet<CommodityID>,
+    svd_commodities: &BorrowedCommodityMap,
     region_ids: &HashSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap>
@@ -63,8 +64,8 @@ where
     let mut demand_slices = DemandSliceMap::new();
 
     for slice in iter {
-        let commodity_id = svd_commodity_ids
-            .get_id(&slice.commodity_id)
+        let commodity = svd_commodities
+            .get(slice.commodity_id.as_str())
             .with_context(|| {
                 format!(
                     "Can only provide demand slice data for SVD commodities. Found entry for '{}'",
@@ -78,29 +79,36 @@ where
         // entry appropriately
         let ts_selection = time_slice_info.get_selection(&slice.time_slice)?;
 
-        // TODO: Fix for other time slice levels
-        for (ts_selection, demand_fraction) in time_slice_info
-            .calculate_share(&ts_selection, TimeSliceLevel::DayNight, slice.fraction)
-            .unwrap()
-        {
-            let TimeSliceSelection::Single(ts) = ts_selection else {
-                unreachable!()
-            };
-
-            // Share demand between the time slices in proportion to duration
-            ensure!(demand_slices.insert((commodity_id.clone(), region_id.clone(), ts.clone()), demand_fraction).is_none(),
+        // Share demand between the time slice selections in proportion to duration
+        let iter = time_slice_info
+            .calculate_share(&ts_selection, commodity.time_slice_level, slice.fraction)
+            .with_context(|| {
+                format!(
+                    "Cannot provide demand at {:?} level when commodity time slice level is {:?}",
+                    ts_selection.level(),
+                    commodity.time_slice_level
+                )
+            })?;
+        for (ts_selection, demand_fraction) in iter {
+            let existing = demand_slices
+                .insert(
+                    (
+                        commodity.id.clone(),
+                        region_id.clone(),
+                        ts_selection.clone(),
+                    ),
+                    demand_fraction,
+                )
+                .is_some();
+            ensure!(!existing,
                 "Duplicate demand slicing entry (or same time slice covered by more than one entry) \
-                (commodity: {commodity_id}, region: {region_id}, time slice: {ts})"
+                (commodity: {}, region: {}, time slice(s): {})"
+                ,commodity.id,region_id,ts_selection
             );
         }
     }
 
-    validate_demand_slices(
-        svd_commodity_ids,
-        region_ids,
-        &demand_slices,
-        time_slice_info,
-    )?;
+    validate_demand_slices(svd_commodities, region_ids, &demand_slices, time_slice_info)?;
 
     Ok(demand_slices)
 }
@@ -113,25 +121,25 @@ where
 /// * For every commodity + region pair, there must be entries covering every time slice
 /// * The demand fractions for all entries related to a commodity + region pair sum to one
 fn validate_demand_slices(
-    svd_commodity_ids: &HashSet<CommodityID>,
+    svd_commodities: &BorrowedCommodityMap,
     region_ids: &HashSet<RegionID>,
     demand_slices: &DemandSliceMap,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<()> {
-    let commodity_regions = svd_commodity_ids
-        .iter()
-        .cartesian_product(region_ids.iter())
-        .collect::<HashSet<_>>();
-    for (commodity_id, region_id) in commodity_regions {
+    for (commodity, region_id) in iproduct!(svd_commodities.values(), region_ids) {
         time_slice_info
-            .iter_ids()
-            .map(|time_slice| {
+            .iter_selections_for_level(commodity.time_slice_level)
+            .map(|ts_selection| {
                 demand_slices
-                    .get(&(commodity_id.clone(), region_id.clone(), time_slice.clone()))
+                    .get(&(
+                        commodity.id.clone(),
+                        region_id.clone(),
+                        ts_selection.clone(),
+                    ))
                     .with_context(|| {
                         format!(
-                            "Demand slice missing for time slice {} (commodity: {}, region {})",
-                            time_slice, commodity_id, region_id
+                            "Demand slice missing for time slice(s) '{}' (commodity: {}, region {})",
+                            ts_selection, commodity.id, region_id
                         )
                     })
             })
@@ -146,7 +154,9 @@ fn validate_demand_slices(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fixture::{assert_error, commodity_ids, time_slice_info};
+    use crate::commodity::Commodity;
+    use crate::fixture::{assert_error, get_svd_map, svd_commodity, time_slice_info};
+    use crate::time_slice::TimeSliceID;
     use rstest::{fixture, rstest};
     use std::iter;
 
@@ -157,11 +167,12 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_valid(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Valid
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "GBR".into(),
@@ -171,12 +182,12 @@ mod tests {
         let time_slice = time_slice_info
             .get_time_slice_id_from_str("winter.day")
             .unwrap();
-        let key = ("commodity1".into(), "GBR".into(), time_slice);
+        let key = ("commodity1".into(), "GBR".into(), time_slice.into());
         let expected = DemandSliceMap::from_iter(iter::once((key, 1.0)));
         assert_eq!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice.clone()),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             )
@@ -187,10 +198,11 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_valid_multiple_time_slices(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
     ) {
         // Valid, multiple time slices
+        let svd_commodities = get_svd_map(&svd_commodity);
         let time_slice_info = TimeSliceInfo {
             seasons: [("winter".into(), 0.5), ("summer".into(), 0.5)]
                 .into_iter()
@@ -248,7 +260,7 @@ mod tests {
             season: &str,
             time_of_day: &str,
             demand: f64,
-        ) -> ((CommodityID, RegionID, TimeSliceID), f64) {
+        ) -> ((CommodityID, RegionID, TimeSliceSelection), f64) {
             (
                 (
                     "commodity1".into(),
@@ -256,7 +268,8 @@ mod tests {
                     TimeSliceID {
                         season: season.into(),
                         time_of_day: time_of_day.into(),
-                    },
+                    }
+                    .into(),
                 ),
                 demand,
             )
@@ -271,7 +284,7 @@ mod tests {
         assert_eq!(
             read_demand_slices_from_iter(
                 demand_slices.into_iter(),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             )
@@ -282,29 +295,31 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_empty_file(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Empty CSV file
+        let svd_commodities = get_svd_map(&svd_commodity);
         assert_error!(
             read_demand_slices_from_iter(
                 iter::empty(),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
-            "Demand slice missing for time slice winter.day (commodity: commodity1, region GBR)"
+            "Demand slice missing for time slice(s) 'winter.day' (commodity: commodity1, region GBR)"
         );
     }
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_commodity(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad commodity
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity2".into(),
             region_id: "GBR".into(),
@@ -314,7 +329,7 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice.clone()),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
@@ -324,11 +339,12 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_region(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad region
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "FRA".into(),
@@ -338,7 +354,7 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice.clone()),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
@@ -348,11 +364,12 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_time_slice(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad time slice selection
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "GBR".into(),
@@ -362,7 +379,7 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice.clone()),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
@@ -372,10 +389,11 @@ mod tests {
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_missing_time_slices(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
     ) {
         // Some time slices uncovered
+        let svd_commodities = get_svd_map(&svd_commodity);
         let time_slice_info = TimeSliceInfo {
             seasons: [("winter".into(), 0.5), ("summer".into(), 0.5)]
                 .into_iter()
@@ -409,21 +427,22 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice.clone()),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
-            "Demand slice missing for time slice summer.day (commodity: commodity1, region GBR)"
+            "Demand slice missing for time slice(s) 'summer.day' (commodity: commodity1, region GBR)"
         );
     }
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_duplicate_time_slice(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Same time slice twice
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "GBR".into(),
@@ -433,22 +452,23 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::repeat_n(demand_slice.clone(), 2),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
             "Duplicate demand slicing entry (or same time slice covered by more than one entry) \
-            (commodity: commodity1, region: GBR, time slice: winter.day)"
+                (commodity: commodity1, region: GBR, time slice(s): winter.day)"
         );
     }
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_season_time_slice_conflict(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Whole season and single time slice conflicting
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "GBR".into(),
@@ -464,22 +484,23 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 [demand_slice, demand_slice_season].into_iter(),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),
             "Duplicate demand slicing entry (or same time slice covered by more than one entry) \
-            (commodity: commodity1, region: GBR, time slice: winter.day)"
+                (commodity: commodity1, region: GBR, time slice(s): winter.day)"
         );
     }
 
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_fractions(
-        commodity_ids: HashSet<CommodityID>,
+        svd_commodity: Commodity,
         region_ids: HashSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Fractions don't sum to one
+        let svd_commodities = get_svd_map(&svd_commodity);
         let demand_slice = DemandSlice {
             commodity_id: "commodity1".into(),
             region_id: "GBR".into(),
@@ -489,7 +510,7 @@ mod tests {
         assert_error!(
             read_demand_slices_from_iter(
                 iter::once(demand_slice),
-                &commodity_ids,
+                &svd_commodities,
                 &region_ids,
                 &time_slice_info,
             ),

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -5,7 +5,7 @@ use crate::process::{
     Process, ProcessEnergyLimitsMap, ProcessFlowsMap, ProcessID, ProcessMap, ProcessParameterMap,
 };
 use crate::region::{parse_region_str, RegionID};
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
+use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use anyhow::{ensure, Context, Ok, Result};
 use itertools::iproduct;
 use serde::Deserialize;
@@ -173,14 +173,17 @@ fn validate_commodities(
                 validate_sed_commodity(&commodity.id, flows, region_id, year)?;
             }
             CommodityType::ServiceDemand => {
-                for time_slice in time_slice_info.iter_ids() {
+                for ts_selection in
+                    time_slice_info.iter_selections_for_level(commodity.time_slice_level)
+                {
                     validate_svd_commodity(
+                        time_slice_info,
                         commodity,
                         flows,
                         availabilities,
                         region_id,
                         year,
-                        time_slice,
+                        &ts_selection,
                     )?;
                 }
             }
@@ -221,36 +224,42 @@ fn validate_sed_commodity(
 }
 
 fn validate_svd_commodity(
+    time_slice_info: &TimeSliceInfo,
     commodity: &Commodity,
     flows: &HashMap<ProcessID, ProcessFlowsMap>,
     availabilities: &HashMap<ProcessID, ProcessEnergyLimitsMap>,
     region_id: &RegionID,
     year: &u32,
-    time_slice: &TimeSliceID,
+    ts_selection: &TimeSliceSelection,
 ) -> Result<()> {
     // Check if the commodity has a demand in the given time slice, region and year.
     // We only need to check for producers if there is positive demand.
-    let demand = commodity
+    let demand = *commodity
         .demand
-        .get(&(region_id.clone(), *year, time_slice.clone()))
+        .get(&(region_id.clone(), *year, ts_selection.clone()))
         .unwrap();
-    if demand <= &0.0 {
+    if demand <= 0.0 {
         return Ok(());
     }
 
-    // We must check for producers in the given year, region and time slice.
+    // We must check for producers in the given year, region and time slices.
     // This includes checking if flow > 0 and if availability > 0.
     for (process_id, flows) in flows.iter() {
         let flows = flows.get(&(region_id.clone(), *year)).unwrap();
-        if let Some(flow) = flows.get(&commodity.id) {
-            if flow.flow <= 0.0 {
-                continue;
-            }
+        let Some(flow) = flows.get(&commodity.id) else {
+            // We're only interested in processes which produce this commodity
+            continue;
+        };
+        if flow.flow <= 0.0 {
+            // Check if it's a producer
+            continue;
+        }
 
+        // If the process has availability >0 in any time slice for this selection, we accept it
+        let availabilities = availabilities.get(process_id).unwrap();
+        for (ts, _) in time_slice_info.iter_selection(ts_selection) {
             let availability = availabilities
-                .get(process_id)
-                .unwrap()
-                .get(&(region_id.clone(), *year, time_slice.clone()))
+                .get(&(region_id.clone(), *year, ts.clone()))
                 .unwrap();
             if *availability.end() > 0.0 {
                 return Ok(());
@@ -260,11 +269,11 @@ fn validate_svd_commodity(
 
     // If we reach this point it means there is no producer, so we return an error.
     bail!(
-        "Commodity {} of 'SVD' type must have a producer process for region {} in year {} and time slice {}",
+        "Commodity {} of 'SVD' type must have a producer process for region {} in year {} and time slice(s) {}",
         commodity.id,
         region_id,
         year,
-        time_slice,
+        ts_selection,
     )
 }
 
@@ -272,9 +281,9 @@ fn validate_svd_commodity(
 mod tests {
     use super::*;
     use crate::commodity::{CommodityCostMap, DemandMap};
-    use crate::fixture::time_slice;
+    use crate::fixture::{time_slice, time_slice_info};
     use crate::process::{FlowType, ProcessFlow};
-    use crate::time_slice::TimeSliceLevel;
+    use crate::time_slice::{TimeSliceID, TimeSliceLevel};
     use indexmap::indexmap;
     use rstest::{fixture, rstest};
 
@@ -351,7 +360,7 @@ mod tests {
 
     #[fixture]
     fn commodity_svd(time_slice: TimeSliceID) -> Commodity {
-        let demand = DemandMap::from_iter(vec![(("GBR".into(), 2010, time_slice.clone()), 10.0)]);
+        let demand = DemandMap::from_iter(vec![(("GBR".into(), 2010, time_slice.into()), 10.0)]);
 
         Commodity {
             id: "commodity_svd".into(),
@@ -384,6 +393,7 @@ mod tests {
     fn test_validate_svd_commodity_valid(
         commodity_svd: Commodity,
         flows_svd: HashMap<ProcessID, ProcessFlowsMap>,
+        time_slice_info: TimeSliceInfo,
         time_slice: TimeSliceID,
     ) {
         let availabilities = HashMap::from_iter(vec![(
@@ -396,18 +406,20 @@ mod tests {
 
         // Valid scenario
         assert!(validate_svd_commodity(
+            &time_slice_info,
             &commodity_svd,
             &flows_svd,
             &availabilities,
             &"GBR".into(),
             &2010,
-            &time_slice.clone(),
+            &time_slice.into()
         )
         .is_ok());
     }
 
     #[rstest]
     fn test_validate_svd_commodity_invalid_no_availability(
+        time_slice_info: TimeSliceInfo,
         commodity_svd: Commodity,
         flows_svd: HashMap<ProcessID, ProcessFlowsMap>,
         time_slice: TimeSliceID,
@@ -421,12 +433,13 @@ mod tests {
             )]),
         )]);
         assert!(validate_svd_commodity(
+            &time_slice_info,
             &commodity_svd,
             &flows_svd,
             &availabilities,
             &"GBR".into(),
             &2010,
-            &time_slice.clone(),
+            &time_slice.into()
         )
         .is_err());
     }

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -257,7 +257,7 @@ fn validate_svd_commodity(
 
         // If the process has availability >0 in any time slice for this selection, we accept it
         let availabilities = availabilities.get(process_id).unwrap();
-        for (ts, _) in time_slice_info.iter_selection(ts_selection) {
+        for (ts, _) in ts_selection.iter(time_slice_info) {
             let availability = availabilities
                 .get(&(region_id.clone(), *year, ts.clone()))
                 .unwrap();

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -242,14 +242,17 @@ fn validate_svd_commodity(
     // This includes checking if flow > 0 and if availability > 0.
     for (process_id, flows) in flows.iter() {
         let flows = flows.get(&(region_id.clone(), *year)).unwrap();
-        let availability = availabilities
-            .get(process_id)
-            .unwrap()
-            .get(&(region_id.clone(), *year, time_slice.clone()))
-            .unwrap();
-
         if let Some(flow) = flows.get(&commodity.id) {
-            if flow.flow > 0.0 && *availability.end() > 0.0 {
+            if flow.flow <= 0.0 {
+                continue;
+            }
+
+            let availability = availabilities
+                .get(process_id)
+                .unwrap()
+                .get(&(region_id.clone(), *year, time_slice.clone()))
+                .unwrap();
+            if *availability.end() > 0.0 {
                 return Ok(());
             }
         }

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -134,7 +134,7 @@ where
         let entry = map
             .entry(id.clone())
             .or_insert_with(ProcessEnergyLimitsMap::new);
-        for (time_slice, ts_length) in time_slice_info.iter_selection(&ts_selection) {
+        for (time_slice, ts_length) in ts_selection.iter(time_slice_info) {
             let bounds = record.to_bounds(ts_length);
 
             for region in &record_regions {

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -61,7 +61,7 @@ where
     Ok(TimeSliceInfo {
         seasons,
         times_of_day,
-        fractions,
+        time_slices: fractions,
     })
 }
 
@@ -133,7 +133,7 @@ autumn,evening,0.25"
                 ]
                 .into_iter()
                 .collect(),
-                fractions: [
+                time_slices: [
                     (
                         TimeSliceID {
                             season: "winter".into(),

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -81,8 +81,8 @@ impl Solution<'_> {
             .commodity_balance_keys
             .zip_duals(self.solution.dual_rows())
             .flat_map(|((commodity_id, region_id, ts_selection), price)| {
-                self.time_slice_info
-                    .iter_selection(ts_selection)
+                ts_selection
+                    .iter(self.time_slice_info)
                     .map(move |(ts, _)| (commodity_id, region_id, ts, price))
             })
     }

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -291,7 +291,7 @@ impl TimeSliceInfo {
     /// # Returns
     ///
     /// An iterator of time slices along with the fraction of the total selection.
-    pub fn iterate_selection_share<'a>(
+    pub fn iter_selection_share<'a>(
         &'a self,
         selection: &'a TimeSliceSelection,
     ) -> impl Iterator<Item = (&'a TimeSliceID, f64)> {
@@ -325,7 +325,7 @@ impl TimeSliceInfo {
         selection: &'a TimeSliceSelection,
         value: f64,
     ) -> impl Iterator<Item = (&'a TimeSliceID, f64)> {
-        self.iterate_selection_share(selection)
+        self.iter_selection_share(selection)
             .map(move |(ts, share)| (ts, value * share))
     }
 }

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -80,6 +80,18 @@ impl TimeSliceSelection {
     }
 }
 
+impl From<TimeSliceID> for TimeSliceSelection {
+    fn from(value: TimeSliceID) -> Self {
+        Self::Single(value)
+    }
+}
+
+impl From<Season> for TimeSliceSelection {
+    fn from(value: Season) -> Self {
+        Self::Season(value)
+    }
+}
+
 /// The time granularity for a particular operation
 #[derive(PartialEq, PartialOrd, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -69,6 +69,17 @@ pub enum TimeSliceSelection {
     Single(TimeSliceID),
 }
 
+impl TimeSliceSelection {
+    /// The [`TimeSliceLevel`] to which this [`TimeSliceSelection`] corresponds
+    pub fn level(&self) -> TimeSliceLevel {
+        match self {
+            TimeSliceSelection::Annual => TimeSliceLevel::Annual,
+            TimeSliceSelection::Season(_) => TimeSliceLevel::Season,
+            TimeSliceSelection::Single(_) => TimeSliceLevel::DayNight,
+        }
+    }
+}
+
 /// The time granularity for a particular operation
 #[derive(PartialEq, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -91,7 +91,7 @@ pub struct TimeSliceInfo {
     /// Names of times of day (e.g. "evening")
     pub times_of_day: IndexSet<TimeOfDay>,
     /// The fraction of the year that this combination of season and time of day occupies
-    pub fractions: IndexMap<TimeSliceID, f64>,
+    pub time_slices: IndexMap<TimeSliceID, f64>,
 }
 
 impl Default for TimeSliceInfo {
@@ -106,7 +106,7 @@ impl Default for TimeSliceInfo {
         Self {
             seasons: iter::once(id.season).collect(),
             times_of_day: iter::once(id.time_of_day).collect(),
-            fractions,
+            time_slices: fractions,
         }
     }
 }
@@ -156,12 +156,14 @@ impl TimeSliceInfo {
 
     /// Iterate over all [`TimeSliceID`]s
     pub fn iter_ids(&self) -> impl Iterator<Item = &TimeSliceID> {
-        self.fractions.keys()
+        self.time_slices.keys()
     }
 
     /// Iterate over all time slices
     pub fn iter(&self) -> impl Iterator<Item = (&TimeSliceID, f64)> {
-        self.fractions.iter().map(|(ts, fraction)| (ts, *fraction))
+        self.time_slices
+            .iter()
+            .map(|(ts, fraction)| (ts, *fraction))
     }
 
     /// Iterate over the subset of time slices indicated by `selection`
@@ -175,7 +177,7 @@ impl TimeSliceInfo {
                 Box::new(self.iter().filter(move |(ts, _)| ts.season == *season))
             }
             TimeSliceSelection::Single(ts) => {
-                Box::new(iter::once((ts, *self.fractions.get(ts).unwrap())))
+                Box::new(iter::once((ts, *self.time_slices.get(ts).unwrap())))
             }
         }
     }
@@ -271,7 +273,7 @@ mod tests {
         let ts_info = TimeSliceInfo {
             seasons: ["winter".into(), "summer".into()].into_iter().collect(),
             times_of_day: ["day".into(), "night".into()].into_iter().collect(),
-            fractions: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
+            time_slices: [(slices[0].clone(), 0.5), (slices[1].clone(), 0.5)]
                 .into_iter()
                 .collect(),
         };
@@ -320,7 +322,7 @@ mod tests {
         let ts_info = TimeSliceInfo {
             seasons: ["winter".into(), "summer".into()].into_iter().collect(),
             times_of_day: ["day".into(), "night".into()].into_iter().collect(),
-            fractions: slices.iter().map(|ts| (ts.clone(), 0.25)).collect(),
+            time_slices: slices.iter().map(|ts| (ts.clone(), 0.25)).collect(),
         };
 
         macro_rules! check_share {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -154,26 +154,17 @@ impl TimeSliceInfo {
         }
     }
 
-    /// Iterate over all [`TimeSliceID`]s.
-    ///
-    /// The order will be consistent each time this is called, but not every time the program is
-    /// run.
+    /// Iterate over all [`TimeSliceID`]s
     pub fn iter_ids(&self) -> impl Iterator<Item = &TimeSliceID> {
         self.fractions.keys()
     }
 
-    /// Iterate over all time slices.
-    ///
-    /// The order will be consistent each time this is called, but not every time the program is
-    /// run.
+    /// Iterate over all time slices
     pub fn iter(&self) -> impl Iterator<Item = (&TimeSliceID, f64)> {
         self.fractions.iter().map(|(ts, fraction)| (ts, *fraction))
     }
 
-    /// Iterate over the subset of time slices indicated by `selection`.
-    ///
-    /// The order will be consistent each time this is called, but not every time the program is
-    /// run.
+    /// Iterate over the subset of time slices indicated by `selection`
     pub fn iter_selection<'a>(
         &'a self,
         selection: &'a TimeSliceSelection,

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -81,17 +81,17 @@ impl TimeSliceSelection {
 }
 
 /// The time granularity for a particular operation
-#[derive(PartialEq, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
+#[derive(PartialEq, PartialOrd, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {
-    /// The whole year
-    #[string = "annual"]
-    Annual,
-    /// Whole seasons
-    #[string = "season"]
-    Season,
     /// Treat individual time slices separately
     #[string = "daynight"]
     DayNight,
+    /// Whole seasons
+    #[string = "season"]
+    Season,
+    /// The whole year
+    #[string = "annual"]
+    Annual,
 }
 
 /// Information about the time slices in the simulation, including names and fractions

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -59,7 +59,7 @@ impl Serialize for TimeSliceID {
 }
 
 /// Represents a time slice read from an input file, which can be all
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum TimeSliceSelection {
     /// All year and all day
     Annual,

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -73,9 +73,9 @@ impl TimeSliceSelection {
     /// The [`TimeSliceLevel`] to which this [`TimeSliceSelection`] corresponds
     pub fn level(&self) -> TimeSliceLevel {
         match self {
-            TimeSliceSelection::Annual => TimeSliceLevel::Annual,
-            TimeSliceSelection::Season(_) => TimeSliceLevel::Season,
-            TimeSliceSelection::Single(_) => TimeSliceLevel::DayNight,
+            Self::Annual => TimeSliceLevel::Annual,
+            Self::Season(_) => TimeSliceLevel::Season,
+            Self::Single(_) => TimeSliceLevel::DayNight,
         }
     }
 
@@ -92,6 +92,65 @@ impl TimeSliceSelection {
             }
             Self::Single(ts) => Box::new(iter::once((ts, *ts_info.time_slices.get(ts).unwrap()))),
         }
+    }
+
+    /// Iterate over this [`TimeSliceSelection`] at the specified level.
+    ///
+    /// For example, this allows you to iterate over a [`TimeSliceSelection::Season`] at the level
+    /// of either seasons (in which case, the iterator will just contain the season) or time slices
+    /// (in which case it will contain all time slices for that season).
+    ///
+    /// Note that you cannot iterate over a [`TimeSliceSelection`] with coarser temporal granularity
+    /// than the [`TimeSliceSelection`] itself (for example, you cannot iterate over a
+    /// [`TimeSliceSelection::Season`] at the [`TimeSliceLevel::Annual`] level). In this case, the
+    /// function will return `None`.
+    pub fn iter_at_level<'a>(
+        &'a self,
+        time_slice_info: &'a TimeSliceInfo,
+        level: TimeSliceLevel,
+    ) -> Option<Box<dyn Iterator<Item = (Self, f64)> + 'a>> {
+        if level > self.level() {
+            return None;
+        }
+
+        let ts_info = time_slice_info;
+        let iter: Box<dyn Iterator<Item = _>> = match self {
+            Self::Annual => match level {
+                TimeSliceLevel::Annual => Box::new(iter::once((Self::Annual, 1.0))),
+                TimeSliceLevel::Season => Box::new(
+                    ts_info
+                        .seasons
+                        .iter()
+                        .map(|(season, fraction)| (season.clone().into(), *fraction)),
+                ),
+                TimeSliceLevel::DayNight => Box::new(
+                    ts_info
+                        .time_slices
+                        .iter()
+                        .map(|(ts, fraction)| (ts.clone().into(), *fraction)),
+                ),
+            },
+            Self::Season(season) => match level {
+                TimeSliceLevel::Season => Box::new(iter::once((
+                    self.clone(),
+                    *ts_info.seasons.get(season).unwrap(),
+                ))),
+                TimeSliceLevel::DayNight => Box::new(
+                    ts_info
+                        .time_slices
+                        .iter()
+                        .filter(move |(ts, _)| &ts.season == season)
+                        .map(|(ts, fraction)| (ts.clone().into(), *fraction)),
+                ),
+                _ => unreachable!(),
+            },
+            Self::Single(time_slice) => Box::new(iter::once((
+                time_slice.clone().into(),
+                *ts_info.time_slices.get(time_slice).unwrap(),
+            ))),
+        };
+
+        Some(iter)
     }
 }
 
@@ -214,61 +273,6 @@ impl TimeSliceInfo {
             .map(|(ts, fraction)| (ts, *fraction))
     }
 
-    /// Iterate over the given [`TimeSliceSelection`] at the specified level.
-    ///
-    /// For example, this allows you to iterate over a [`TimeSliceSelection::Season`] at the level
-    /// of either seasons (in which case, the iterator will just contain the season) or time slices
-    /// (in which case it will contain all time slices for that season).
-    ///
-    /// Note that you cannot iterate over a [`TimeSliceSelection`] with coarser temporal granularity
-    /// than the [`TimeSliceSelection`] itself (for example, you cannot iterate over a
-    /// [`TimeSliceSelection::Season`] at the [`TimeSliceLevel::Annual`] level). In this case, the
-    /// function will return `None`.
-    pub fn iter_selection_at_level<'a>(
-        &'a self,
-        selection: &'a TimeSliceSelection,
-        level: TimeSliceLevel,
-    ) -> Option<Box<dyn Iterator<Item = (TimeSliceSelection, f64)> + 'a>> {
-        if level > selection.level() {
-            return None;
-        }
-
-        let iter: Box<dyn Iterator<Item = _>> = match selection {
-            TimeSliceSelection::Annual => match level {
-                TimeSliceLevel::Annual => Box::new(iter::once((TimeSliceSelection::Annual, 1.0))),
-                TimeSliceLevel::Season => Box::new(
-                    self.seasons
-                        .iter()
-                        .map(|(season, fraction)| (season.clone().into(), *fraction)),
-                ),
-                TimeSliceLevel::DayNight => Box::new(
-                    self.time_slices
-                        .iter()
-                        .map(|(ts, fraction)| (ts.clone().into(), *fraction)),
-                ),
-            },
-            TimeSliceSelection::Season(season) => match level {
-                TimeSliceLevel::Season => Box::new(iter::once((
-                    selection.clone(),
-                    *self.seasons.get(season).unwrap(),
-                ))),
-                TimeSliceLevel::DayNight => Box::new(
-                    self.time_slices
-                        .iter()
-                        .filter(move |(ts, _)| &ts.season == season)
-                        .map(|(ts, fraction)| (ts.clone().into(), *fraction)),
-                ),
-                _ => unreachable!(),
-            },
-            TimeSliceSelection::Single(time_slice) => Box::new(iter::once((
-                time_slice.clone().into(),
-                *self.time_slices.get(time_slice).unwrap(),
-            ))),
-        };
-
-        Some(iter)
-    }
-
     /// Iterate over the different time slice selections for a given time slice level.
     ///
     /// For example, if [`TimeSliceLevel::Season`] is specified, this function will return an
@@ -306,9 +310,7 @@ impl TimeSliceInfo {
         level: TimeSliceLevel,
     ) -> Option<impl Iterator<Item = (TimeSliceSelection, f64)>> {
         // Store selections as we have to iterate twice
-        let selections = self
-            .iter_selection_at_level(selection, level)?
-            .collect_vec();
+        let selections = selection.iter_at_level(self, level)?.collect_vec();
 
         // Total fraction of year covered by selection
         let time_total: f64 = selections.iter().map(|(_, fraction)| *fraction).sum();

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -92,6 +92,16 @@ impl From<Season> for TimeSliceSelection {
     }
 }
 
+impl Display for TimeSliceSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Annual => write!(f, "annual"),
+            Self::Season(season) => write!(f, "{season}"),
+            Self::Single(ts) => write!(f, "{ts}"),
+        }
+    }
+}
+
 /// The time granularity for a particular operation
 #[derive(PartialEq, PartialOrd, Copy, Clone, Debug, DeserializeLabeledStringEnum)]
 pub enum TimeSliceLevel {

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -261,7 +261,7 @@ impl TimeSliceInfo {
     ///
     /// If the string is empty, the default value is `TimeSliceSelection::Annual`.
     pub fn get_selection(&self, time_slice: &str) -> Result<TimeSliceSelection> {
-        if time_slice.is_empty() || time_slice.eq_ignore_ascii_case("annual") {
+        if time_slice.eq_ignore_ascii_case("annual") {
             Ok(TimeSliceSelection::Annual)
         } else if time_slice.contains('.') {
             let time_slice = self.get_time_slice_id_from_str(time_slice)?;


### PR DESCRIPTION
# Description

I've reworked the demand map for commodities to use a `TimeSliceSelection` to represent a time period rather than a `TimeSliceID`, so that we can represent e.g. individual seasons rather than time slices (there will never be a mix in the map though). I've changed the input code to handle this as well as adding some more time slice-related functionality (e.g. `TimeSliceSelection::iter_at_level` for iterating over time slice selections at the specified time slice level).

This is a pretty big set of changes, but I figured it made sense to do this before we add the demand satisfaction constraint (#578).

While I was busy changing the time slice-related code, I disallowed the option to represent a `TimeSliceSelection::Annual` as an empty string in input files, as I think it's a bit of a footgun. Now users have to spell it out (i.e. as `"annual"`).

Closes #391.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
