### PR TITLE
A couple of small fixes for unit types

### DIFF
--- a/src/units.rs
+++ b/src/units.rs
@@ -60,19 +60,19 @@ macro_rules! base_unit_struct {
         }
         impl $name {
             /// Returns the underlying f64 value.
-            pub fn value(self) -> f64 {
+            pub fn value(&self) -> f64 {
                 self.0
             }
             /// Returns true if the value is a normal number.
-            pub fn is_normal(self) -> bool {
+            pub fn is_normal(&self) -> bool {
                 self.0.is_normal()
             }
             /// Returns true if the value is finite.
-            pub fn is_finite(self) -> bool {
+            pub fn is_finite(&self) -> bool {
                 self.0.is_finite()
             }
             /// Returns the absolute value of this unit.
-            pub fn abs(self) -> Self {
+            pub fn abs(&self) -> Self {
                 $name(self.0.abs())
             }
         }

--- a/src/units.rs
+++ b/src/units.rs
@@ -27,9 +27,9 @@ macro_rules! base_unit_struct {
             }
         }
         impl std::ops::Div<$name> for $name {
-            type Output = $name;
-            fn div(self, rhs: $name) -> $name {
-                $name(self.0 / rhs.0)
+            type Output = Dimensionless;
+            fn div(self, rhs: $name) -> Dimensionless {
+                Dimensionless(self.0 / rhs.0)
             }
         }
         impl std::iter::Sum for $name {


### PR DESCRIPTION
# Description

I was fiddling with unit types on another branch and noticed a couple of small problems:

1. A unit type `U` divided by `U` should yield `Dimensionless`, not `U`
2. We should pass self by ref (`&self`) not value (`self`) for various methods of unit types, otherwise it'll be consumed when they're run

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
