### PR TITLE
Represent collections of `RegionID`s with `IndexSet`s, not `HashSet`s

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,10 +5,9 @@ use crate::id::{define_id_getter, define_id_type};
 use crate::process::Process;
 use crate::region::RegionID;
 use crate::units::{Dimensionless, Money};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::rc::Rc;
 
 define_id_type! {AgentID}
@@ -47,7 +46,7 @@ pub struct Agent {
     /// Cost limits (e.g. capital cost, annual operating cost)
     pub cost_limits: AgentCostLimitsMap,
     /// The regions in which this agent operates.
-    pub regions: HashSet<RegionID>,
+    pub regions: IndexSet<RegionID>,
     /// The agent's objectives.
     pub objectives: AgentObjectiveMap,
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -338,9 +338,9 @@ mod tests {
         ActivityPerCapacity, Dimensionless, MoneyPerActivity, MoneyPerCapacity,
         MoneyPerCapacityPerYear,
     };
+    use indexmap::IndexSet;
     use itertools::{assert_equal, Itertools};
     use rstest::{fixture, rstest};
-    use std::collections::HashSet;
     use std::iter;
     use std::ops::RangeInclusive;
 
@@ -414,7 +414,7 @@ mod tests {
             activity_limits: ProcessActivityLimitsMap::new(),
             flows: ProcessFlowsMap::new(),
             parameters: process_parameter_map,
-            regions: HashSet::from(["GBR".into()]),
+            regions: IndexSet::from(["GBR".into()]),
         });
         let future = [2020, 2010]
             .map(|year| {
@@ -467,7 +467,7 @@ mod tests {
             activity_limits,
             flows: ProcessFlowsMap::new(),
             parameters: process_parameter_map,
-            regions: HashSet::from(["GBR".into()]),
+            regions: IndexSet::from(["GBR".into()]),
         });
         let asset = Asset::new(
             "agent1".into(),

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -17,9 +17,10 @@ use crate::units::{
     MoneyPerCapacityPerYear,
 };
 use indexmap::indexmap;
+use indexmap::IndexSet;
 use itertools::Itertools;
 use rstest::fixture;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::iter;
 use std::rc::Rc;
 
@@ -40,12 +41,12 @@ pub fn region_id() -> RegionID {
 }
 
 #[fixture]
-pub fn commodity_ids() -> HashSet<CommodityID> {
-    iter::once("commodity1".into()).collect()
+pub fn commodity_ids() -> IndexSet<CommodityID> {
+    IndexSet::from(["commodity1".into()])
 }
 
 #[fixture]
-pub fn region_ids() -> HashSet<RegionID> {
+pub fn region_ids() -> IndexSet<RegionID> {
     ["GBR".into(), "USA".into()].into_iter().collect()
 }
 
@@ -99,7 +100,7 @@ pub fn assets(asset: Asset) -> AssetPool {
 }
 
 #[fixture]
-pub fn process_parameter_map(region_ids: HashSet<RegionID>) -> ProcessParameterMap {
+pub fn process_parameter_map(region_ids: IndexSet<RegionID>) -> ProcessParameterMap {
     let parameter = Rc::new(ProcessParameter {
         capital_cost: MoneyPerCapacity(0.0),
         fixed_operating_cost: MoneyPerCapacityPerYear(0.0),
@@ -118,7 +119,7 @@ pub fn process_parameter_map(region_ids: HashSet<RegionID>) -> ProcessParameterM
 
 #[fixture]
 pub fn process(
-    region_ids: HashSet<RegionID>,
+    region_ids: IndexSet<RegionID>,
     process_parameter_map: ProcessParameterMap,
 ) -> Process {
     Process {
@@ -148,7 +149,7 @@ pub fn agents() -> AgentMap {
             search_space: AgentSearchSpaceMap::new(),
             decision_rule: DecisionRule::Single,
             cost_limits: AgentCostLimitsMap::new(),
-            regions: HashSet::new(),
+            regions: IndexSet::new(),
             objectives: AgentObjectiveMap::new(),
         },
     ))

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -8,8 +8,8 @@ use crate::commodity::CommodityMap;
 use crate::process::ProcessMap;
 use crate::region::{parse_region_str, RegionID};
 use anyhow::{bail, ensure, Context, Result};
+use indexmap::IndexSet;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::path::Path;
 
 mod objective;
@@ -54,7 +54,7 @@ pub fn read_agents(
     model_dir: &Path,
     commodities: &CommodityMap,
     processes: &ProcessMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<AgentMap> {
     let mut agents = read_agents_file(model_dir, region_ids)?;
@@ -105,14 +105,14 @@ pub fn read_agents(
 /// # Returns
 ///
 /// A map of Agents, with the agent ID as the key
-fn read_agents_file(model_dir: &Path, region_ids: &HashSet<RegionID>) -> Result<AgentMap> {
+fn read_agents_file(model_dir: &Path, region_ids: &IndexSet<RegionID>) -> Result<AgentMap> {
     let file_path = model_dir.join(AGENT_FILE_NAME);
     let agents_csv = read_csv(&file_path)?;
     read_agents_file_from_iter(agents_csv, region_ids).with_context(|| input_err_msg(&file_path))
 }
 
 /// Read agents info from an iterator.
-fn read_agents_file_from_iter<I>(iter: I, region_ids: &HashSet<RegionID>) -> Result<AgentMap>
+fn read_agents_file_from_iter<I>(iter: I, region_ids: &IndexSet<RegionID>) -> Result<AgentMap>
 where
     I: Iterator<Item = AgentRaw>,
 {
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn test_read_agents_file_from_iter() {
         // Valid case
-        let region_ids = HashSet::from(["GBR".into()]);
+        let region_ids = IndexSet::from(["GBR".into()]);
         let agent = AgentRaw {
             id: "agent".into(),
             description: "".into(),
@@ -188,7 +188,7 @@ mod tests {
             search_space: AgentSearchSpaceMap::new(),
             decision_rule: DecisionRule::Single,
             cost_limits: AgentCostLimitsMap::new(),
-            regions: HashSet::from(["GBR".into()]),
+            regions: IndexSet::from(["GBR".into()]),
             objectives: AgentObjectiveMap::new(),
         };
         let expected = AgentMap::from_iter(iter::once(("agent".into(), agent_out)));

--- a/src/input/agent/commodity_portion.rs
+++ b/src/input/agent/commodity_portion.rs
@@ -7,6 +7,7 @@ use crate::region::RegionID;
 use crate::units::Dimensionless;
 use crate::year::parse_year_str;
 use anyhow::{ensure, Context, Result};
+use indexmap::IndexSet;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -39,7 +40,7 @@ pub fn read_agent_commodity_portions(
     model_dir: &Path,
     agents: &AgentMap,
     commodities: &CommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<HashMap<AgentID, AgentCommodityPortionsMap>> {
     let file_path = model_dir.join(AGENT_COMMODITIES_FILE_NAME);
@@ -58,7 +59,7 @@ fn read_agent_commodity_portions_from_iter<I>(
     iter: I,
     agents: &AgentMap,
     commodities: &CommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<HashMap<AgentID, AgentCommodityPortionsMap>>
 where
@@ -103,7 +104,7 @@ fn validate_agent_commodity_portions(
     agent_commodity_portions: &HashMap<AgentID, AgentCommodityPortionsMap>,
     agents: &AgentMap,
     commodities: &CommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<()> {
     // CHECK 1: Each specified commodity must have data for all years
@@ -201,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_validate_agent_commodity_portions() {
-        let region_ids = HashSet::from([RegionID::new("region1"), RegionID::new("region2")]);
+        let region_ids = IndexSet::from([RegionID::new("region1"), RegionID::new("region2")]);
         let milestone_years = [2020];
         let agents = IndexMap::from([(
             AgentID::new("agent1"),

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -161,11 +161,12 @@ mod tests {
         ProcessActivityLimitsMap, ProcessFlowsMap, ProcessID, ProcessParameterMap,
     };
     use crate::region::RegionID;
+    use indexmap::IndexSet;
     use rstest::{fixture, rstest};
     use std::iter;
 
     #[fixture]
-    pub fn processes(region_ids: HashSet<RegionID>) -> ProcessMap {
+    pub fn processes(region_ids: IndexSet<RegionID>) -> ProcessMap {
         ["A", "B", "C"]
             .map(|id| {
                 let id: ProcessID = id.into();

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -7,9 +7,9 @@ use crate::process::ProcessMap;
 use crate::region::RegionID;
 use crate::units::Capacity;
 use anyhow::{Context, Result};
+use indexmap::IndexSet;
 use itertools::Itertools;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -38,9 +38,9 @@ struct AssetRaw {
 /// A `HashMap` containing assets grouped by agent ID.
 pub fn read_assets(
     model_dir: &Path,
-    agent_ids: &HashSet<AgentID>,
+    agent_ids: &IndexSet<AgentID>,
     processes: &ProcessMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
 ) -> Result<Vec<Asset>> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
     let assets_csv = read_csv(&file_path)?;
@@ -62,9 +62,9 @@ pub fn read_assets(
 /// A [`Vec`] of [`Asset`]s or an error.
 fn read_assets_from_iter<I>(
     iter: I,
-    agent_ids: &HashSet<AgentID>,
+    agent_ids: &IndexSet<AgentID>,
     processes: &ProcessMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
 ) -> Result<Vec<Asset>>
 where
     I: Iterator<Item = AssetRaw>,
@@ -97,15 +97,15 @@ mod tests {
     use std::iter;
 
     #[fixture]
-    fn agent_ids() -> HashSet<AgentID> {
-        iter::once("agent1".into()).collect()
+    fn agent_ids() -> IndexSet<AgentID> {
+        IndexSet::from(["agent1".into()])
     }
 
     #[rstest]
     fn test_read_assets_from_iter_valid(
-        agent_ids: HashSet<AgentID>,
+        agent_ids: IndexSet<AgentID>,
         processes: ProcessMap,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         let asset_in = AssetRaw {
             agent_id: "agent1".into(),
@@ -153,9 +153,9 @@ mod tests {
         })]
     fn test_read_assets_from_iter_invalid(
         #[case] asset: AssetRaw,
-        agent_ids: HashSet<AgentID>,
+        agent_ids: IndexSet<AgentID>,
         processes: ProcessMap,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         assert!(
             read_assets_from_iter(iter::once(asset), &agent_ids, &processes, &region_ids).is_err()

--- a/src/input/commodity.rs
+++ b/src/input/commodity.rs
@@ -4,7 +4,7 @@ use crate::commodity::{Commodity, CommodityID, CommodityMap};
 use crate::region::RegionID;
 use crate::time_slice::TimeSliceInfo;
 use anyhow::Result;
-use std::collections::HashSet;
+use indexmap::IndexSet;
 use std::path::Path;
 
 mod levy;
@@ -29,7 +29,7 @@ const COMMODITY_FILE_NAME: &str = "commodities.csv";
 /// A map containing commodities, grouped by commodity ID or an error.
 pub fn read_commodities(
     model_dir: &Path,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
 ) -> Result<CommodityMap> {

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -8,9 +8,10 @@ use crate::region::RegionID;
 use crate::time_slice::{TimeSliceInfo, TimeSliceLevel};
 use crate::units::Flow;
 use anyhow::{ensure, Result};
+use indexmap::IndexSet;
 use itertools::iproduct;
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 const DEMAND_FILE_NAME: &str = "demand.csv";
@@ -50,7 +51,7 @@ pub type BorrowedCommodityMap<'a> = HashMap<CommodityID, &'a Commodity>;
 pub fn read_demand(
     model_dir: &Path,
     commodities: &IndexMap<CommodityID, Commodity>,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
 ) -> Result<HashMap<CommodityID, DemandMap>> {
@@ -82,7 +83,7 @@ pub fn read_demand(
 fn read_demand_file(
     model_dir: &Path,
     svd_commodities: &BorrowedCommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<AnnualDemandMap> {
     let file_path = model_dir.join(DEMAND_FILE_NAME);
@@ -107,7 +108,7 @@ fn read_demand_file(
 fn read_demand_from_iter<I>(
     iter: I,
     svd_commodities: &BorrowedCommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
 ) -> Result<AnnualDemandMap>
 where
@@ -225,7 +226,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[rstest]
-    fn test_read_demand_from_iter(svd_commodity: Commodity, region_ids: HashSet<RegionID>) {
+    fn test_read_demand_from_iter(svd_commodity: Commodity, region_ids: IndexSet<RegionID>) {
         let svd_commodities = get_svd_map(&svd_commodity);
         let demand = [
             Demand {
@@ -252,7 +253,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_from_iter_bad_commodity_id(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Bad commodity ID
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -279,7 +280,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_from_iter_bad_region_id(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Bad region ID
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -306,7 +307,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_from_iter_bad_year(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Bad year
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -339,7 +340,7 @@ mod tests {
     #[case(f64::INFINITY)]
     fn test_read_demand_from_iter_bad_demand(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         #[case] quantity: f64,
     ) {
         // Bad demand quantity
@@ -359,7 +360,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_from_iter_multiple_entries(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Multiple entries for same commodity and region
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -392,7 +393,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_from_iter_missing_year(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Missing entry for a milestone year
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -425,7 +426,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_read_demand_file(svd_commodity: Commodity, region_ids: HashSet<RegionID>) {
+    fn test_read_demand_file(svd_commodity: Commodity, region_ids: IndexSet<RegionID>) {
         let svd_commodities = get_svd_map(&svd_commodity);
         let dir = tempdir().unwrap();
         create_demand_file(dir.path());

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -7,9 +7,10 @@ use crate::region::RegionID;
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use crate::units::Dimensionless;
 use anyhow::{ensure, Context, Result};
+use indexmap::IndexSet;
 use itertools::{iproduct, Itertools};
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 const DEMAND_SLICING_FILE_NAME: &str = "demand_slicing.csv";
@@ -38,7 +39,7 @@ pub type DemandSliceMap = HashMap<(CommodityID, RegionID, TimeSliceSelection), D
 pub fn read_demand_slices(
     model_dir: &Path,
     svd_commodities: &BorrowedCommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap> {
     let file_path = model_dir.join(DEMAND_SLICING_FILE_NAME);
@@ -56,7 +57,7 @@ pub fn read_demand_slices(
 fn read_demand_slices_from_iter<I>(
     iter: I,
     svd_commodities: &BorrowedCommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<DemandSliceMap>
 where
@@ -123,7 +124,7 @@ where
 /// * The demand fractions for all entries related to a commodity + region pair sum to one
 fn validate_demand_slices(
     svd_commodities: &BorrowedCommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     demand_slices: &DemandSliceMap,
     time_slice_info: &TimeSliceInfo,
 ) -> Result<()> {
@@ -162,14 +163,14 @@ mod tests {
     use std::iter;
 
     #[fixture]
-    pub fn region_ids() -> HashSet<RegionID> {
-        iter::once("GBR".into()).collect()
+    pub fn region_ids() -> IndexSet<RegionID> {
+        IndexSet::from(["GBR".into()])
     }
 
     #[rstest]
     fn test_read_demand_slices_from_iter_valid(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Valid
@@ -200,7 +201,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_valid_multiple_time_slices(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Valid, multiple time slices
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -300,7 +301,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_empty_file(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Empty CSV file
@@ -319,7 +320,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_commodity(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad commodity
@@ -344,7 +345,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_region(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad region
@@ -369,7 +370,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_time_slice(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Bad time slice selection
@@ -394,7 +395,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_missing_time_slices(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
     ) {
         // Some time slices uncovered
         let svd_commodities = get_svd_map(&svd_commodity);
@@ -445,7 +446,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_duplicate_time_slice(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Same time slice twice
@@ -471,7 +472,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_season_time_slice_conflict(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Whole season and single time slice conflicting
@@ -503,7 +504,7 @@ mod tests {
     #[rstest]
     fn test_read_demand_slices_from_iter_invalid_bad_fractions(
         svd_commodity: Commodity,
-        region_ids: HashSet<RegionID>,
+        region_ids: IndexSet<RegionID>,
         time_slice_info: TimeSliceInfo,
     ) {
         // Fractions don't sum to one

--- a/src/input/process.rs
+++ b/src/input/process.rs
@@ -8,9 +8,10 @@ use crate::region::{parse_region_str, RegionID};
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
 use crate::units::Flow;
 use anyhow::{ensure, Context, Ok, Result};
+use indexmap::IndexSet;
 use itertools::iproduct;
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -50,7 +51,7 @@ define_id_getter! {ProcessRaw, ProcessID}
 pub fn read_processes(
     model_dir: &Path,
     commodities: &CommodityMap,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     time_slice_info: &TimeSliceInfo,
     milestone_years: &[u32],
 ) -> Result<ProcessMap> {
@@ -90,7 +91,7 @@ pub fn read_processes(
 fn read_processes_file(
     model_dir: &Path,
     milestone_years: &[u32],
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
 ) -> Result<ProcessMap> {
     let file_path = model_dir.join(PROCESSES_FILE_NAME);
     let processes_csv = read_csv(&file_path)?;
@@ -101,7 +102,7 @@ fn read_processes_file(
 fn read_processes_file_from_iter<I>(
     iter: I,
     milestone_years: &[u32],
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
 ) -> Result<ProcessMap>
 where
     I: Iterator<Item = ProcessRaw>,
@@ -154,7 +155,7 @@ fn validate_commodities(
     commodities: &CommodityMap,
     flows: &HashMap<ProcessID, ProcessFlowsMap>,
     availabilities: &HashMap<ProcessID, ProcessActivityLimitsMap>,
-    region_ids: &HashSet<RegionID>,
+    region_ids: &IndexSet<RegionID>,
     milestone_years: &[u32],
     time_slice_info: &TimeSliceInfo,
 ) -> Result<()> {

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -129,8 +129,8 @@ where
             })?;
 
         // Get regions
-        let process_regions = process.regions.clone();
-        let parameter_regions = parse_region_str(&param_raw.regions, &process_regions)
+        let process_regions = &process.regions;
+        let parameter_regions = parse_region_str(&param_raw.regions, process_regions)
             .with_context(|| {
                 format!("Invalid region for process {id}. Valid regions are {process_regions:?}")
             })?;

--- a/src/process.rs
+++ b/src/process.rs
@@ -8,9 +8,9 @@ use crate::units::{
     ActivityPerCapacity, Dimensionless, FlowPerActivity, MoneyPerActivity, MoneyPerCapacity,
     MoneyPerCapacityPerYear, MoneyPerFlow,
 };
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
 
@@ -50,7 +50,7 @@ pub struct Process {
     /// Additional parameters for this process
     pub parameters: ProcessParameterMap,
     /// The regions in which this process can operate
-    pub regions: HashSet<RegionID>,
+    pub regions: IndexSet<RegionID>,
 }
 
 /// Represents a maximum annual commodity coeff for a given process

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,9 +1,8 @@
 //! Regions represent different geographical areas in which agents, processes, etc. are active.
 use crate::id::{define_id_getter, define_id_type, IDCollection};
 use anyhow::{ensure, Result};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
-use std::collections::HashSet;
 
 define_id_type! {RegionID}
 
@@ -24,7 +23,7 @@ define_id_getter! {Region, RegionID}
 ///
 /// The string can be either "all" (case-insensitive), a single region, or a semicolon-separated
 /// list of regions (e.g. "GBR;FRA;USA" or "GBR; FRA; USA")
-pub fn parse_region_str(s: &str, region_ids: &HashSet<RegionID>) -> Result<HashSet<RegionID>> {
+pub fn parse_region_str(s: &str, region_ids: &IndexSet<RegionID>) -> Result<IndexSet<RegionID>> {
     let s = s.trim();
     ensure!(!s.is_empty(), "No regions provided");
 
@@ -43,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_parse_region_str() {
-        let region_ids: HashSet<RegionID> = ["GBR".into(), "USA".into()].into_iter().collect();
+        let region_ids: IndexSet<RegionID> = ["GBR".into(), "USA".into()].into_iter().collect();
 
         // List of regions
         let parsed = parse_region_str("GBR;USA", &region_ids).unwrap();


### PR DESCRIPTION
# Description

This is possibly the most boring PR on the planet, but it involves little changes all over the place so didn't want to include it with something else.

I've changed everywhere that we store `RegionID`s in a `HashSet` to use an `IndexSet` instead. The reason is because I want to iterate over the regions a process can operate in with a deterministic order. The problem is that to do this we'd need to change things in various other places (e.g. `parse_region_str`) so I figured it would be easier to do in one go.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
