### PR TITLE
Add commodity balance and demand satisfaction constraints

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -264,20 +264,15 @@ impl AssetPool {
         self.iter().filter(|asset| asset.region_id == *region_id)
     }
 
-    /// Iterate over only the active assets in a given region that produce or consume a given
-    /// commodity
+    /// Iterate over the active assets in a given region that produce/consume a commodity with the
+    /// associated process flow
     pub fn iter_for_region_and_commodity<'a>(
         &'a self,
         region_id: &'a RegionID,
         commodity_id: &'a CommodityID,
-    ) -> impl Iterator<Item = &'a AssetRef> {
-        self.iter_for_region(region_id).filter(|asset| {
-            asset.process.contains_commodity_flow(
-                commodity_id,
-                &asset.region_id,
-                asset.commission_year,
-            )
-        })
+    ) -> impl Iterator<Item = (&'a AssetRef, &'a ProcessFlow)> {
+        self.iter_for_region(region_id)
+            .filter_map(|asset| Some((asset, asset.get_flow(commodity_id)?)))
     }
 
     /// Replace the active pool with new and/or already commissioned assets

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -187,7 +187,7 @@ fn compute_demand_maps(
 ) -> HashMap<CommodityID, DemandMap> {
     let mut map = HashMap::new();
     for ((commodity_id, region_id, year), (level, annual_demand)) in demand.iter() {
-        for ts_selection in time_slice_info.iter_selections_for_level(*level) {
+        for ts_selection in time_slice_info.iter_selections_at_level(*level) {
             let slice_key = (
                 commodity_id.clone(),
                 region_id.clone(),

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -128,7 +128,7 @@ fn validate_demand_slices(
 ) -> Result<()> {
     for (commodity, region_id) in iproduct!(svd_commodities.values(), region_ids) {
         time_slice_info
-            .iter_selections_for_level(commodity.time_slice_level)
+            .iter_selections_at_level(commodity.time_slice_level)
             .map(|ts_selection| {
                 demand_slices
                     .get(&(

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -174,7 +174,7 @@ fn validate_commodities(
             }
             CommodityType::ServiceDemand => {
                 for ts_selection in
-                    time_slice_info.iter_selections_for_level(commodity.time_slice_level)
+                    time_slice_info.iter_selections_at_level(commodity.time_slice_level)
                 {
                     validate_svd_commodity(
                         time_slice_info,

--- a/src/output.rs
+++ b/src/output.rs
@@ -130,17 +130,6 @@ struct CommodityBalanceDualsRow {
     value: f64,
 }
 
-/// Represents the fixed asset duals data in a row of the fixed asset duals CSV file
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-struct FixedAssetDualsRow {
-    pac: CommodityID,
-    pac_flow: f64,
-    commodity_id: CommodityID,
-    commodity_flow: f64,
-    time_slice: TimeSliceID,
-    value: f64,
-}
-
 /// For writing extra debug information about the model
 struct DebugDataWriter {
     commodity_balance_duals_writer: csv::Writer<File>,

--- a/src/process.rs
+++ b/src/process.rs
@@ -48,21 +48,6 @@ pub struct Process {
     pub regions: HashSet<RegionID>,
 }
 
-impl Process {
-    /// Whether the process contains a flow for a given commodity
-    pub fn contains_commodity_flow(
-        &self,
-        commodity_id: &CommodityID,
-        region_id: &RegionID,
-        year: u32,
-    ) -> bool {
-        self.flows
-            .get(&(region_id.clone(), year))
-            .unwrap() // all regions and years are covered
-            .contains_key(commodity_id)
-    }
-}
-
 /// Represents a maximum annual commodity coeff for a given process
 #[derive(PartialEq, Debug, Clone)]
 pub struct ProcessFlow {

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -128,7 +128,7 @@ pub fn perform_dispatch_optimisation<'a>(
     let variables = add_variables(&mut problem, model, assets, year);
 
     // Add constraints
-    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, assets);
+    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, assets, year);
 
     // Solve problem
     let mut highs_model = problem.optimise(Sense::Minimise);

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -128,7 +128,7 @@ pub fn perform_dispatch_optimisation<'a>(
     let variables = add_variables(&mut problem, model, assets, year);
 
     // Add constraints
-    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, assets, year);
+    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, assets);
 
     // Solve problem
     let mut highs_model = problem.optimise(Sense::Minimise);

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -292,7 +292,7 @@ impl TimeSliceInfo {
     ///
     /// For example, if [`TimeSliceLevel::Season`] is specified, this function will return an
     /// iterator of [`TimeSliceSelection`]s covering each season.
-    pub fn iter_selections_for_level(
+    pub fn iter_selections_at_level(
         &self,
         level: TimeSliceLevel,
     ) -> Box<dyn Iterator<Item = TimeSliceSelection> + '_> {


### PR DESCRIPTION
# Description

As before, these two kinds of constraint are pretty similar, so I took the approach we had previously and just added one function to handle both of them. We will also want to use the duals of these values in the result for calculating prices (as we did before), so it makes sense to lump them together.

Closes #578. Closes #577.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
