### PR TITLE
Allow candidate assets in dispatch

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -227,6 +227,11 @@ impl AssetPool {
         }
     }
 
+    /// Get the active pool as a slice of [`AssetRef`]s
+    pub fn as_slice(&self) -> &[AssetRef] {
+        &self.active
+    }
+
     /// Commission new assets for the specified milestone year from the input data
     pub fn commission_new(&mut self, year: u32) {
         // Count the number of assets to move

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -253,7 +253,7 @@ impl AssetPool {
     }
 
     /// Iterate over active assets
-    pub fn iter(&self) -> impl Iterator<Item = &AssetRef> {
+    pub fn iter(&self) -> std::slice::Iter<AssetRef> {
         self.active.iter()
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -116,7 +116,7 @@ struct CommodityPriceRow {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct ActivityDualsRow {
     milestone_year: u32,
-    asset_id: AssetID,
+    asset_id: Option<AssetID>,
     time_slice: TimeSliceID,
     value: f64,
 }
@@ -173,7 +173,7 @@ impl DebugDataWriter {
         for (asset, time_slice, value) in iter {
             let row = ActivityDualsRow {
                 milestone_year,
-                asset_id: asset.id.unwrap(),
+                asset_id: asset.id,
                 time_slice: time_slice.clone(),
                 value,
             };
@@ -476,7 +476,7 @@ mod tests {
         // Read back and compare
         let expected = ActivityDualsRow {
             milestone_year,
-            asset_id: asset.id.unwrap(),
+            asset_id: asset.id,
             time_slice,
             value,
         };

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -50,7 +50,7 @@ pub fn run(
         writer.write_assets(year, assets.iter())?;
 
         // Dispatch optimisation
-        let solution = perform_dispatch_optimisation(&model, &assets, year)?;
+        let solution = perform_dispatch_optimisation(&model, &assets, &[], year)?;
         let flow_map = solution.create_flow_map();
         let prices = CommodityPrices::from_model_and_solution(&model, &solution);
 

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -47,7 +47,6 @@ impl VariableMap {
     }
 
     /// Iterate over the variable map
-    #[allow(dead_code)]
     fn iter(&self) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, Variable)> {
         self.0
             .iter()

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -45,6 +45,14 @@ impl VariableMap {
             .get(&key)
             .expect("No variable found for given params")
     }
+
+    /// Iterate over the variable map
+    #[allow(dead_code)]
+    fn iter(&self) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, Variable)> {
+        self.0
+            .iter()
+            .map(|((asset, time_slice), var)| (asset, time_slice, *var))
+    }
 }
 
 /// The solution to the dispatch optimisation problem

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -10,6 +10,8 @@ use crate::units::{Activity, Flow, MoneyPerActivity};
 use anyhow::{anyhow, Result};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::IndexMap;
+use itertools::{chain, iproduct};
+use std::ops::Range;
 
 mod constraints;
 use constraints::{add_asset_constraints, ConstraintKeys};
@@ -58,6 +60,8 @@ impl VariableMap {
 pub struct Solution<'a> {
     solution: highs::Solution,
     variables: VariableMap,
+    active_asset_var_idx: Range<usize>,
+    candidate_asset_var_idx: Range<usize>,
     time_slice_info: &'a TimeSliceInfo,
     constraint_keys: ConstraintKeys,
 }
@@ -71,16 +75,27 @@ impl Solution<'_> {
         // The decision variables represent assets' activity levels, not commodity flows. We
         // multiply this value by the flow coeffs to get commodity flows.
         let mut flows = FlowMap::new();
-        for ((asset, time_slice), activity) in self.variables.0.keys().zip(self.solution.columns())
-        {
+        for (asset, time_slice, activity) in self.iter_activity_for_active() {
             for flow in asset.iter_flows() {
                 let flow_key = (asset.clone(), flow.commodity.id.clone(), time_slice.clone());
-                let flow_value = Activity(*activity) * flow.coeff;
+                let flow_value = Activity(activity) * flow.coeff;
                 flows.insert(flow_key, flow_value);
             }
         }
 
         flows
+    }
+
+    /// Activity for each active asset
+    fn iter_activity_for_active(&self) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, f64)> {
+        self.zip_var_keys_with_output(&self.active_asset_var_idx, self.solution.columns())
+    }
+
+    /// Reduced costs for candidate assets
+    pub fn iter_reduced_costs_for_candidates(
+        &self,
+    ) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, f64)> {
+        self.zip_var_keys_with_output(&self.candidate_asset_var_idx, self.solution.dual_columns())
     }
 
     /// Keys and dual values for commodity balance constraints.
@@ -107,6 +122,25 @@ impl Solution<'_> {
             .zip_duals(self.solution.dual_rows())
             .map(|((asset, time_slice), dual)| (asset, time_slice, dual))
     }
+
+    /// Zip a subset of keys in the variable map with a subset of the given output variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `variable_idx` - The subset of variables to look at
+    /// * `output` - The output variable of interest
+    fn zip_var_keys_with_output<'a>(
+        &'a self,
+        variable_idx: &Range<usize>,
+        output: &'a [f64],
+    ) -> impl Iterator<Item = (&'a AssetRef, &'a TimeSliceID, f64)> {
+        assert!(variable_idx.end <= output.len());
+        self.variables
+            .0
+            .keys()
+            .zip(output[variable_idx.clone()].iter())
+            .map(|((asset, time_slice), value)| (asset, time_slice, *value))
+    }
 }
 
 /// Perform the dispatch optimisation.
@@ -118,7 +152,8 @@ impl Solution<'_> {
 /// # Arguments
 ///
 /// * `model` - The model
-/// * `assets` - The asset pool
+/// * `asset_pool` - The asset pool
+/// * `candidate_assets` - Candidate assets for inclusion in active pool
 /// * `year` - Current milestone year
 ///
 /// # Returns
@@ -126,15 +161,31 @@ impl Solution<'_> {
 /// A solution containing new commodity flows for assets and prices for (some) commodities.
 pub fn perform_dispatch_optimisation<'a>(
     model: &'a Model,
-    assets: &AssetPool,
+    asset_pool: &AssetPool,
+    candidate_assets: &[AssetRef],
     year: u32,
 ) -> Result<Solution<'a>> {
     // Set up problem
     let mut problem = Problem::default();
-    let variables = add_variables(&mut problem, model, assets, year);
+    let mut variables = VariableMap::default();
+    let active_asset_var_idx = add_variables(
+        &mut problem,
+        &mut variables,
+        &model.time_slice_info,
+        asset_pool.as_slice(),
+        year,
+    );
+    let candidate_asset_var_idx = add_variables(
+        &mut problem,
+        &mut variables,
+        &model.time_slice_info,
+        candidate_assets,
+        year,
+    );
 
     // Add constraints
-    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, assets, year);
+    let all_assets = chain(asset_pool.iter(), candidate_assets.iter());
+    let constraint_keys = add_asset_constraints(&mut problem, &variables, model, all_assets, year);
 
     // Solve problem
     let mut highs_model = problem.optimise(Sense::Minimise);
@@ -153,6 +204,8 @@ pub fn perform_dispatch_optimisation<'a>(
         HighsModelStatus::Optimal => Ok(Solution {
             solution: solution.get_solution(),
             variables,
+            active_asset_var_idx,
+            candidate_asset_var_idx,
             time_slice_info: &model.time_slice_info,
             constraint_keys,
         }),
@@ -178,32 +231,29 @@ fn enable_highs_logging(model: &mut highs::Model) {
 /// # Arguments
 ///
 /// * `problem` - The optimisation problem
-/// * `model` - The model
-/// * `assets` - The asset pool
+/// * `variables` - The variable map
+/// * `time_slice_info` - Information about assets
+/// * `assets` - Assets to include
 /// * `year` - Current milestone year
-///
-/// # Returns
-///
-/// A [`VariableMap`] with the problem's variables as values.
 fn add_variables(
     problem: &mut Problem,
-    model: &Model,
-    assets: &AssetPool,
+    variables: &mut VariableMap,
+    time_slice_info: &TimeSliceInfo,
+    assets: &[AssetRef],
     year: u32,
-) -> VariableMap {
-    let mut variables = VariableMap::default();
+) -> Range<usize> {
+    // This line **must** come before we add more variables
+    let start = problem.num_cols();
 
-    for asset in assets.iter() {
-        for time_slice in model.time_slice_info.iter_ids() {
-            let coeff = calculate_cost_coefficient(asset, year, time_slice);
-            let var = problem.add_column(coeff.value(), 0.0..);
-            let key = (asset.clone(), time_slice.clone());
-            let existing = variables.0.insert(key, var).is_some();
-            assert!(!existing, "Duplicate entry for var");
-        }
+    for (asset, time_slice) in iproduct!(assets.iter(), time_slice_info.iter_ids()) {
+        let coeff = calculate_cost_coefficient(asset, year, time_slice);
+        let var = problem.add_column(coeff.value(), 0.0..);
+        let key = (asset.clone(), time_slice.clone());
+        let existing = variables.0.insert(key, var).is_some();
+        assert!(!existing, "Duplicate entry for var");
     }
 
-    variables
+    start..problem.num_cols()
 }
 
 /// Calculate the cost coefficient for a decision variable

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -37,8 +37,6 @@ pub struct VariableMap(IndexMap<(AssetRef, TimeSliceID), Variable>);
 
 impl VariableMap {
     /// Get the [`Variable`] corresponding to the given parameters.
-    // **TODO:** Remove line below when we're using this
-    #[allow(dead_code)]
     fn get(&self, asset: &AssetRef, time_slice: &TimeSliceID) -> Variable {
         let key = (asset.clone(), time_slice.clone());
 

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -1,6 +1,6 @@
 //! Code for adding constraints to the dispatch optimisation problem.
 use super::VariableMap;
-use crate::asset::{AssetPool, AssetRef};
+use crate::asset::{AssetIterator, AssetPool, AssetRef};
 use crate::commodity::{CommodityID, CommodityType};
 use crate::model::Model;
 use crate::region::RegionID;
@@ -106,7 +106,11 @@ fn add_commodity_balance_constraints(
                 .time_slice_info
                 .iter_selections_at_level(commodity.time_slice_level)
             {
-                for (asset, flow) in assets.iter_for_region_and_commodity(region_id, commodity_id) {
+                for (asset, flow) in assets
+                    .iter()
+                    .filter_region(region_id)
+                    .flows_for_commodity(commodity_id)
+                {
                     // If the commodity has a time slice level of season/annual, the constraint will
                     // cover multiple time slices
                     for (time_slice, _) in ts_selection.iter(&model.time_slice_info) {

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -65,13 +65,13 @@ pub fn add_asset_constraints(
     let commodity_balance_keys =
         add_commodity_balance_constraints(problem, variables, model, assets, year);
 
-    let capacity_keys =
+    let activity_keys =
         add_activity_constraints(problem, variables, &model.time_slice_info, assets);
 
     // Return constraint keys
     ConstraintKeys {
         commodity_balance_keys,
-        activity_keys: capacity_keys,
+        activity_keys,
     }
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -278,7 +278,7 @@ impl TimeSliceInfo {
     }
 
     /// Iterate over all [`TimeSliceID`]s
-    pub fn iter_ids(&self) -> impl Iterator<Item = &TimeSliceID> {
+    pub fn iter_ids(&self) -> indexmap::map::Keys<TimeSliceID, Dimensionless> {
         self.time_slices.keys()
     }
 


### PR DESCRIPTION
# Description

I've added the bare minimum of functionality to allow for optionally including candidate assets in the dispatch optimisation, as well as the active pool. In practice, we will only want to do this on the final iteration of the investment step and the rest of the time, only the active assets will be included. There are two reasons for wanting to do this: 1) to get prices for commodities not produced in the last milestone year and 2) to calculate reduced costs for candidate assets (given by the column duals). I've added an `iter_reduced_costs_for_candidates` method to `Solution`, but it's not currently used anywhere.

Note that the constraints are applied to both active and candidate assets. Individual commodity balance constraints can include a mix of active and candidate assets (this is what Adam wants). Activity constraints only apply to individual assets; in practice, candidate assets will have their capacities set to zero.

From talking to Adam, I *think* we can get away with leaving the commodity price calculation using the duals as it is (by design, it is supposed to include values derived from both active and candidate assets).

I had to do some refactoring to make all this work:

- Change `AssetRef`s to work with non-commissioned assets (i.e. whose IDs are unset). For non-commissioned assets, we compare the agent, process, region and milestone year instead.
- Make some of the helper functions for iterating over a subset of the `AssetPool` work on any iterator of `AssetRef`s instead

There's some additional data that we will want to write to output files at some point, but I've left that as a job for another day (#640).

Closes #632.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
