### PR TITLE
Use unit types for optimisation output values

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,7 @@ use crate::region::RegionID;
 use crate::simulation::optimisation::{FlowMap, Solution};
 use crate::simulation::CommodityPrices;
 use crate::time_slice::TimeSliceID;
-use crate::units::{Flow, MoneyPerFlow};
+use crate::units::{Flow, MoneyPerActivity, MoneyPerFlow};
 use anyhow::{Context, Result};
 use csv;
 use serde::{Deserialize, Serialize};
@@ -118,7 +118,7 @@ struct ActivityDualsRow {
     milestone_year: u32,
     asset_id: Option<AssetID>,
     time_slice: TimeSliceID,
-    value: f64,
+    value: MoneyPerActivity,
 }
 
 /// Represents the commodity balance duals data in a row of the commodity balance duals CSV file
@@ -128,7 +128,7 @@ struct CommodityBalanceDualsRow {
     commodity_id: CommodityID,
     region_id: RegionID,
     time_slice: TimeSliceID,
-    value: f64,
+    value: MoneyPerFlow,
 }
 
 /// For writing extra debug information about the model
@@ -168,7 +168,7 @@ impl DebugDataWriter {
     /// Write activity duals to file
     fn write_activity_duals<'a, I>(&mut self, milestone_year: u32, iter: I) -> Result<()>
     where
-        I: Iterator<Item = (&'a AssetRef, &'a TimeSliceID, f64)>,
+        I: Iterator<Item = (&'a AssetRef, &'a TimeSliceID, MoneyPerActivity)>,
     {
         for (asset, time_slice, value) in iter {
             let row = ActivityDualsRow {
@@ -186,7 +186,7 @@ impl DebugDataWriter {
     /// Write commodity balance duals to file
     fn write_commodity_balance_duals<'a, I>(&mut self, milestone_year: u32, iter: I) -> Result<()>
     where
-        I: Iterator<Item = (&'a CommodityID, &'a RegionID, &'a TimeSliceID, f64)>,
+        I: Iterator<Item = (&'a CommodityID, &'a RegionID, &'a TimeSliceID, MoneyPerFlow)>,
     {
         for (commodity_id, region_id, time_slice, value) in iter {
             let row = CommodityBalanceDualsRow {
@@ -436,7 +436,7 @@ mod tests {
         time_slice: TimeSliceID,
     ) {
         let milestone_year = 2020;
-        let value = 0.5;
+        let value = MoneyPerFlow(0.5);
         let dir = tempdir().unwrap();
 
         // Write commodity balance dual
@@ -471,7 +471,7 @@ mod tests {
     #[rstest]
     fn test_write_activity_duals(assets: AssetPool, time_slice: TimeSliceID) {
         let milestone_year = 2020;
-        let value = 0.5;
+        let value = MoneyPerActivity(0.5);
         let dir = tempdir().unwrap();
         let asset = assets.iter().next().unwrap();
 

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -6,7 +6,7 @@ use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
-use crate::units::{Activity, Flow, MoneyPerActivity, UnitType};
+use crate::units::{Activity, Flow, MoneyPerActivity, MoneyPerFlow, UnitType};
 use anyhow::{anyhow, Result};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::IndexMap;
@@ -103,7 +103,7 @@ impl Solution<'_> {
     /// Keys and dual values for commodity balance constraints.
     pub fn iter_commodity_balance_duals(
         &self,
-    ) -> impl Iterator<Item = (&CommodityID, &RegionID, &TimeSliceID, f64)> {
+    ) -> impl Iterator<Item = (&CommodityID, &RegionID, &TimeSliceID, MoneyPerFlow)> {
         // Each commodity balance constraint applies to a particular time slice
         // selection (depending on time slice level). Where this covers multiple timeslices,
         // we return the same dual for each individual timeslice.
@@ -118,7 +118,9 @@ impl Solution<'_> {
     }
 
     /// Keys and dual values for activity constraints.
-    pub fn iter_activity_duals(&self) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, f64)> {
+    pub fn iter_activity_duals(
+        &self,
+    ) -> impl Iterator<Item = (&AssetRef, &TimeSliceID, MoneyPerActivity)> {
         self.constraint_keys
             .activity_keys
             .zip_duals(self.solution.dual_rows())

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -5,6 +5,7 @@ use crate::commodity::{CommodityID, CommodityType};
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceSelection};
+use crate::units::UnitType;
 use highs::RowProblem as Problem;
 use log::debug;
 
@@ -16,13 +17,18 @@ pub struct KeysWithOffset<T> {
 
 impl<T> KeysWithOffset<T> {
     /// Zip the keys with the corresponding dual values in the solution, accounting for the offset
-    pub fn zip_duals<'a>(&'a self, duals: &'a [f64]) -> impl Iterator<Item = (&'a T, f64)> {
+    pub fn zip_duals<'a, U>(&'a self, duals: &'a [f64]) -> impl Iterator<Item = (&'a T, U)>
+    where
+        U: UnitType,
+    {
         assert!(
             self.offset + self.keys.len() <= duals.len(),
             "Bad constraint keys: dual rows out of range"
         );
 
-        self.keys.iter().zip(duals[self.offset..].iter().copied())
+        self.keys
+            .iter()
+            .zip(duals[self.offset..].iter().copied().map(U::new))
     }
 }
 

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -58,10 +58,15 @@ impl CommodityPrices {
 
         // Add the highest activity dual for each commodity/region/timeslice to each commodity
         // balance dual
-        for (commodity_id, region_id, time_slice, dual) in solution.iter_commodity_balance_duals() {
+        for (commodity_id, region_id, time_slice, mut price) in
+            solution.iter_commodity_balance_duals()
+        {
             let key = (commodity_id.clone(), region_id.clone(), time_slice.clone());
-            let price = dual + highest_duals.get(&key).unwrap_or(&0.0);
-            self.0.insert(key, MoneyPerFlow(price));
+            if let Some(highest) = highest_duals.get(&key) {
+                // highest is in units of MoneyPerActivity, but this is correct according to Adam
+                price += MoneyPerFlow(highest.value());
+            }
+            self.0.insert(key, price);
         }
     }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,8 +1,43 @@
 //! This module defines various unit types and their conversions.
 
+use float_cmp::{ApproxEq, F64Margin};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::ops::{AddAssign, Mul, SubAssign};
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
+
+/// A trait encompassing most of the functionality of unit types
+pub trait UnitType:
+    fmt::Debug
+    + Copy
+    + PartialEq
+    + PartialOrd
+    + Serialize
+    + Add
+    + Sub
+    + Div
+    + Mul<Dimensionless, Output = Self>
+    + AddAssign
+    + SubAssign
+    + Sum
+    + ApproxEq<Margin = F64Margin>
+    + fmt::Display
+{
+    /// Create from an f64 value
+    fn new(value: f64) -> Self;
+    /// Returns the underlying f64 value.
+    fn value(&self) -> f64;
+    /// Returns true if the value is a normal number.
+    fn is_normal(&self) -> bool;
+    /// Returns true if the value is finite.
+    fn is_finite(&self) -> bool;
+    /// Returns the absolute value of this unit.
+    fn abs(&self) -> Self;
+    /// Returns the max of two values
+    fn max(&self, other: Self) -> Self;
+    /// Returns the min of two values
+    fn min(&self, other: Self) -> Self;
+}
 
 macro_rules! base_unit_struct {
     ($name:ident) => {
@@ -53,6 +88,10 @@ macro_rules! base_unit_struct {
             }
         }
         impl $name {
+            /// Create from an f64 value
+            pub fn new(value: f64) -> Self {
+                $name(value)
+            }
             /// Returns the underlying f64 value.
             pub fn value(&self) -> f64 {
                 self.0
@@ -76,6 +115,36 @@ macro_rules! base_unit_struct {
             /// Returns the min of two values
             pub fn min(&self, other: Self) -> Self {
                 Self(self.0.min(other.0))
+            }
+        }
+        impl UnitType for $name {
+            /// Create from an f64 value
+            fn new(value: f64) -> Self {
+                Self::new(value)
+            }
+            /// Returns the underlying f64 value.
+            fn value(&self) -> f64 {
+                self.value()
+            }
+            /// Returns true if the value is a normal number.
+            fn is_normal(&self) -> bool {
+                self.is_normal()
+            }
+            /// Returns true if the value is finite.
+            fn is_finite(&self) -> bool {
+                self.is_finite()
+            }
+            /// Returns the absolute value of this unit.
+            fn abs(&self) -> Self {
+                self.abs()
+            }
+            /// Returns the max of two values
+            fn max(&self, other: Self) -> Self {
+                self.max(other)
+            }
+            /// Returns the min of two values
+            fn min(&self, other: Self) -> Self {
+                self.min(other)
             }
         }
     };


### PR DESCRIPTION
# Description

I've changed the return types for various optimisation output values:

- Flows
- Reduced costs (== column duals)
- Activity duals
- Commodity balance duals

I was mostly interested in fixing the types of reduced costs to make #647 easier, but it seemed like a good idea to do the others while I was at it.

With the price calculation, there is one place where we add activity duals to commodity balance duals and so have to circumvent the units check, but Adam says the maths works out (see #663). I figure it's still better to have the correct unit types and have a comment saying why they don't match up in this one place than to just treat everything as a number everywhere. (Incidentally, we won't actually be using this calculation anyway in most cases in the near future anyway; see #677.)

Closes #660.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
