### PR TITLE
Incorporate Adam's "overview" into documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,36 @@
 
 # MUSE 2.0
 
-MUSE 2.0 is a tool for running simulations of energy systems, written in Rust. It is a slimmer and
-faster version of [the older MUSE tool].
+MUSE 2.0 (**M**od**U**lar energy systems **S**imulation **E**nvironment) is a tool for running
+simulations of energy systems, written in Rust. Its purpose is to provide users with a framework to
+simulate pathways of energy system transition, usually in the context of climate change mitigation.
 
-Documentation is available on our [GitHub Pages site].
+It is the successor to [MUSE], which is written in Python. It was developed following re-design of
+MUSE to address a range of legacy issues that are challenging to address via upgrades to the
+existing MUSE framework, and to implement the framework in the high-performance Rust language.
 
-For example Rust code showing how to solve a constrained optimisation, see the
-[`highs-example-rust`] repository.
+:construction: **Please note that this code is under heavy development and is not yet suitable for
+end users. Watch this space!** :construction:
 
-:construction: Note that this repository is under heavy development and not suitable for end users!
-:construction:
+## Model overview
 
-[the older MUSE tool]: https://github.com/EnergySystemsModellingLab/MUSE_OS
-[GitHub Pages site]: https://energysystemsmodellinglab.github.io/MUSE_2.0
-[`highs-example-rust`]: https://github.com/EnergySystemsModellingLab/highs-example-rust
+MUSE is an [Integrated Assessment Modelling] framework that is designed to enable users to create
+and apply an agent-based model to simulate a market equilibrium on a set of user-defined
+commodities, over a user-defined time period, for a user-specified region or set of regions. MUSE
+was developed to simulate approaches to climate change mitigation over a long time horizon (e.g.
+5-year steps to 2050 or 2100), but the framework is generalised and can therefore simulate any
+market equilibrium.
+
+It is a recursive dynamic modelling framework in the sense that it iterates on a single time period
+to find a market equilibrium, and then moves to the next time period. Agents in MUSE have limited
+foresight, reacting only to information available in the current time period. This is distinct from
+intertemporal optimisation modelling frameworks (such as [TIMES] and [MESSAGEix]) which have perfect
+foresight over the whole modelled time horizon.
+
+[MUSE]: https://github.com/EnergySystemsModellingLab/MUSE_OS
+[Integrated Assessment Modelling]: https://unfccc.int/topics/mitigation/workstreams/response-measures/modelling-tools-to-assess-the-impact-of-the-implementation-of-response-measures/integrated-assessment-models-iams-and-energy-environment-economy-e3-models
+[TIMES]: https://iea-etsap.org/index.php/etsap-tools/model-generators/times
+[MESSAGEix]: https://docs.messageix.org/en/latest
 
 ## Getting started
 

--- a/docs/model_description.md
+++ b/docs/model_description.md
@@ -9,10 +9,9 @@
 
 ### Model Purpose
 
-This Software Requirements Specification (SRS) describes MUSE 2.0 (**M**od**U**lar energy systems
-**S**imulation **E**nvironment).
-The purpose of MUSE is to provide users with a framework to simulate pathways of energy system
-transition, usually in the context of climate change mitigation.
+The purpose of MUSE 2.0 (**M**od**U**lar energy systems **S**imulation **E**nvironment) is to
+provide users with a framework to simulate pathways of energy system transition, usually in the
+context of climate change mitigation.
 
 ### Model Scope
 

--- a/docs/model_description.md
+++ b/docs/model_description.md
@@ -5,43 +5,11 @@
 
 # Model Description
 
-## Introduction
-
-### Model Purpose
-
 The purpose of MUSE 2.0 (**M**od**U**lar energy systems **S**imulation **E**nvironment) is to
 provide users with a framework to simulate pathways of energy system transition, usually in the
 context of climate change mitigation.
 
-### Model Scope
-
-MUSE is an [Integrated Assessment
-Modelling](https://unfccc.int/topics/mitigation/workstreams/response-measures/modelling-tools-to-assess-the-impact-of-the-implementation-of-response-measures/integrated-assessment-models-iams-and-energy-environment-economy-e3-models)
-framework that is designed to enable users to create and apply an agent-based model that simulates a
-market equilibrium on a set of user-defined commodities, over a user-defined time period, for a
-user-specified region or set of regions. MUSE was developed to simulate approaches to climate change
-mitigation over a long time horizon (e.g. 5-year steps to 2050 or 2100), but the framework is
-generalised and can therefore simulate any market equilibrium.
-
-## Overall Description
-
-### Overview
-
-MUSE 2.0 is the successor to MUSE. The original MUSE framework is open-source software [available on
-GitHub](https://github.com/EnergySystemsModellingLab/MUSE_OS), coded in Python. MUSE 2.0 is
-implemented following re-design of MUSE to address a range of legacy issues that are challenging to
-address via upgrades to the existing MUSE framework, and to implement the framework in the
-high-performance Rust language.
-
-MUSE is classified as a recursive dynamic modelling framework in the sense that it iterates on a
-single time period to find a market equilibrium, and then moves to the next time period. Agents in
-MUSE have limited foresight, reacting only to information available in the current time period. This
-is distinct from intertemporal optimisation modelling frameworks (such as
-[TIMES](https://iea-etsap.org/index.php/etsap-tools/model-generators/times) and
-[MESSAGEix](https://docs.messageix.org/en/latest/)) which have perfect foresight over the whole
-modelled time horizon.
-
-### Model Concept
+## Model Concept
 
 MUSE 2.0 is a bottom-up engineering-economic modelling framework that computes a price-induced
 supply-demand equilibrium on a set of user-defined commodities.

--- a/docs/model_description.md
+++ b/docs/model_description.md
@@ -76,7 +76,7 @@ At a high level, the user defines:
     base time period (i.e. assets) and possible future processes that
     could be adopted in future milestone time periods.
 
-5) The agents that choose between technologies by applying search
+5) The agents that choose between processes by applying search
     spaces, objectives and decision rules. Portions of demand for each
     commodity must be assigned to an agent, and the sum of these
     portions must be one.


### PR DESCRIPTION
# Description

As Adam's doc is finished, we can start incorporating parts into the repo documentation.

In this PR, I've added the content from the "overview" document (converted with `pandoc`) to the model description page, which I think is where it makes most sense. I've lightly edited it so it flows with the surrounding text.

While I was at it, I thought I'd move some of the background info about the model into the readme, which is currently a bit sparse. Again, I lightly edited it, but have tried not to change the meaning.

Closes #674. Closes #667.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
