### PR TITLE
Upload binaries on release

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   build_and_test:
     name: Run tests

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1" # midnight every Monday
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+on:
+  push:
+    branches: [main]
+  release:
+  workflow_dispatch:
+
+jobs:
+  build_and_upload:
+    name: Build release
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        archive_ext: [tar.gz]
+        archive_cmd: ["tar cf"]
+        include:
+          - os: ubuntu-latest
+            osname: linux
+            # We build on an old Linux distro so that we get an older version of libstdc++.
+            # libstdc++ has good backwards compatibility (but not forwards) so by linking against an
+            # old version, we can target more Linuxes.
+            image: debian:oldstable
+          - os: windows-latest
+            osname: windows
+            archive_ext: zip
+            archive_cmd: 7z a
+            exe_suffix: .exe
+          - os: macos-latest
+            osname: macos_arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install extra dependencies on Linux
+        if: ${{ matrix.osname == 'linux' }}
+        run: |
+          apt update
+          apt install -y curl build-essential cmake libclang-16-dev
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build --release
+      - name: Gather release files
+        run: |
+          mkdir muse2
+          cp target/release/muse2${{ matrix.exe_suffix }} muse2
+          cp LICENSE muse2/LICENCE.txt
+          cp assets/readme/readme_${{ matrix.osname }}.txt muse2/README.txt
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event_name != 'release' }}
+        with:
+          name: muse2_${{ matrix.osname }}
+          path: muse2
+      - name: Archive release
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          cd muse2
+          ${{ matrix.archive_cmd }} ../muse2_${{ matrix.osname }}.${{ matrix.archive_ext }} *
+      - name: Upload release artifacts
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: muse2_${{ matrix.osname }}.${{ matrix.archive_ext }}

--- a/assets/readme/README.md
+++ b/assets/readme/README.md
@@ -1,0 +1,3 @@
+# Readme files for MUSE 2.0
+
+This folder contains readme files to be included with MUSE 2.0 releases.

--- a/assets/readme/readme_linux.txt
+++ b/assets/readme/readme_linux.txt
@@ -1,0 +1,16 @@
+This folder contains the MUSE 2.0 executable for Linux, called `muse2`.
+
+The only pre-requisite is libstdc++.so, which is likely installed on your system already. If not,
+you can install with your package manager, e.g. for Ubuntu:
+
+    sudo apt install libstdc++6
+
+For more information on how to use MUSE 2.0, you can consult the program help:
+
+    ./muse2 help
+
+Documentation is also available on the web:
+    https://energysystemsmodellinglab.github.io/MUSE_2.0/
+
+Please report bugs on our GitHub issue tracker:
+    https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues

--- a/assets/readme/readme_macos_arm.txt
+++ b/assets/readme/readme_macos_arm.txt
@@ -1,0 +1,17 @@
+This folder contains the MUSE 2.0 executable for macOS (Apple Silicon), called `muse2`.
+
+When trying to run the `muse2` program, you may see an error message saying "muse2 can't be opened
+because Apple cannot check it for malicious software." To fix this, you should open `muse2` by
+right-clicking on it in your file explorer and clicking "Open". You will be prompted to give
+permission for the program to run. Once you have completed this step, you should be able to run the
+program as normal.
+
+For more information on how to use MUSE 2.0, you can consult the program help:
+
+    ./muse2 help
+
+Documentation is also available on the web:
+    https://energysystemsmodellinglab.github.io/MUSE_2.0/
+
+Please report bugs on our GitHub issue tracker:
+    https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues

--- a/assets/readme/readme_windows.txt
+++ b/assets/readme/readme_windows.txt
@@ -1,0 +1,11 @@
+This folder contains the MUSE 2.0 executable for Windows, called `muse2`.
+
+For more information on how to use MUSE 2.0, you can consult the program help:
+
+    ./muse2 help
+
+Documentation is also available on the web:
+    https://energysystemsmodellinglab.github.io/MUSE_2.0/
+
+Please report bugs on our GitHub issue tracker:
+    https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues


### PR DESCRIPTION
# Description

This PR adds a CI workflow to build and upload executable files on release. The executables are stored in an archive with a readme file and a copy of the licence. Maybe we'll want a changelog in there too at some point.

In theory the program should run without any extra dependencies being installed.

I've also set the workflow to run when we push to `main`. I know that's a little odd, but I'd like to check that things are still building as we go along, as they could stop working when we update dependencies etc. (e.g. the old version of `g++` we're using might not be compatible with a newer version of HiGHS). In this case, the executables are uploaded as test artifacts.

Unrelated change: I noticed we were missing the `workflow_dispatch` trigger for most of our workflows, so I've added it.

Closes #128.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
