### PR TITLE
Exclude a flaky host from link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,6 @@
 
 # Times out on GitHub runner
 ^http://www.adobe.com
+
+# Often times out
+^https://iea-etsap.org


### PR DESCRIPTION
The link checker often times out for iea-etsap.org, so let's just exclude it from checks.