### PR TITLE
Add code for getting commodity flows

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -56,11 +56,12 @@ pub fn run(
 
         // Dispatch optimisation
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
+        let flow_map = solution.create_flow_map();
         let prices = CommodityPrices::from_model_and_solution(&model, &solution, &assets);
 
         // Write result of dispatch optimisation to file
         writer.write_debug_info(year, &solution)?;
-        writer.write_flows(year, solution.iter_commodity_flows_for_assets())?;
+        writer.write_flows(year, &flow_map)?;
         writer.write_prices(year, &prices)?;
 
         opt_results = Some((solution, prices));

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -37,8 +37,8 @@ pub fn run(
         assets.decommission_old(year);
 
         // NB: Agent investment is not carried out in first milestone year
-        if let Some((solution, prices)) = opt_results {
-            perform_agent_investment(&model, &solution, &prices, &mut assets);
+        if let Some((flow_map, prices)) = opt_results {
+            perform_agent_investment(&model, &flow_map, &prices, &mut assets);
 
             // **TODO:** Remove this when we implement at least some of the agent investment code
             //   See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/304
@@ -64,7 +64,7 @@ pub fn run(
         writer.write_flows(year, &flow_map)?;
         writer.write_prices(year, &prices)?;
 
-        opt_results = Some((solution, prices));
+        opt_results = Some((flow_map, prices));
     }
 
     writer.flush()?;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -29,22 +29,17 @@ pub fn run(
 ) -> Result<()> {
     let mut writer = DataWriter::create(output_path, debug_model)?;
 
-    let mut opt_results = None; // all results of dispatch optimisation
-    for year in model.iter_years() {
+    // Iterate over milestone years
+    let mut year_iter = model.iter_years();
+    let mut year = year_iter.next().unwrap(); // NB: There will be at least one year
+
+    // There shouldn't be assets already commissioned, but let's do this just in case
+    assets.decommission_old(year);
+
+    // **TODO:** Remove annotation when the loop actually loops
+    #[allow(clippy::never_loop)]
+    loop {
         info!("Milestone year: {year}");
-
-        // Assets that have been decommissioned cannot be selected by agents
-        assets.decommission_old(year);
-
-        // NB: Agent investment is not carried out in first milestone year
-        if let Some((flow_map, prices)) = opt_results {
-            perform_agent_investment(&model, &flow_map, &prices, &mut assets);
-
-            // **TODO:** Remove this when we implement at least some of the agent investment code
-            //   See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/304
-            error!("Agent investment is not yet implemented. Exiting...");
-            return Ok(());
-        }
 
         // Newly commissioned assets will be included in optimisation for at least one milestone
         // year before agents have the option of decommissioning them
@@ -64,7 +59,23 @@ pub fn run(
         writer.write_flows(year, &flow_map)?;
         writer.write_prices(year, &prices)?;
 
-        opt_results = Some((flow_map, prices));
+        if let Some(next_year) = year_iter.next() {
+            year = next_year;
+
+            // NB: Agent investment is not carried out in first milestone year
+            perform_agent_investment(&model, &flow_map, &prices, &mut assets);
+
+            // Decommission assets whose lifetime has passed
+            assets.decommission_old(year);
+        } else {
+            // No more milestone years. Simulation is finished.
+            break;
+        }
+
+        // **TODO:** Remove this when we implement at least some of the agent investment code
+        //   See: https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/304
+        error!("Agent investment is not yet implemented. Exiting...");
+        break;
     }
 
     writer.flush()?;

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -1,5 +1,5 @@
 //! Code for performing agent investment.
-use super::optimisation::Solution;
+use super::optimisation::FlowMap;
 use super::CommodityPrices;
 use crate::asset::AssetPool;
 use crate::model::Model;
@@ -10,12 +10,12 @@ use log::info;
 /// # Arguments
 ///
 /// * `model` - The model
-/// * `solution` - The solution to the dispatch optimisation
+/// * `flow_map` - Map of commodity flows
 /// * `prices` - Commodity prices
 /// * `assets` - The asset pool
 pub fn perform_agent_investment(
     _model: &Model,
-    _solution: &Solution,
+    _flow_map: &FlowMap,
     _prices: &CommodityPrices,
     assets: &mut AssetPool,
 ) {

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -13,6 +13,9 @@ use indexmap::IndexMap;
 mod constraints;
 use constraints::{add_asset_constraints, ConstraintKeys};
 
+/// A map of commodity flows calculated during the optimisation
+pub type FlowMap = IndexMap<(AssetRef, CommodityID, TimeSliceID), f64>;
+
 /// A decision variable in the optimisation
 ///
 /// Note that this type does **not** include the value of the variable; it just refers to a
@@ -54,17 +57,11 @@ pub struct Solution<'a> {
 }
 
 impl Solution<'_> {
-    /// Iterate over the newly calculated commodity flows for assets.
+    /// Create a map of commodity flows for each asset's coeffs at every time slice.
     ///
     /// Note that this only includes commodity flows which relate to assets, so not every commodity
     /// in the simulation will necessarily be represented.
-    ///
-    /// # Returns
-    ///
-    /// An iterator of tuples containing an asset, commodity, time slice and flow.
-    pub fn iter_commodity_flows_for_assets(
-        &self,
-    ) -> impl Iterator<Item = (&AssetRef, &CommodityID, &TimeSliceID, f64)> {
+    pub fn create_flow_map(&self) -> FlowMap {
         // The decision variables represent assets' activity levels, not commodity flows. We
         // multiply this value by the flow coeffs to get commodity flows.
         self.variables
@@ -72,10 +69,14 @@ impl Solution<'_> {
             .keys()
             .zip(self.solution.columns())
             .flat_map(|((asset, time_slice), activity)| {
-                asset
-                    .iter_flows()
-                    .map(move |flow| (asset, &flow.commodity.id, time_slice, activity * flow.coeff))
+                asset.iter_flows().map(move |flow| {
+                    (
+                        (asset.clone(), flow.commodity.id.clone(), time_slice.clone()),
+                        activity * flow.coeff,
+                    )
+                })
             })
+            .collect()
     }
 
     /// Keys and dual values for commodity balance constraints.


### PR DESCRIPTION
# Description

For the new model, we have to calculate commodity flows by multiplying activity by process flows. As we will want these values in multiple places, I opted to add a function for storing these values in a map so we can reuse them.

I also refactored the main simulation loop while I was at it, as I realised it could be made a bit simpler if we increment the milestone year in the middle of the loop body rather than on every iteration. No functional change is intended.

Closes #593.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
