### PR TITLE
Fix logging on error

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use crate::input::load_model;
 use crate::log;
 use crate::output::{create_output_directory, get_output_dir};
 use crate::settings::Settings;
-use ::log::{error, info};
+use ::log::info;
 use anyhow::{ensure, Context, Result};
 use clap::{Parser, Subcommand};
 use include_dir::{include_dir, Dir, DirEntry};
@@ -98,20 +98,13 @@ pub fn handle_run_command(
     log::init(settings.log_level.as_deref(), &output_path)
         .context("Failed to initialise logging.")?;
 
-    let load_and_run_model = || {
-        // Load the model to run
-        let (model, assets) = load_model(model_path).context("Failed to load model.")?;
-        info!("Loaded model from {}", model_path.display());
-        info!("Output data will be written to {}", output_path.display());
+    // Load the model to run
+    let (model, assets) = load_model(model_path).context("Failed to load model.")?;
+    info!("Loaded model from {}", model_path.display());
+    info!("Output data will be written to {}", output_path.display());
 
-        // Run the simulation
-        crate::simulation::run(model, assets, &output_path, settings.debug_model)
-    };
-
-    // Once the logger is initialised, we can write fatal errors to log
-    if let Err(err) = load_and_run_model() {
-        error!("{err:?}");
-    }
+    // Run the simulation
+    crate::simulation::run(model, assets, &output_path, settings.debug_model)?;
 
     Ok(())
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -12,6 +12,10 @@ use std::env;
 use std::fmt::{Arguments, Display};
 use std::io::IsTerminal;
 use std::path::Path;
+use std::sync::OnceLock;
+
+/// A flag indicating whether the logger has been initialised
+static LOGGER_INIT: OnceLock<()> = OnceLock::new();
 
 /// The default log level for the program.
 ///
@@ -24,6 +28,11 @@ const LOG_INFO_FILE_NAME: &str = "muse2_info.log";
 
 /// The file name for the log file containing warnings and error messages
 const LOG_ERROR_FILE_NAME: &str = "muse2_error.log";
+
+/// Whether the program logger has been initialised
+pub fn is_logger_initialised() -> bool {
+    LOGGER_INIT.get().is_some()
+}
 
 /// Initialise the program logger using the `fern` logging library with colourised output.
 ///
@@ -117,6 +126,9 @@ pub fn init(log_level_from_settings: Option<&str>, output_path: &Path) -> Result
 
     // Apply the logger configuration
     dispatch.apply().expect("Logger already initialised");
+
+    // Set a flag to indicate that the logger has been initialised
+    LOGGER_INIT.set(()).unwrap();
 
     Ok(())
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -116,7 +116,7 @@ pub fn init(log_level_from_settings: Option<&str>, output_path: &Path) -> Result
         );
 
     // Apply the logger configuration
-    dispatch.apply()?;
+    dispatch.apply().expect("Logger already initialised");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,9 @@ fn main() {
         } else {
             eprintln!("Error: {err:?}");
         }
+
+        // Terminate program, signalling an error
+        std::process::exit(1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use human_panic::{metadata, setup_panic};
+use log::error;
 use muse2::commands::{
     handle_example_extract_command, handle_example_list_command, handle_example_run_command,
     handle_run_command, Cli, Commands, ExampleSubcommands,
 };
+use muse2::log::is_logger_initialised;
 
 fn main() {
     setup_panic!(metadata!().support(format!(
@@ -20,7 +22,13 @@ fn main() {
         return;
     }
 
-    execute_cli_command(cli.command).unwrap_or_else(|err| eprintln!("Error: {:?}", err));
+    if let Err(err) = execute_cli_command(cli.command) {
+        if is_logger_initialised() {
+            error!("{err:?}");
+        } else {
+            eprintln!("Error: {err:?}");
+        }
+    }
 }
 
 fn execute_cli_command(command: Option<Commands>) -> Result<()> {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -2,8 +2,8 @@
 use crate::asset::AssetPool;
 use crate::model::Model;
 use crate::output::DataWriter;
-use anyhow::{bail, Result};
-use log::info;
+use anyhow::Result;
+use log::{error, info};
 use std::path::Path;
 
 pub mod optimisation;
@@ -42,7 +42,8 @@ pub fn run(
 
             // **TODO:** Remove this when we implement at least some of the agent investment code
             //   See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/304
-            bail!("Agent investment is not yet implemented. Exiting...");
+            error!("Agent investment is not yet implemented. Exiting...");
+            return Ok(());
         }
 
         // Newly commissioned assets will be included in optimisation for at least one milestone

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,5 +1,6 @@
 //! Integration tests for the `run` command.
 use muse2::commands::handle_run_command;
+use muse2::log::is_logger_initialised;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -9,12 +10,18 @@ fn get_model_dir() -> PathBuf {
 }
 
 /// An integration test for the `run` command.
+///
+/// We also check that the logger is initialised after it is run.
 #[test]
 fn test_handle_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
+
+    assert!(!is_logger_initialised());
 
     // Save results to non-existent directory to check that directory creation works
     let tempdir = tempdir().unwrap();
     let output_dir = tempdir.path().join("results");
     handle_run_command(&get_model_dir(), Some(&output_dir), false).unwrap();
+
+    assert!(is_logger_initialised());
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -13,21 +13,8 @@ fn get_model_dir() -> PathBuf {
 fn test_handle_run_command() {
     std::env::set_var("MUSE2_LOG_LEVEL", "off");
 
-    {
-        // Save results to non-existent directory to check that directory creation works
-        let tempdir = tempdir().unwrap();
-        let output_dir = tempdir.path().join("results");
-        handle_run_command(&get_model_dir(), Some(&output_dir), false).unwrap();
-    }
-
-    // Second time will fail because the logging is already initialised
-    assert_eq!(
-        handle_run_command(&get_model_dir(), Some(tempdir().unwrap().path()), false)
-            .unwrap_err()
-            .chain()
-            .next()
-            .unwrap()
-            .to_string(),
-        "Failed to initialise logging."
-    );
+    // Save results to non-existent directory to check that directory creation works
+    let tempdir = tempdir().unwrap();
+    let output_dir = tempdir.path().join("results");
+    handle_run_command(&get_model_dir(), Some(&output_dir), false).unwrap();
 }


### PR DESCRIPTION
# Description

This isn't high priority to review....

When I found that bug in #599, I noticed we're not returning errors from `handle_run_command` after the logger is initialised; we just log the message then return `Ok`.

Basically we want to log error messages to the logger if it's initialised and otherwise just print it. The way we're doing it now though doesn't seem particularly clean and means that errors aren't passed up the call chain if they occur after the logger is initialised, which isn't good for testing (apart from anything).

I've reworked things a bit so that we always return errors from `handle_run_command` and `main()` checks whether the logger is initialised in case of error and, if so, uses that instead of a `println`.

I also changed it so the program exits with a nonzero code in case of error, which is useful for scripting etc. 

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
