### PR TITLE
Fill agent search spaces for missing commodities/milestone years

### DIFF
--- a/src/input/agent.rs
+++ b/src/input/agent.rs
@@ -87,9 +87,7 @@ pub fn read_agents(
 
     for (id, agent) in agents.iter_mut() {
         agent.objectives = objectives.remove(id).unwrap();
-        if let Some(search_space) = search_spaces.remove(id) {
-            agent.search_space = search_space;
-        }
+        agent.search_space = search_spaces.remove(id).unwrap();
         if let Some(cost_limits) = cost_limits.remove(id) {
             agent.cost_limits = cost_limits;
         }


### PR DESCRIPTION
As we discussed, for missing entries in `agent_search_space.csv`, we should assume that agents are able to choose any process whose primary output is the commodity for which the agent is responsible.

I took your suggestion of filling missing entries in advance when we load the input data, rather than waiting until we need that info, as it seemed the cleanest way to do it.

Because the input format is a bit odd and technically currently allows users to have different primary outputs in different regions, we include any process which has the commodity as a primary output in at least one region for the given year. This is a bit weird, but will probably do until we do #666.