### PR TITLE
Use `AssetID` in output files

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -34,6 +34,11 @@ pub struct Asset {
 }
 
 impl Asset {
+    /// Get the asset's ID as a u32
+    pub fn get_id(&self) -> Option<u32> {
+        self.id.map(|AssetID(id)| id)
+    }
+
     /// Create a new [`Asset`].
     ///
     /// The `id` field is initially set to `None`, but is changed to a unique value when the asset

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -6,19 +6,20 @@ use crate::region::RegionID;
 use crate::time_slice::TimeSliceID;
 use anyhow::{ensure, Context, Result};
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, RangeInclusive};
 use std::rc::Rc;
 
 /// A unique identifier for an asset
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct AssetID(u32);
 
 /// An asset controlled by an agent.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Asset {
     /// A unique identifier for the asset
-    id: Option<AssetID>,
+    pub id: Option<AssetID>,
     /// A unique identifier for the agent
     pub agent_id: AgentID,
     /// The [`Process`] that this asset corresponds to
@@ -34,11 +35,6 @@ pub struct Asset {
 }
 
 impl Asset {
-    /// Get the asset's ID as a u32
-    pub fn get_id(&self) -> Option<u32> {
-        self.id.map(|AssetID(id)| id)
-    }
-
     /// Create a new [`Asset`].
     ///
     /// The `id` field is initially set to `None`, but is changed to a unique value when the asset

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,6 @@
 //! The module responsible for writing output data to disk.
 use crate::agent::AgentID;
-use crate::asset::{Asset, AssetRef};
+use crate::asset::{Asset, AssetID, AssetRef};
 use crate::commodity::CommodityID;
 use crate::process::ProcessID;
 use crate::region::RegionID;
@@ -70,7 +70,7 @@ pub fn create_output_directory(output_dir: &Path) -> Result<()> {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct AssetRow {
     milestone_year: u32,
-    asset_id: u32,
+    asset_id: AssetID,
     process_id: ProcessID,
     region_id: RegionID,
     agent_id: AgentID,
@@ -82,7 +82,7 @@ impl AssetRow {
     fn new(milestone_year: u32, asset: &Asset) -> Self {
         Self {
             milestone_year,
-            asset_id: asset.get_id().unwrap(),
+            asset_id: asset.id.unwrap(),
             process_id: asset.process.id.clone(),
             region_id: asset.region_id.clone(),
             agent_id: asset.agent_id.clone(),
@@ -95,7 +95,7 @@ impl AssetRow {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CommodityFlowRow {
     milestone_year: u32,
-    asset_id: u32,
+    asset_id: AssetID,
     commodity_id: CommodityID,
     time_slice: TimeSliceID,
     flow: f64,
@@ -115,7 +115,7 @@ struct CommodityPriceRow {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CapacityDualsRow {
     milestone_year: u32,
-    asset_id: u32,
+    asset_id: AssetID,
     time_slice: TimeSliceID,
     value: f64,
 }
@@ -183,7 +183,7 @@ impl DebugDataWriter {
         for (asset, time_slice, value) in iter {
             let row = CapacityDualsRow {
                 milestone_year,
-                asset_id: asset.get_id().unwrap(),
+                asset_id: asset.id.unwrap(),
                 time_slice: time_slice.clone(),
                 value,
             };
@@ -278,7 +278,7 @@ impl DataWriter {
         for ((asset, commodity_id, time_slice), flow) in flow_map {
             let row = CommodityFlowRow {
                 milestone_year,
-                asset_id: asset.get_id().unwrap(),
+                asset_id: asset.id.unwrap(),
                 commodity_id: commodity_id.clone(),
                 time_slice: time_slice.clone(),
                 flow: *flow,
@@ -381,7 +381,7 @@ mod tests {
         // Read back and compare
         let expected = CommodityFlowRow {
             milestone_year,
-            asset_id: asset.get_id().unwrap(),
+            asset_id: asset.id.unwrap(),
             commodity_id,
             time_slice,
             flow: 42.0,
@@ -486,7 +486,7 @@ mod tests {
         // Read back and compare
         let expected = CapacityDualsRow {
             milestone_year,
-            asset_id: asset.get_id().unwrap(),
+            asset_id: asset.id.unwrap(),
             time_slice,
             value,
         };

--- a/src/output.rs
+++ b/src/output.rs
@@ -66,13 +66,11 @@ pub fn create_output_directory(output_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Used to represent assets in assets output CSV file and other output files.
-///
-/// NB: It may be better to represent assets in these other files with IDs instead, see
-/// [#581](https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/581).
+/// Represents a row in the assets output CSV file.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct AssetRow {
     milestone_year: u32,
+    asset_id: u32,
     process_id: ProcessID,
     region_id: RegionID,
     agent_id: AgentID,
@@ -84,6 +82,7 @@ impl AssetRow {
     fn new(milestone_year: u32, asset: &Asset) -> Self {
         Self {
             milestone_year,
+            asset_id: asset.get_id().unwrap(),
             process_id: asset.process.id.clone(),
             region_id: asset.region_id.clone(),
             agent_id: asset.agent_id.clone(),
@@ -93,10 +92,10 @@ impl AssetRow {
 }
 
 /// Represents the flow-related data in a row of the commodity flows CSV file.
-///
-/// This will be written along with an [`AssetRow`] containing asset-related info.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CommodityFlowRow {
+    milestone_year: u32,
+    asset_id: u32,
     commodity_id: CommodityID,
     time_slice: TimeSliceID,
     flow: f64,
@@ -112,11 +111,11 @@ struct CommodityPriceRow {
     price: f64,
 }
 
-/// Represents the capacity duals data in a row of the capacity duals CSV file.
-///
-/// This will be written along with an [`AssetRow`] containing asset-related info.
+/// Represents the capacity duals data in a row of the capacity duals CSV file
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct CapacityDualsRow {
+    milestone_year: u32,
+    asset_id: u32,
     time_slice: TimeSliceID,
     value: f64,
 }
@@ -182,13 +181,13 @@ impl DebugDataWriter {
         I: Iterator<Item = (&'a AssetRef, &'a TimeSliceID, f64)>,
     {
         for (asset, time_slice, value) in iter {
-            let asset_row = AssetRow::new(milestone_year, asset);
-            let dual_row = CapacityDualsRow {
+            let row = CapacityDualsRow {
+                milestone_year,
+                asset_id: asset.get_id().unwrap(),
                 time_slice: time_slice.clone(),
                 value,
             };
-            self.capacity_duals_writer
-                .serialize((asset_row, dual_row))?;
+            self.capacity_duals_writer.serialize(row)?;
         }
 
         Ok(())
@@ -277,13 +276,14 @@ impl DataWriter {
     /// Write commodity flows to a CSV file
     pub fn write_flows(&mut self, milestone_year: u32, flow_map: &FlowMap) -> Result<()> {
         for ((asset, commodity_id, time_slice), flow) in flow_map {
-            let asset_row = AssetRow::new(milestone_year, asset);
-            let flow_row = CommodityFlowRow {
+            let row = CommodityFlowRow {
+                milestone_year,
+                asset_id: asset.get_id().unwrap(),
                 commodity_id: commodity_id.clone(),
                 time_slice: time_slice.clone(),
                 flow: *flow,
             };
-            self.flows_writer.serialize((asset_row, flow_row))?;
+            self.flows_writer.serialize(row)?;
         }
 
         Ok(())
@@ -380,6 +380,8 @@ mod tests {
 
         // Read back and compare
         let expected = CommodityFlowRow {
+            milestone_year,
+            asset_id: asset.get_id().unwrap(),
             commodity_id,
             time_slice,
             flow: 42.0,
@@ -482,7 +484,12 @@ mod tests {
         }
 
         // Read back and compare
-        let expected = CapacityDualsRow { time_slice, value };
+        let expected = CapacityDualsRow {
+            milestone_year,
+            asset_id: asset.get_id().unwrap(),
+            time_slice,
+            value,
+        };
         let records: Vec<CapacityDualsRow> =
             csv::Reader::from_path(dir.path().join(CAPACITY_DUALS_FILE_NAME))
                 .unwrap()


### PR DESCRIPTION
# Description

Using the asset's ID in the output files, rather than displaying the full asset details every time. For now, I'm keeping asset ID's as integers. We could think about making these more descriptive in the future, as outlined in the issue (perhaps worth opening up another issue for this).

In theory, users could get back what they had before by doing a join between the table of interest (e.g. commodity_flows) and the assets table.

One other thing I noticed is that the assets table is creating a row for each asset every milestone year that the asset is active. I guess in most cases the user could then figure out the decommission year based on the last entry for the asset, but I think it would be cleaner to have a decommission year column, which will be modified as the simulation progresses, with just a single row per asset. Thoughts?

Fixes #581

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
