### PR TITLE
Small fixes for optimisation/investment

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 pub struct AssetID(u32);
 
 /// An asset controlled by an agent.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Asset {
     /// A unique identifier for the asset
     pub id: Option<AssetID>,
@@ -139,6 +139,19 @@ impl Asset {
     /// Iterate over the asset's flows
     pub fn iter_flows(&self) -> impl Iterator<Item = &ProcessFlow> {
         self.get_flows_map().values()
+    }
+}
+
+impl std::fmt::Debug for Asset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Asset")
+            .field("id", &self.id)
+            .field("agent_id", &self.agent_id)
+            .field("process", &self.process.id)
+            .field("region_id", &self.region_id)
+            .field("capacity", &self.capacity)
+            .field("commission_year", &self.commission_year)
+            .finish()
     }
 }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -206,7 +206,6 @@ impl PartialEq for AssetRef {
             self.0.id == other.0.id
         } else {
             other.0.id.is_none()
-                && self.0.agent_id == other.0.agent_id
                 && Rc::ptr_eq(&self.0.process, &other.0.process)
                 && self.0.region_id == other.0.region_id
                 && self.0.commission_year == other.0.commission_year
@@ -222,7 +221,6 @@ impl Hash for AssetRef {
         if let Some(id) = self.0.id {
             id.hash(state);
         } else {
-            self.0.agent_id.hash(state);
             self.0.process.id.hash(state);
             self.0.region_id.hash(state);
             self.0.commission_year.hash(state);

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -138,11 +138,10 @@ impl Solution<'_> {
         variable_idx: &Range<usize>,
         output: &'a [f64],
     ) -> impl Iterator<Item = (&'a AssetRef, &'a TimeSliceID, T)> {
-        assert!(variable_idx.end <= output.len());
-        self.variables
-            .0
-            .keys()
-            .zip(output[variable_idx.clone()].iter())
+        let keys = self.variables.0.keys().skip(variable_idx.start);
+        assert!(keys.len() >= variable_idx.len());
+
+        keys.zip(output[variable_idx.clone()].iter())
             .map(|((asset, time_slice), value)| (asset, time_slice, T::new(*value)))
     }
 }


### PR DESCRIPTION
# Description

A couple of small fixes:

1. `AssetRef`s shouldn't compare agent IDs for non-commissioned assets, as we want to match regardless of this field (e.g. getting reduced costs for a candidate asset)
2. The `Solution` object was returning the wrong variable keys for `iter_reduced_costs_for_candidates()`

I also added a terser implementation of `Debug` for `Asset` as the default one was a bit too verbose (e.g. it included all the fields of the `process`) and it made debugging hard.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
