### PR TITLE
Write metadata to TOML file in output folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,9 @@ name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 dependencies = [
  "chrono",
+ "git2",
 ]
 
 [[package]]
@@ -171,6 +172,8 @@ version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -325,6 +328,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +412,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -469,6 +505,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +703,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.1+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,10 +725,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -678,6 +861,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "plist"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +883,15 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -912,6 +1116,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +1142,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -970,6 +1197,16 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1026,6 +1263,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1293,12 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasi"
@@ -1328,4 +1588,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "log",
+ "platform-info",
  "regex",
  "rstest",
  "serde",
@@ -871,6 +872,16 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "platform-info"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7539aeb3fdd8cb4f6a331307cf71a1039cee75e94e8a71725b9484f4a0d9451a"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "plist"
@@ -1366,6 +1377,28 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +594,7 @@ name = "muse2"
 version = "2.0.0-dev1"
 dependencies = [
  "anyhow",
+ "built",
  "chrono",
  "clap",
  "clap-markdown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ clap-markdown = "0.1.5"
 [dev-dependencies]
 regex = "1.11.1"
 rstest = {version = "0.25.0", default-features = false, features = ["crate-name"]}
+
+[build-dependencies]
+built = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ regex = "1.11.1"
 rstest = {version = "0.25.0", default-features = false, features = ["crate-name"]}
 
 [build-dependencies]
-built = "0.8.0"
+built = {version = "0.8.0", features = ["chrono"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ highs = "1.8.0"
 indexmap = "2.9.0"
 human-panic = "2.0.2"
 clap-markdown = "0.1.5"
+platform-info = "2.0.5"
 
 [dev-dependencies]
 regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ regex = "1.11.1"
 rstest = {version = "0.25.0", default-features = false, features = ["crate-name"]}
 
 [build-dependencies]
-built = {version = "0.8.0", features = ["chrono"]}
+built = {version = "0.8.0", features = ["chrono", "git2"]}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+/// Write data about build
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -196,7 +196,12 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
     let agent_ids = agents.keys().cloned().collect();
     let assets = read_assets(model_dir.as_ref(), &agent_ids, &processes, &region_ids)?;
 
+    let model_path = model_dir
+        .as_ref()
+        .canonicalize()
+        .context("Could not parse path to model")?;
     let model = Model {
+        model_path,
         milestone_years: model_file.milestone_years.years,
         agents,
         commodities,

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,12 +7,14 @@ use crate::region::{RegionID, RegionMap};
 use crate::time_slice::TimeSliceInfo;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const MODEL_FILE_NAME: &str = "model.toml";
 
 /// Model definition
 pub struct Model {
+    /// Path to model folder
+    pub model_path: PathBuf,
     /// Milestone years for the simulation. Sorted.
     pub milestone_years: Vec<u32>,
     /// Agents for the simulation

--- a/src/output.rs
+++ b/src/output.rs
@@ -78,6 +78,7 @@ struct ProgramMetadata<'a> {
     target: &'a str,
     is_debug: bool,
     rustc_version: &'a str,
+    build_time_utc: &'a str,
 }
 
 /// Information about the program build via `built` crate
@@ -94,6 +95,7 @@ impl Default for ProgramMetadata<'_> {
             target: built_info::TARGET,
             is_debug: built_info::DEBUG,
             rustc_version: built_info::RUSTC_VERSION,
+            build_time_utc: built_info::BUILT_TIME_UTC,
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -236,9 +236,10 @@ impl DataWriter {
     /// # Arguments
     ///
     /// * `output_path` - Folder where files will be saved
+    /// * `model_path` - Path to input model
     /// * `save_debug_info` - Whether to include extra CSV files for debugging model
-    pub fn create(output_path: &Path, save_debug_info: bool) -> Result<Self> {
-        write_metadata(output_path).context("Failed to save metadata")?;
+    pub fn create(output_path: &Path, model_path: &Path, save_debug_info: bool) -> Result<Self> {
+        write_metadata(output_path, model_path).context("Failed to save metadata")?;
 
         let new_writer = |file_name| {
             let file_path = output_path.join(file_name);
@@ -345,7 +346,7 @@ mod tests {
 
         // Write an asset
         {
-            let mut writer = DataWriter::create(dir.path(), false).unwrap();
+            let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer.write_assets(milestone_year, assets.iter()).unwrap();
             writer.flush().unwrap();
         }
@@ -372,7 +373,7 @@ mod tests {
         // Write a flow
         let dir = tempdir().unwrap();
         {
-            let mut writer = DataWriter::create(dir.path(), false).unwrap();
+            let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer.write_flows(milestone_year, &flow_map).unwrap();
             writer.flush().unwrap();
         }
@@ -403,7 +404,7 @@ mod tests {
 
         // Write a price
         {
-            let mut writer = DataWriter::create(dir.path(), false).unwrap();
+            let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer.write_prices(milestone_year, &prices).unwrap();
             writer.flush().unwrap();
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -79,12 +79,26 @@ struct ProgramMetadata<'a> {
     is_debug: bool,
     rustc_version: &'a str,
     build_time_utc: &'a str,
+    git_commit_hash: String,
 }
 
 /// Information about the program build via `built` crate
 mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+/// Get information about program version from git
+fn get_git_hash() -> String {
+    let Some(hash) = built_info::GIT_COMMIT_HASH_SHORT else {
+        return "unknown".into();
+    };
+
+    if built_info::GIT_DIRTY == Some(true) {
+        format!("{hash}-dirty")
+    } else {
+        hash.into()
+    }
 }
 
 impl Default for ProgramMetadata<'_> {
@@ -96,6 +110,7 @@ impl Default for ProgramMetadata<'_> {
             is_debug: built_info::DEBUG,
             rustc_version: built_info::RUSTC_VERSION,
             build_time_utc: built_info::BUILT_TIME_UTC,
+            git_commit_hash: get_git_hash(),
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -71,14 +71,22 @@ struct Metadata<'a> {
     program: ProgramMetadata<'a>,
 }
 
+/// Information about the version and build of MUSE
 #[derive(Serialize)]
 struct ProgramMetadata<'a> {
+    /// The program name
     name: &'a str,
+    /// The program version as specified in Cargo.toml
     version: &'a str,
+    /// The target architecture for the build (e.g. x86_64-unknown-linux-gnu)
     target: &'a str,
+    /// Whether it is a debug build
     is_debug: bool,
+    /// The version of rustc used to compile MUSE
     rustc_version: &'a str,
+    /// When MUSE was built
     build_time_utc: &'a str,
+    /// The git commit hash for the version of MUSE (if known)
     git_commit_hash: String,
 }
 

--- a/src/output/metadata.rs
+++ b/src/output/metadata.rs
@@ -1,0 +1,74 @@
+//! Code for writing metadata to file
+use anyhow::Result;
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+
+/// The output file name for metadata
+const METADATA_FILE_NAME: &str = "metadata.toml";
+
+/// Information about the program build via `built` crate
+mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+/// Get information about program version from git
+fn get_git_hash() -> String {
+    let Some(hash) = built_info::GIT_COMMIT_HASH_SHORT else {
+        return "unknown".into();
+    };
+
+    if built_info::GIT_DIRTY == Some(true) {
+        format!("{hash}-dirty")
+    } else {
+        hash.into()
+    }
+}
+
+#[derive(Serialize, Default)]
+struct Metadata<'a> {
+    program: ProgramMetadata<'a>,
+}
+
+/// Information about the version and build of MUSE
+#[derive(Serialize)]
+struct ProgramMetadata<'a> {
+    /// The program name
+    name: &'a str,
+    /// The program version as specified in Cargo.toml
+    version: &'a str,
+    /// The target architecture for the build (e.g. x86_64-unknown-linux-gnu)
+    target: &'a str,
+    /// Whether it is a debug build
+    is_debug: bool,
+    /// The version of rustc used to compile MUSE
+    rustc_version: &'a str,
+    /// When MUSE was built
+    build_time_utc: &'a str,
+    /// The git commit hash for the version of MUSE (if known)
+    git_commit_hash: String,
+}
+
+impl Default for ProgramMetadata<'_> {
+    fn default() -> Self {
+        Self {
+            name: built_info::PKG_NAME,
+            version: built_info::PKG_VERSION,
+            target: built_info::TARGET,
+            is_debug: built_info::DEBUG,
+            rustc_version: built_info::RUSTC_VERSION,
+            build_time_utc: built_info::BUILT_TIME_UTC,
+            git_commit_hash: get_git_hash(),
+        }
+    }
+}
+
+/// Write metadata to the specified output path in TOML format
+pub fn write_metadata(output_path: &Path) -> Result<()> {
+    let metadata = Metadata::default();
+    let file_path = output_path.join(METADATA_FILE_NAME);
+    fs::write(&file_path, toml::to_string(&metadata)?)?;
+
+    Ok(())
+}

--- a/src/output/metadata.rs
+++ b/src/output/metadata.rs
@@ -28,6 +28,7 @@ fn get_git_hash() -> String {
     }
 }
 
+/// Metadata about the program run, build and version information for MUSE and the user's system
 #[derive(Serialize)]
 struct Metadata<'a> {
     run: RunMetadata<'a>,

--- a/src/output/metadata.rs
+++ b/src/output/metadata.rs
@@ -1,5 +1,6 @@
 //! Code for writing metadata to file
 use anyhow::Result;
+use platform_info::{PlatformInfo, PlatformInfoAPI, UNameAPI};
 use serde::Serialize;
 use std::fs;
 use std::path::Path;
@@ -29,6 +30,7 @@ fn get_git_hash() -> String {
 #[derive(Serialize, Default)]
 struct Metadata<'a> {
     program: ProgramMetadata<'a>,
+    platform: PlatformMetadata,
 }
 
 /// Information about the version and build of MUSE
@@ -60,6 +62,33 @@ impl Default for ProgramMetadata<'_> {
             rustc_version: built_info::RUSTC_VERSION,
             build_time_utc: built_info::BUILT_TIME_UTC,
             git_commit_hash: get_git_hash(),
+        }
+    }
+}
+
+/// Information about the platform on which MUSE is running.
+///
+/// The fields correspond to different data available from the [`PlatformInfo`] struct.
+#[derive(Serialize)]
+struct PlatformMetadata {
+    sysname: String,
+    nodename: String,
+    release: String,
+    version: String,
+    machine: String,
+    osname: String,
+}
+
+impl Default for PlatformMetadata {
+    fn default() -> Self {
+        let info = PlatformInfo::new().expect("Unable to determine platform info");
+        Self {
+            sysname: info.sysname().to_string_lossy().into(),
+            nodename: info.nodename().to_string_lossy().into(),
+            release: info.release().to_string_lossy().into(),
+            version: info.version().to_string_lossy().into(),
+            machine: info.machine().to_string_lossy().into(),
+            osname: info.osname().to_string_lossy().into(),
         }
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -27,7 +27,7 @@ pub fn run(
     output_path: &Path,
     debug_model: bool,
 ) -> Result<()> {
-    let mut writer = DataWriter::create(output_path, debug_model)?;
+    let mut writer = DataWriter::create(output_path, &model.model_path, debug_model)?;
 
     // Iterate over milestone years
     let mut year_iter = model.iter_years();


### PR DESCRIPTION
# Description

It makes sense to include some metadata in the output folder along with the actual data. This is partly to help users figure out which model runs different sets of output files correspond to, but we can also include information about the version of MUSE they're running and their system for the sake of debugging/reproducibility.

There could be more information provided in the `[run]` section, but I figure this is a good place to start. Suggestions about what to include/exclude etc. are welcome!

I used two external crates to get information about the program build (`built`) and the running system (`platform-info`).

This is an example of the metadata file I get on my system:

```toml
[run]
model_path = "/tmp/.tmp5UUvxn/simple"
datetime = "Tue, 10 Jun 2025 14:07:13 +0100"

[program]
name = "muse2"
version = "2.0.0-dev1"
target = "x86_64-unknown-linux-gnu"
is_debug = true
rustc_version = "rustc 1.86.0 (05f9846f8 2025-03-31)"
build_time_utc = "Tue, 10 Jun 2025 13:03:31 +0000"
git_commit_hash = "2d4101b-dirty"

[platform]
sysname = "Linux"
nodename = "medion"
release = "6.14.10-arch1-1"
version = "#1 SMP PREEMPT_DYNAMIC Wed, 04 Jun 2025 18:52:35 +0000"
machine = "x86_64"
osname = "GNU/Linux"
```

Closes #526.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
