### PR TITLE
Get demand profile for SVD commodities

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -44,9 +44,7 @@ pub struct ModelFile {
     /// Don't change unless you know what you're doing.
     #[serde(default = "default_candidate_asset_capacity")]
     pub candidate_asset_capacity: Capacity,
-    /// If set to false, removes the effect of scarcity on commodity prices.
-    ///
-    /// Don't disable unless you know what you're doing.
+    /// Defines the strategy used for calculating commodity prices
     #[serde(default)]
     pub pricing_strategy: PricingStrategy,
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -64,3 +64,74 @@ pub fn get_demand_profile(
 
     map
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asset::{Asset, AssetRef};
+    use crate::commodity::CommodityID;
+    use crate::fixture::{asset, commodity_id, region_id, time_slice};
+    use crate::units::Flow;
+    use rstest::rstest;
+    use std::collections::HashMap;
+
+    #[rstest]
+    fn test_get_demand_profile(
+        commodity_id: CommodityID,
+        region_id: RegionID,
+        time_slice: TimeSliceID,
+        asset: Asset,
+    ) {
+        // Setup test commodities
+        let mut commodities = IndexSet::new();
+        commodities.insert(commodity_id.clone());
+
+        // Setup test asset and AssetRef
+        let asset_ref1 = AssetRef::from(asset.clone());
+        // Create a second asset with the same region, commodity, and time_slice
+        let mut asset2 = asset.clone();
+        asset2.id = None; // Ensure it's treated as a different asset
+        asset2.commission_year += 1; // Make it unique
+        let asset_ref2 = AssetRef::from(asset2);
+
+        let mut flow_map = FlowMap::new();
+        flow_map.insert(
+            (asset_ref1.clone(), commodity_id.clone(), time_slice.clone()),
+            Flow(10.0),
+        );
+        flow_map.insert(
+            (asset_ref2.clone(), commodity_id.clone(), time_slice.clone()),
+            Flow(7.0),
+        );
+        flow_map.insert(
+            (
+                asset_ref1.clone(),
+                CommodityID("C2".to_string().into()),
+                time_slice.clone(),
+            ),
+            Flow(5.0),
+        ); // Should be ignored
+        flow_map.insert(
+            (
+                asset_ref1.clone(),
+                commodity_id.clone(),
+                crate::time_slice::TimeSliceID {
+                    season: "summer".into(),
+                    time_of_day: "night".into(),
+                },
+            ),
+            Flow(0.0),
+        ); // Should be ignored
+
+        // Call get_demand_profile
+        let result = get_demand_profile(&commodities, &flow_map);
+
+        // Check result
+        let mut expected = HashMap::new();
+        expected.insert(
+            (commodity_id.clone(), region_id.clone(), time_slice.clone()),
+            Flow(17.0),
+        );
+        assert_eq!(result, expected);
+    }
+}

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -1,10 +1,16 @@
 //! Code for performing agent investment.
 use super::optimisation::FlowMap;
+use super::prices::ReducedCosts;
 use super::CommodityPrices;
 use crate::asset::AssetPool;
+use crate::commodity::{CommodityID, CommodityType};
 use crate::model::Model;
-use crate::simulation::prices::ReducedCosts;
+use crate::region::RegionID;
+use crate::time_slice::TimeSliceID;
+use crate::units::Flow;
+use indexmap::IndexSet;
 use log::info;
+use std::collections::HashMap;
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -16,8 +22,8 @@ use log::info;
 /// * `assets` - The asset pool
 /// * `year` - Current milestone year
 pub fn perform_agent_investment(
-    _model: &Model,
-    _flow_map: &FlowMap,
+    model: &Model,
+    flow_map: &FlowMap,
     _prices: &CommodityPrices,
     _reduced_costs: &ReducedCosts,
     _assets: &AssetPool,
@@ -25,6 +31,36 @@ pub fn perform_agent_investment(
 ) {
     info!("Performing agent investment...");
 
+    // We consider SVD commodities first
+    let commodities_of_interest = model
+        .commodities
+        .iter()
+        .filter(|(_, commodity)| commodity.kind == CommodityType::ServiceDemand)
+        .map(|(id, _)| id.clone())
+        .collect();
+    let _demand = get_demand_profile(&commodities_of_interest, flow_map);
+
     // **TODO:** Perform agent investment. For now, let's just leave the pool unmodified.
     // assets.replace_active_pool(new_pool);
+}
+
+/// Get demand per time slice for specified commodities
+pub fn get_demand_profile(
+    commodities: &IndexSet<CommodityID>,
+    flow_map: &FlowMap,
+) -> HashMap<(CommodityID, RegionID, TimeSliceID), Flow> {
+    let mut map = HashMap::new();
+    for ((asset, commodity_id, time_slice), &flow) in flow_map.iter() {
+        if commodities.contains(commodity_id) && flow > Flow(0.0) {
+            map.entry((
+                commodity_id.clone(),
+                asset.region_id.clone(),
+                time_slice.clone(),
+            ))
+            .and_modify(|value| *value += flow)
+            .or_insert(flow);
+        }
+    }
+
+    map
 }


### PR DESCRIPTION
# Description

I've got other bits of agent investment code that are on hold while we figure out #689, but I figure this is worth merging now, even if it's small.

This PR adds code to calculate the demand profile for commodities of interest. For now, this will just be the SVD commodities, but I've tried to write it in such a way that it'll be useful for subsequent rounds of agent investment looking at SED commodities.

Unrelated change: Fixed a doc comment re the pricing strategy.

Closes #645.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
