### PR TITLE
Calculate commodity prices using dual values

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -52,7 +52,7 @@ pub fn run(
         // Dispatch optimisation
         let solution = perform_dispatch_optimisation(&model, &assets, year)?;
         let flow_map = solution.create_flow_map();
-        let prices = CommodityPrices::from_model_and_solution(&model, &solution, &assets);
+        let prices = CommodityPrices::from_model_and_solution(&model, &solution);
 
         // Write result of dispatch optimisation to file
         writer.write_debug_info(year, &solution)?;

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -1,12 +1,11 @@
 //! Code for updating the simulation state.
 use super::optimisation::Solution;
-use crate::asset::AssetPool;
 use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use log::warn;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// A map relating commodity ID + region + time slice to current price (endogenous)
 #[derive(Default)]
@@ -16,9 +15,9 @@ impl CommodityPrices {
     /// Calculate commodity prices based on the result of the dispatch optimisation.
     ///
     /// Missing prices will be calculated directly from the input data
-    pub fn from_model_and_solution(model: &Model, solution: &Solution, assets: &AssetPool) -> Self {
+    pub fn from_model_and_solution(model: &Model, solution: &Solution) -> Self {
         let mut prices = CommodityPrices::default();
-        let commodity_regions_updated = prices.add_from_solution(solution, assets);
+        let commodity_regions_updated = prices.add_from_solution(solution);
 
         // Find commodity/region combinations not updated in last step
         let mut remaining_commodity_regions = HashSet::new();
@@ -44,20 +43,43 @@ impl CommodityPrices {
     /// # Arguments
     ///
     /// * `solution` - The solution to the dispatch optimisation
-    /// * `assets` - The asset pool
     ///
     /// # Returns
     ///
     /// The set of commodities for which prices were added.
-    fn add_from_solution(
-        &mut self,
-        _solution: &Solution,
-        _assets: &AssetPool,
-    ) -> HashSet<(CommodityID, RegionID)> {
-        // **TODO:** Calculate commodity prices here:
-        //  https://github.com/EnergySystemsModellingLab/MUSE_2.0/issues/589
+    fn add_from_solution(&mut self, solution: &Solution) -> HashSet<(CommodityID, RegionID)> {
+        let mut commodity_regions_updated = HashSet::new();
 
-        HashSet::new()
+        // Calculate highest activity dual for each commodity/region/timeslice
+        let mut highest_duals = HashMap::new();
+        for (asset, time_slice, dual) in solution.iter_activity_duals() {
+            // Iterate over all output flows
+            for flow in asset.iter_flows().filter(|flow| flow.coeff > 0.0) {
+                // Update the highest dual for this commodity/timeslice
+                highest_duals
+                    .entry((
+                        flow.commodity.id.clone(),
+                        asset.region_id.clone(),
+                        time_slice.clone(),
+                    ))
+                    .and_modify(|current_dual| {
+                        if dual > *current_dual {
+                            *current_dual = dual;
+                        }
+                    })
+                    .or_insert(dual);
+            }
+        }
+
+        // Add the highest capacity dual for each commodity/timeslice to each commodity balance dual
+        for (commodity_id, region_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
+            let key = (commodity_id.clone(), region_id.clone(), time_slice.clone());
+            let price = dual + highest_duals.get(&key).unwrap_or(&0.0);
+            self.insert(commodity_id, region_id, time_slice, price);
+            commodity_regions_updated.insert((commodity_id.clone(), region_id.clone()));
+        }
+
+        commodity_regions_updated
     }
 
     /// Add prices for any commodity not updated by the dispatch step.

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -12,9 +12,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 pub struct CommodityPrices(BTreeMap<(CommodityID, RegionID, TimeSliceID), f64>);
 
 impl CommodityPrices {
-    /// Calculate commodity prices based on the result of the dispatch optimisation.
-    ///
-    /// Missing prices will be calculated directly from the input data
+    /// Calculate commodity prices based on the result of the dispatch optimisation
     pub fn from_model_and_solution(model: &Model, solution: &Solution) -> Self {
         let mut prices = CommodityPrices::default();
         let commodity_regions_updated = prices.add_from_solution(solution);
@@ -46,7 +44,7 @@ impl CommodityPrices {
     ///
     /// # Returns
     ///
-    /// The set of commodities for which prices were added.
+    /// The set of commodity/region pairs for which prices were added.
     fn add_from_solution(&mut self, solution: &Solution) -> HashSet<(CommodityID, RegionID)> {
         let mut commodity_regions_updated = HashSet::new();
 
@@ -71,7 +69,8 @@ impl CommodityPrices {
             }
         }
 
-        // Add the highest capacity dual for each commodity/timeslice to each commodity balance dual
+        // Add the highest capacity dual for each commodity/region/timeslice to each commodity
+        // balance dual
         for (commodity_id, region_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
             let key = (commodity_id.clone(), region_id.clone(), time_slice.clone());
             let price = dual + highest_duals.get(&key).unwrap_or(&0.0);
@@ -86,7 +85,7 @@ impl CommodityPrices {
     ///
     /// # Arguments
     ///
-    /// * `commodity_ids` - IDs of commodities to update
+    /// * `commodity_regions` - Commodity/region pairs to update
     /// * `time_slice_info` - Information about time slices
     fn add_remaining<'a, I>(&mut self, commodity_regions: I, time_slice_info: &TimeSliceInfo)
     where
@@ -100,7 +99,7 @@ impl CommodityPrices {
         }
     }
 
-    /// Insert a price for the given commodity, time slice and region
+    /// Insert a price for the given commodity, region and time slice
     pub fn insert(
         &mut self,
         commodity_id: &CommodityID,
@@ -116,7 +115,7 @@ impl CommodityPrices {
     ///
     /// # Returns
     ///
-    /// An iterator of tuples containing commodity ID, time slice and price.
+    /// An iterator of tuples containing commodity ID, region ID, time slice and price.
     pub fn iter(&self) -> impl Iterator<Item = (&CommodityID, &RegionID, &TimeSliceID, f64)> {
         self.0
             .iter()

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -69,7 +69,7 @@ impl CommodityPrices {
             }
         }
 
-        // Add the highest capacity dual for each commodity/region/timeslice to each commodity
+        // Add the highest activity dual for each commodity/region/timeslice to each commodity
         // balance dual
         for (commodity_id, region_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
             let key = (commodity_id.clone(), region_id.clone(), time_slice.clone());


### PR DESCRIPTION
# Description

This PR re-adds the code for calculating commodity prices using broadly the same method as before, i.e. the commodity balance duals plus the highest capacity duals. Given that we no longer have PACs, we now just consider all the output flows for each asset.

@ahawkes says this should be fine, but that we should check, so I'll open this as a draft and give him a chance to look at the new numbers before we merge. Is that ok, Adam? I've attached the results below. An alternative would be to just merge it now (so that we at least have some prices to work with) and revisit it later. Up to you.

[muse2_results_20250618_b0b26db2.zip](https://github.com/user-attachments/files/20791663/muse2_results_20250618_b0b26db2.zip)

Closes #589.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
