### PR TITLE
More tweaks to unit code

### DIFF
--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -2,7 +2,7 @@
 use crate::id::{define_id_getter, define_id_type};
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceLevel, TimeSliceSelection};
-use crate::units::{Energy, MoneyPerEnergy};
+use crate::units::{Flow, MoneyPerFlow};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_string_enum::DeserializeLabeledStringEnum;
@@ -18,7 +18,7 @@ pub type CommodityMap = IndexMap<CommodityID, Rc<Commodity>>;
 pub type CommodityLevyMap = HashMap<(RegionID, u32, TimeSliceID), CommodityLevy>;
 
 /// A map of demand values, keyed by region ID, year and time slice selection
-pub type DemandMap = HashMap<(RegionID, u32, TimeSliceSelection), Energy>;
+pub type DemandMap = HashMap<(RegionID, u32, TimeSliceSelection), Flow>;
 
 /// A commodity within the simulation.
 ///
@@ -75,7 +75,7 @@ pub struct CommodityLevy {
     /// Type of balance for application of cost
     pub balance_type: BalanceType,
     /// Cost per unit commodity
-    pub value: MoneyPerEnergy,
+    pub value: MoneyPerFlow,
 }
 
 /// Commodity balance type
@@ -105,7 +105,7 @@ mod tests {
             season: "all-year".into(),
             time_of_day: "all-day".into(),
         });
-        let value = Energy(0.25);
+        let value = Flow(0.25);
         let mut map = DemandMap::new();
         map.insert(("North".into(), 2020, ts_selection.clone()), value);
 
@@ -123,7 +123,7 @@ mod tests {
         };
         let value = CommodityLevy {
             balance_type: BalanceType::Consumption,
-            value: MoneyPerEnergy(0.5),
+            value: MoneyPerFlow(0.5),
         };
         let mut map = CommodityLevyMap::new();
         assert!(map

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -6,7 +6,7 @@ use crate::commodity::{Commodity, CommodityID, CommodityType, DemandMap};
 use crate::id::IDCollection;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel};
-use crate::units::Energy;
+use crate::units::Flow;
 use anyhow::{ensure, Result};
 use itertools::iproduct;
 use serde::Deserialize;
@@ -25,11 +25,11 @@ struct Demand {
     /// The year of the demand entry
     year: u32,
     /// Annual demand quantity
-    demand: Energy,
+    demand: Flow,
 }
 
 /// A map relating commodity, region and year to annual demand
-pub type AnnualDemandMap = HashMap<(CommodityID, RegionID, u32), (TimeSliceLevel, Energy)>;
+pub type AnnualDemandMap = HashMap<(CommodityID, RegionID, u32), (TimeSliceLevel, Flow)>;
 
 /// A map containing a references to commodities
 pub type BorrowedCommodityMap<'a> = HashMap<CommodityID, &'a Commodity>;
@@ -133,7 +133,7 @@ where
         );
 
         ensure!(
-            demand.demand.is_normal() && demand.demand > Energy(0.0),
+            demand.demand.is_normal() && demand.demand > Flow(0.0),
             "Demand must be a valid number greater than zero"
         );
 
@@ -232,13 +232,13 @@ mod tests {
                 year: 2020,
                 region_id: "GBR".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "USA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(11.0),
+                demand: Flow(11.0),
             },
         ];
 
@@ -261,13 +261,13 @@ mod tests {
                 year: 2020,
                 region_id: "GBR".to_string(),
                 commodity_id: "commodity2".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "USA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(11.0),
+                demand: Flow(11.0),
             },
         ];
         assert_error!(
@@ -288,13 +288,13 @@ mod tests {
                 year: 2020,
                 region_id: "FRA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "USA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(11.0),
+                demand: Flow(11.0),
             },
         ];
         assert_error!(
@@ -315,13 +315,13 @@ mod tests {
                 year: 2010,
                 region_id: "GBR".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "USA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(11.0),
+                demand: Flow(11.0),
             },
         ];
         assert_error!(
@@ -348,7 +348,7 @@ mod tests {
             year: 2020,
             region_id: "GBR".to_string(),
             commodity_id: "commodity1".to_string(),
-            demand: Energy(quantity),
+            demand: Flow(quantity),
         }];
         assert_error!(
             read_demand_from_iter(demand.into_iter(), &svd_commodities, &region_ids, &[2020],),
@@ -368,19 +368,19 @@ mod tests {
                 year: 2020,
                 region_id: "GBR".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "GBR".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(10.0),
+                demand: Flow(10.0),
             },
             Demand {
                 year: 2020,
                 region_id: "USA".to_string(),
                 commodity_id: "commodity1".to_string(),
-                demand: Energy(11.0),
+                demand: Flow(11.0),
             },
         ];
         assert_error!(
@@ -400,7 +400,7 @@ mod tests {
             year: 2020,
             region_id: "GBR".to_string(),
             commodity_id: "commodity1".to_string(),
-            demand: Energy(10.0),
+            demand: Flow(10.0),
         };
         assert!(read_demand_from_iter(
             std::iter::once(demand),
@@ -433,11 +433,11 @@ mod tests {
         let expected = AnnualDemandMap::from_iter([
             (
                 ("commodity1".into(), "GBR".into(), 2020),
-                (TimeSliceLevel::DayNight, Energy(10.0)),
+                (TimeSliceLevel::DayNight, Flow(10.0)),
             ),
             (
                 ("commodity1".into(), "USA".into(), 2020),
-                (TimeSliceLevel::DayNight, Energy(11.0)),
+                (TimeSliceLevel::DayNight, Flow(11.0)),
             ),
         ]);
         let demand =

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -4,7 +4,7 @@ use crate::commodity::{BalanceType, CommodityID, CommodityLevy, CommodityLevyMap
 use crate::id::IDCollection;
 use crate::region::{parse_region_str, RegionID};
 use crate::time_slice::TimeSliceInfo;
-use crate::units::MoneyPerEnergy;
+use crate::units::MoneyPerFlow;
 use crate::year::parse_year_str;
 use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
@@ -27,7 +27,7 @@ struct CommodityLevyRaw {
     /// The time slice to which the cost applies.
     time_slice: String,
     /// Cost per unit commodity
-    value: MoneyPerEnergy,
+    value: MoneyPerFlow,
 }
 
 /// Read costs associated with each commodity from levies CSV file.
@@ -163,7 +163,7 @@ mod tests {
     fn cost_map(time_slice: TimeSliceID) -> CommodityLevyMap {
         let cost = CommodityLevy {
             balance_type: BalanceType::Net,
-            value: MoneyPerEnergy(1.0),
+            value: MoneyPerFlow(1.0),
         };
 
         let mut map = CommodityLevyMap::new();

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -6,7 +6,7 @@ use crate::process::{
 };
 use crate::region::{parse_region_str, RegionID};
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
-use crate::units::{Energy, EnergyPerActivity};
+use crate::units::{Flow, FlowPerActivity};
 use anyhow::{ensure, Context, Ok, Result};
 use itertools::iproduct;
 use serde::Deserialize;
@@ -200,7 +200,7 @@ fn validate_other_commodity(
     let mut is_producer = None;
     for flows in flows.values().flat_map(|flows| flows.values()) {
         if let Some(flow) = flows.get(commodity_id) {
-            let cur_is_producer = flow.coeff > EnergyPerActivity(0.0);
+            let cur_is_producer = flow.coeff > FlowPerActivity(0.0);
             if let Some(is_producer) = is_producer {
                 ensure!(
                     is_producer == cur_is_producer,
@@ -233,9 +233,9 @@ fn validate_sed_commodity(
     for flows in flows.values() {
         let flows = flows.get(&(region_id.clone(), year)).unwrap();
         if let Some(flow) = flows.get(&commodity_id.clone()) {
-            if flow.coeff > EnergyPerActivity(0.0) {
+            if flow.coeff > FlowPerActivity(0.0) {
                 has_producer = true;
-            } else if flow.coeff < EnergyPerActivity(0.0) {
+            } else if flow.coeff < FlowPerActivity(0.0) {
                 has_consumer = true;
             }
         }
@@ -266,7 +266,7 @@ fn validate_svd_commodity(
         .demand
         .get(&(region_id.clone(), year, ts_selection.clone()))
         .unwrap();
-    if demand <= Energy(0.0) {
+    if demand <= Flow(0.0) {
         return Ok(());
     }
 
@@ -279,7 +279,7 @@ fn validate_svd_commodity(
             continue;
         };
         ensure!(
-            flow.coeff > EnergyPerActivity(0.0),
+            flow.coeff > FlowPerActivity(0.0),
             "SVD commodity {} is consumed by process {}. \
             SVD commodities can only be produced, not consumed.",
             commodity.id,
@@ -315,7 +315,7 @@ mod tests {
     use crate::fixture::{assert_error, time_slice, time_slice_info};
     use crate::process::{FlowType, ProcessFlow};
     use crate::time_slice::{TimeSliceID, TimeSliceLevel};
-    use crate::units::{Dimensionless, EnergyPerActivity, MoneyPerEnergy};
+    use crate::units::{Dimensionless, FlowPerActivity, MoneyPerFlow};
     use indexmap::indexmap;
     use rstest::{fixture, rstest};
     use std::iter;
@@ -338,9 +338,9 @@ mod tests {
             ("GBR".into(), 2010),
             indexmap! { commodity_sed.id.clone() => ProcessFlow {
                 commodity: commodity_sed.into(),
-                coeff: EnergyPerActivity(-10.0),
+                coeff: FlowPerActivity(-10.0),
                 kind: FlowType::Fixed,
-                cost: MoneyPerEnergy(1.0),
+                cost: MoneyPerFlow(1.0),
                 is_primary_output: false,
             }},
         )])
@@ -352,9 +352,9 @@ mod tests {
             ("GBR".into(), 2010),
             indexmap! {commodity_sed.id.clone()=>ProcessFlow {
                 commodity: commodity_sed.into(),
-                coeff: EnergyPerActivity(10.0),
+                coeff: FlowPerActivity(10.0),
                 kind: FlowType::Fixed,
-                cost: MoneyPerEnergy(1.0),
+                cost: MoneyPerFlow(1.0),
                 is_primary_output: false,
             }},
         )])
@@ -399,8 +399,7 @@ mod tests {
 
     #[fixture]
     fn commodity_svd(time_slice: TimeSliceID) -> Commodity {
-        let demand =
-            DemandMap::from_iter([(("GBR".into(), 2010, time_slice.into()), Energy(10.0))]);
+        let demand = DemandMap::from_iter([(("GBR".into(), 2010, time_slice.into()), Flow(10.0))]);
 
         Commodity {
             id: "commodity_svd".into(),
@@ -420,9 +419,9 @@ mod tests {
                 ("GBR".into(), 2010),
                 indexmap! { commodity_svd.id.clone() => ProcessFlow {
                     commodity: commodity_svd.into(),
-                    coeff: EnergyPerActivity(10.0),
+                    coeff: FlowPerActivity(10.0),
                     kind: FlowType::Fixed,
-                    cost: MoneyPerEnergy(1.0),
+                    cost: MoneyPerFlow(1.0),
                     is_primary_output: false,
                 }},
             )]),
@@ -505,9 +504,9 @@ mod tests {
             ("GBR".into(), 2010),
             indexmap! { commodity_other.id.clone() => ProcessFlow {
                 commodity: commodity_other.into(),
-                coeff: EnergyPerActivity(10.0),
+                coeff: FlowPerActivity(10.0),
                 kind: FlowType::Fixed,
-                cost: MoneyPerEnergy(1.0),
+                cost: MoneyPerFlow(1.0),
                 is_primary_output: false,
             }},
         )])
@@ -519,9 +518,9 @@ mod tests {
             ("GBR".into(), 2010),
             indexmap! { commodity_other.id.clone() => ProcessFlow {
                 commodity: commodity_other.into(),
-                coeff: EnergyPerActivity(-10.0),
+                coeff: FlowPerActivity(-10.0),
                 kind: FlowType::Fixed,
-                cost: MoneyPerEnergy(1.0),
+                cost: MoneyPerFlow(1.0),
                 is_primary_output: false,
             }},
         )])
@@ -596,9 +595,9 @@ mod tests {
                 (region_id.clone(), 2010),
                 indexmap! { commodity_svd.id.clone() => ProcessFlow {
                     commodity: Rc::clone(&commodity_svd),
-                    coeff: EnergyPerActivity(-10.0),
+                    coeff: FlowPerActivity(-10.0),
                     kind: FlowType::Fixed,
-                    cost: MoneyPerEnergy(1.0),
+                    cost: MoneyPerFlow(1.0),
                     is_primary_output: false,
                 }},
             )]),

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,7 @@ use crate::region::RegionID;
 use crate::simulation::optimisation::{FlowMap, Solution};
 use crate::simulation::CommodityPrices;
 use crate::time_slice::TimeSliceID;
-use crate::units::{Energy, MoneyPerEnergy};
+use crate::units::{Flow, MoneyPerFlow};
 use anyhow::{Context, Result};
 use csv;
 use serde::{Deserialize, Serialize};
@@ -99,7 +99,7 @@ struct CommodityFlowRow {
     asset_id: AssetID,
     commodity_id: CommodityID,
     time_slice: TimeSliceID,
-    flow: Energy,
+    flow: Flow,
 }
 
 /// Represents a row in the commodity prices CSV file
@@ -109,7 +109,7 @@ struct CommodityPriceRow {
     commodity_id: CommodityID,
     region_id: RegionID,
     time_slice: TimeSliceID,
-    price: MoneyPerEnergy,
+    price: MoneyPerFlow,
 }
 
 /// Represents the activity duals data in a row of the activity duals CSV file
@@ -357,7 +357,7 @@ mod tests {
         let milestone_year = 2020;
         let asset = assets.iter().next().unwrap();
         let flow_map = indexmap! {
-            (asset.clone(), commodity_id.clone(), time_slice.clone()) => Energy(42.0)
+            (asset.clone(), commodity_id.clone(), time_slice.clone()) => Flow(42.0)
         };
 
         // Write a flow
@@ -374,7 +374,7 @@ mod tests {
             asset_id: asset.id.unwrap(),
             commodity_id,
             time_slice,
-            flow: Energy(42.0),
+            flow: Flow(42.0),
         };
         let records: Vec<CommodityFlowRow> =
             csv::Reader::from_path(dir.path().join(COMMODITY_FLOWS_FILE_NAME))
@@ -388,7 +388,7 @@ mod tests {
     #[rstest]
     fn test_write_prices(commodity_id: CommodityID, region_id: RegionID, time_slice: TimeSliceID) {
         let milestone_year = 2020;
-        let price = MoneyPerEnergy(42.0);
+        let price = MoneyPerFlow(42.0);
         let mut prices = CommodityPrices::default();
         prices.insert(&commodity_id, &region_id, &time_slice, price);
 

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -6,7 +6,7 @@ use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
-use crate::units::{Activity, Energy, MoneyPerActivity};
+use crate::units::{Activity, Flow, MoneyPerActivity};
 use anyhow::{anyhow, Result};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::IndexMap;
@@ -15,7 +15,7 @@ mod constraints;
 use constraints::{add_asset_constraints, ConstraintKeys};
 
 /// A map of commodity flows calculated during the optimisation
-pub type FlowMap = IndexMap<(AssetRef, CommodityID, TimeSliceID), Energy>;
+pub type FlowMap = IndexMap<(AssetRef, CommodityID, TimeSliceID), Flow>;
 
 /// A decision variable in the optimisation
 ///

--- a/src/units.rs
+++ b/src/units.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::ops::{AddAssign, SubAssign};
+use std::ops::{AddAssign, Mul, SubAssign};
 
 macro_rules! base_unit_struct {
     ($name:ident) => {
@@ -20,12 +20,6 @@ macro_rules! base_unit_struct {
         )]
         pub struct $name(pub f64);
 
-        impl std::ops::Mul<$name> for $name {
-            type Output = $name;
-            fn mul(self, rhs: $name) -> $name {
-                $name(self.0 * rhs.0)
-            }
-        }
         impl std::ops::Div<$name> for $name {
             type Output = Dimensionless;
             fn div(self, rhs: $name) -> Dimensionless {
@@ -91,6 +85,14 @@ impl From<f64> for Dimensionless {
 impl From<Dimensionless> for f64 {
     fn from(val: Dimensionless) -> Self {
         val.0
+    }
+}
+
+impl Mul for Dimensionless {
+    type Output = Dimensionless;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Dimensionless(self.0 * rhs.0)
     }
 }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -131,19 +131,19 @@ macro_rules! unit_struct {
 
 // Base quantities
 unit_struct!(Money);
-unit_struct!(Energy);
+unit_struct!(Flow);
 unit_struct!(Activity);
 unit_struct!(Capacity);
 unit_struct!(Year);
 
 // Derived quantities
 unit_struct!(MoneyPerYear);
-unit_struct!(MoneyPerEnergy);
+unit_struct!(MoneyPerFlow);
 unit_struct!(MoneyPerCapacity);
 unit_struct!(MoneyPerCapacityPerYear);
 unit_struct!(MoneyPerActivity);
 unit_struct!(ActivityPerCapacity);
-unit_struct!(EnergyPerActivity);
+unit_struct!(FlowPerActivity);
 
 macro_rules! impl_div {
     ($Lhs:ident, $Rhs:ident, $Out:ident) => {
@@ -181,11 +181,11 @@ macro_rules! impl_div {
 }
 
 // Division rules for derived quantities
-impl_div!(Energy, Activity, EnergyPerActivity);
+impl_div!(Flow, Activity, FlowPerActivity);
 impl_div!(Money, Year, MoneyPerYear);
-impl_div!(Money, Energy, MoneyPerEnergy);
+impl_div!(Money, Flow, MoneyPerFlow);
 impl_div!(Money, Capacity, MoneyPerCapacity);
 impl_div!(Money, Activity, MoneyPerActivity);
 impl_div!(Activity, Capacity, ActivityPerCapacity);
 impl_div!(MoneyPerYear, Capacity, MoneyPerCapacityPerYear);
-impl_div!(MoneyPerActivity, EnergyPerActivity, MoneyPerEnergy);
+impl_div!(MoneyPerActivity, FlowPerActivity, MoneyPerFlow);


### PR DESCRIPTION
# Description

This PR includes two changes:

1. Rename "energy" types to "flow" types, as @ahawkes suggested
2. Remove the option to multiply unit types by things of the same type, as discussed

I decided not to include the `UnitType` trait stuff from #656 as it's not currently needed anywhere. We can cherry-pick it later, if needed.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
