### PR TITLE
Fix broken links to dispatch optimisation docs

### DIFF
--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -150,7 +150,7 @@ impl Solution<'_> {
 ///
 /// For a detailed description, please see the [dispatch optimisation formulation][1].
 ///
-/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html
+/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/model/dispatch_optimisation.html
 ///
 /// # Arguments
 ///

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -90,7 +90,7 @@ where
 ///
 /// See description in [the dispatch optimisation documentation][1].
 ///
-/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html#commodity-balance-for--cin-mathbfcmathrmsed-
+/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/model/dispatch_optimisation.html#commodity-balance-for--cin-mathbfcmathrmsed-
 fn add_commodity_balance_constraints<'a, I>(
     problem: &mut Problem,
     variables: &VariableMap,
@@ -174,7 +174,7 @@ where
 ///
 /// See description in [the dispatch optimisation documentation][1].
 ///
-/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/dispatch_optimisation.html#a4-constraints-capacity--availability-for-standard-assets--a-in-mathbfastd-
+/// [1]: https://energysystemsmodellinglab.github.io/MUSE_2.0/model/dispatch_optimisation.html#a4-constraints-capacity--availability-for-standard-assets--a-in-mathbfastd-
 fn add_activity_constraints(problem: &mut Problem, variables: &VariableMap) -> ActivityKeys {
     // Row offset in problem. This line **must** come before we add more constraints.
     let offset = problem.num_rows();


### PR DESCRIPTION
# Description

I moved the document into a subfolder and now a few links in doc comments no longer work, which is causing the link checker workflow to fail. Fix the links.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
