### PR TITLE
Fix new `format!`-related clippy warnings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -242,7 +242,7 @@ mod tests {
     fn create_csv_file(dir_path: &Path, contents: &str) -> PathBuf {
         let file_path = dir_path.join("test.csv");
         let mut file = File::create(&file_path).unwrap();
-        writeln!(file, "{}", contents).unwrap();
+        writeln!(file, "{contents}").unwrap();
         file_path
     }
 

--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -85,7 +85,7 @@ pub fn read_agents(
         }
         agent.commodity_portions = agent_commodities
             .remove(id)
-            .with_context(|| format!("Missing commodity portions for agent {}", id))?;
+            .with_context(|| format!("Missing commodity portions for agent {id}"))?;
         if let Some(cost_limits) = cost_limits.remove(id) {
             agent.cost_limits = cost_limits;
         }

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -67,10 +67,7 @@ where
             .or_insert_with(AgentObjectiveMap::new);
         for year in parse_year_str(&objective.years, milestone_years)? {
             try_insert(agent_objectives, year, objective.objective_type).with_context(|| {
-                format!(
-                    "Duplicate agent objective entry for agent {} and year {}",
-                    id, year
-                )
+                format!("Duplicate agent objective entry for agent {id} and year {year}")
             })?;
         }
     }
@@ -79,7 +76,7 @@ where
     for agent_id in agents.keys() {
         let agent_objectives = all_objectives
             .get(agent_id)
-            .with_context(|| format!("Agent {} has no objectives", agent_id))?;
+            .with_context(|| format!("Agent {agent_id} has no objectives"))?;
 
         let missing_years = milestone_years
             .iter()

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -118,7 +118,7 @@ where
     for (commodity_id, regions) in commodity_regions.iter() {
         let map = map.get(commodity_id).unwrap();
         validate_commodity_levy_map(map, regions, milestone_years, time_slice_info)
-            .with_context(|| format!("Missing costs for commodity {}", commodity_id))?;
+            .with_context(|| format!("Missing costs for commodity {commodity_id}"))?;
     }
     Ok(map)
 }

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -166,8 +166,7 @@ fn validate_flows_and_update_primary_output(
             let inferred_primary_output = validate_or_infer_primary_output(flows, primary_outputs)
                 .with_context(|| {
                     format!(
-                    "Invalid primary output configuration for process {} (region: {}, year: {})",
-                    process_id, region_id, year
+                    "Invalid primary output configuration for process {process_id} (region: {region_id}, year: {year})"
                 )
                 })?;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -137,10 +137,7 @@ pub fn init(log_level_from_settings: Option<&str>, output_path: &Path) -> Result
 fn write_log<T: Display>(out: FormatCallback, level: T, target: &str, message: &Arguments) {
     let timestamp = Local::now().format("%H:%M:%S");
 
-    out.finish(format_args!(
-        "[{} {} {}] {}",
-        timestamp, level, target, message
-    ));
+    out.finish(format_args!("[{timestamp} {level} {target}] {message}"));
 }
 
 /// Write to the log with no colours

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn execute_cli_command(command: Option<Commands>) -> Result<()> {
     let Some(command) = command else {
         // Output program help in markdown format
         let help_str = Cli::command().render_long_help().to_string();
-        println!("{}", help_str);
+        println!("{help_str}");
         return Ok(());
     };
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -54,8 +54,7 @@ impl<'de> Deserialize<'de> for TimeSliceID {
         let s: &str = Deserialize::deserialize(deserialiser)?;
         let (season, time_of_day) = s.split(".").collect_tuple().ok_or_else(|| {
             D::Error::custom(format!(
-                "Invalid input '{}': Should be in form season.time_of_day",
-                s
+                "Invalid input '{s}': Should be in form season.time_of_day"
             ))
         })?;
         Ok(Self {
@@ -246,11 +245,11 @@ impl TimeSliceInfo {
         let season = self
             .seasons
             .get_id(season)
-            .with_context(|| format!("{} is not a known season", season))?;
+            .with_context(|| format!("{season} is not a known season"))?;
         let time_of_day = self
             .times_of_day
             .get_id(time_of_day)
-            .with_context(|| format!("{} is not a known time of day", time_of_day))?;
+            .with_context(|| format!("{time_of_day} is not a known time of day"))?;
 
         Ok(TimeSliceID {
             season: season.clone(),

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -63,8 +63,7 @@ fn compare_lines(
     for (num, (line1, line2)) in lines1.into_iter().zip(lines2).enumerate() {
         if !compare_line(num, &line1, &line2, file_name, errors) {
             errors.push(format!(
-                "{}: line {}:\n    + \"{}\"\n    - \"{}\"",
-                file_name, num, line1, line2
+                "{file_name}: line {num}:\n    + \"{line1}\"\n    - \"{line2}\""
             ))
         }
     }


### PR DESCRIPTION
# Description

It seems like the latest version of clippy warns if you write something like `format!("hello {}", name)` rather than `format!("hello {name}")`. We could just suppress it, but it seems reasoable enough so I've just taken clippy's autofixes. This is causing the CI runners to fail.

To get the new version of the stable toolchain, run `rustup update stable`.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
