### PR TITLE
Refactor investment code to allow for supplying commodities of interest

### DIFF
--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -9,7 +9,6 @@ use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Capacity, Dimensionless, Flow, FlowPerCapacity};
 use anyhow::{ensure, Result};
-use indexmap::IndexSet;
 use itertools::chain;
 use log::{debug, info};
 use std::collections::HashMap;
@@ -44,16 +43,16 @@ pub fn perform_agent_investment(
     // Get all existing assets and clear pool
     let existing_assets = assets.take();
 
+    // Demand profile for commodities
+    let demand = get_demand_profile(flow_map);
+
     // We consider SVD commodities first
     let commodities_of_interest = model
         .commodities
         .iter()
         .filter(|(_, commodity)| commodity.kind == CommodityType::ServiceDemand)
-        .map(|(id, _)| id.clone())
-        .collect();
-    let demand = get_demand_profile(&commodities_of_interest, flow_map);
-
-    for commodity_id in commodities_of_interest.iter() {
+        .map(|(id, _)| id);
+    for commodity_id in commodities_of_interest {
         let commodity = &model.commodities[commodity_id];
         for (agent, commodity_portion) in
             get_responsible_agents(model.agents.values(), commodity_id, year)
@@ -108,11 +107,11 @@ pub fn perform_agent_investment(
     Ok(())
 }
 
-/// Get demand per time slice for specified commodities
-fn get_demand_profile(commodities: &IndexSet<CommodityID>, flow_map: &FlowMap) -> AllDemandMap {
+/// Get demand per time slice for every commodity
+fn get_demand_profile(flow_map: &FlowMap) -> AllDemandMap {
     let mut map = HashMap::new();
     for ((asset, commodity_id, time_slice), &flow) in flow_map.iter() {
-        if commodities.contains(commodity_id) && flow > Flow(0.0) {
+        if flow > Flow(0.0) {
             map.entry((
                 commodity_id.clone(),
                 asset.region_id.clone(),
@@ -415,10 +414,6 @@ mod tests {
         time_slice: TimeSliceID,
         asset: Asset,
     ) {
-        // Setup test commodities
-        let mut commodities = IndexSet::new();
-        commodities.insert(commodity_id.clone());
-
         // Setup test asset and AssetRef
         let asset_ref1 = AssetRef::from(asset.clone());
         // Create a second asset with the same region, commodity, and time_slice
@@ -439,14 +434,6 @@ mod tests {
         flow_map.insert(
             (
                 asset_ref1.clone(),
-                CommodityID("C2".to_string().into()),
-                time_slice.clone(),
-            ),
-            Flow(5.0),
-        ); // Should be ignored
-        flow_map.insert(
-            (
-                asset_ref1.clone(),
                 commodity_id.clone(),
                 TimeSliceID {
                     season: "summer".into(),
@@ -457,7 +444,7 @@ mod tests {
         ); // Should be ignored
 
         // Call get_demand_profile
-        let result = get_demand_profile(&commodities, &flow_map);
+        let result = get_demand_profile(&flow_map);
 
         // Check result
         let mut expected = HashMap::new();

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -3,7 +3,7 @@ use super::optimisation::FlowMap;
 use super::prices::ReducedCosts;
 use crate::agent::{Agent, ObjectiveType};
 use crate::asset::{Asset, AssetIterator, AssetPool, AssetRef};
-use crate::commodity::{Commodity, CommodityID, CommodityType};
+use crate::commodity::{Commodity, CommodityID};
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
@@ -47,14 +47,9 @@ pub fn perform_agent_investment(
     let demand = get_demand_profile(flow_map);
 
     // We consider SVD commodities first
-    let commodities_of_interest = model
-        .commodities
-        .iter()
-        .filter(|(_, commodity)| commodity.kind == CommodityType::ServiceDemand)
-        .map(|(id, _)| id);
-    for commodity_id in commodities_of_interest {
-        let commodity = &model.commodities[commodity_id];
-        for region_id in model.iter_regions() {
+    for region_id in model.iter_regions() {
+        for commodity_id in model.commodity_order[&(region_id.clone(), year)].iter() {
+            let commodity = &model.commodities[commodity_id];
             for (agent, commodity_portion) in
                 get_responsible_agents(model.agents.values(), commodity_id, region_id, year)
             {

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -139,7 +139,7 @@ fn get_demand_portion_for_commodity(
                 commodity_portion
                     * *demand
                         .get(&(commodity_id.clone(), region_id.clone(), time_slice.clone()))
-                        .unwrap(),
+                        .unwrap_or(&Flow(0.0)),
             )
         })
         .collect()


### PR DESCRIPTION
# Description

As discussed, here are the changes to make it easier to include your work on computing the commodities of interest.

There were two things that I noticed needed changing (but I might have missed something):

1. Change `get_demand_profile` to produce a demand profile for all commodities, not just the current COIs
2. Reorder the investment loop to iterate over regions before agents, which is closer to how things will be done once we have #650 

The way `get_demand_profile` currently works is to sum all positive flows for a given commodity, as supply==demand for both SVD and SED commodities (albeit for SVDs the demand is external), which will have odd consequences for commodities of type "other". That said, I don't think we care about OTH commodities for investment... right? I'm assuming it doesn't make any sense to have agents be responsible for a share of OTH commodity production (in which case, we should probably enforce this).

Closes #722.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
