### PR TITLE
Fix: Use consistent ordering for commodity prices between runs

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -12,7 +12,9 @@ impl<T> IDLike for T where T: Eq + Hash + Borrow<str> + Clone + Display + From<S
 
 macro_rules! define_id_type {
     ($name:ident) => {
-        #[derive(Clone, std::hash::Hash, PartialEq, Eq, Debug, serde::Serialize)]
+        #[derive(
+            Clone, std::hash::Hash, PartialOrd, Ord, PartialEq, Eq, Debug, serde::Serialize,
+        )]
         /// An ID type (e.g. `AgentID`, `CommodityID`, etc.)
         pub struct $name(pub std::rc::Rc<str>);
 

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -5,13 +5,12 @@ use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
-use indexmap::IndexMap;
 use log::warn;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 /// A map relating commodity ID + region + time slice to current price (endogenous)
 #[derive(Default)]
-pub struct CommodityPrices(IndexMap<(CommodityID, RegionID, TimeSliceID), f64>);
+pub struct CommodityPrices(BTreeMap<(CommodityID, RegionID, TimeSliceID), f64>);
 
 impl CommodityPrices {
     /// Calculate commodity prices based on the result of the dispatch optimisation.

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -16,7 +16,7 @@ define_id_type! {Season}
 define_id_type! {TimeOfDay}
 
 /// An ID describing season and time of day
-#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
 pub struct TimeSliceID {
     /// The name of each season.
     pub season: Season,


### PR DESCRIPTION
# Description

While working on #595 I noticed that commodity prices were in a random order after we removed the contents of `CommodityPrices::add_from_solution` and were therefore all being added (as `NaN`) in `add_remaining`. The issue is that we're using a `HashSet` to store the IDs of commodities without prices, so, while `CommodityPrices` retains insertion order (being an `IndexMap`), its contents can end up in a random order anyway. We just didn't notice before because we only had one commodity without a price.

There are different ways we could fix this, but I've opted to change `CommodityPrices` to use a `BTreeMap` rather than an `IndexMap`, so the contents are kept ordered according to the commodity ID (i.e. alphabetically). It doesn't particularly matter, but doing it this way means that the commodities are consistently in the same order for different milestone years, which seems like a nice property to have.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
