### PR TITLE
`ProcessFlow`: Add `is_input` and `is_output` helper methods

### DIFF
--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -190,7 +190,7 @@ fn validate_or_infer_primary_output(
     let mut output_flow = None;
     let mut outputs_count = 0;
     for (commodity_id, is_primary_output) in primary_outputs.iter() {
-        let is_output = flows_map.get(commodity_id).unwrap().coeff > FlowPerActivity(0.0);
+        let is_output = flows_map.get(commodity_id).unwrap().is_output();
         if is_output {
             outputs_count += 1;
         }

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -4,7 +4,7 @@ use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
-use crate::units::{FlowPerActivity, MoneyPerFlow};
+use crate::units::MoneyPerFlow;
 use log::warn;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -53,10 +53,7 @@ impl CommodityPrices {
         let mut highest_duals = HashMap::new();
         for (asset, time_slice, dual) in solution.iter_activity_duals() {
             // Iterate over all output flows
-            for flow in asset
-                .iter_flows()
-                .filter(|flow| flow.coeff > FlowPerActivity(0.0))
-            {
+            for flow in asset.iter_flows().filter(|flow| flow.is_output()) {
                 // Update the highest dual for this commodity/timeslice
                 highest_duals
                     .entry((


### PR DESCRIPTION
# Description

This is only a small change, but because it touches code in various places I thought it should be a separate PR.

I've added `is_input` and `is_output` helper methods to `ProcessFlow`, partly because it's now quite verbose to check whether something's an input/output flow (`flow.coeff > FlowPerActivity(0.0)`) but also because I think it would be easy to miss that someone had put a `>` instead of a `<`. I think it's better to be explicit.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
