### PR TITLE
Write objective values for dispatch optimisation to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "highs"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89be82a023915c2dd6664a94801abe38d10125d4b3d0c245a94c096fcfaf2f0"
+checksum = "122a64dffa53f13578cffd62fdf1cb2f83ac8a71a989dce5d9232049331fff28"
 dependencies = [
  "highs-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ fern = {version = "0.7.1", features = ["chrono", "colored"]}
 chrono = "0.4"
 clap = {version = "4.5.41", features = ["cargo", "derive"]}
 include_dir = "0.7.4"
-highs = "1.8.0"
+highs = "1.12.0"
 indexmap = "2.10.0"
 human-panic = "2.0.3"
 clap-markdown = "0.1.5"

--- a/src/output.rs
+++ b/src/output.rs
@@ -651,4 +651,35 @@ mod tests {
             .unwrap();
         assert_equal(records, iter::once(expected));
     }
+
+    #[rstest]
+    fn test_write_solver_values() {
+        let milestone_year = 2020;
+        let run_number = 42;
+        let objective_value = Money(1234.56);
+        let dir = tempdir().unwrap();
+
+        // Write solver values
+        {
+            let mut writer = DebugDataWriter::create(dir.path()).unwrap();
+            writer
+                .write_solver_values(milestone_year, run_number, objective_value)
+                .unwrap();
+            writer.flush().unwrap();
+        }
+
+        // Read back and compare
+        let expected = SolverValuesRow {
+            milestone_year,
+            run_number,
+            objective_value,
+        };
+        let records: Vec<SolverValuesRow> =
+            csv::Reader::from_path(dir.path().join(SOLVER_VALUES_FILE_NAME))
+                .unwrap()
+                .into_deserialize()
+                .try_collect()
+                .unwrap();
+        assert_equal(records, iter::once(expected));
+    }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -285,6 +285,7 @@ impl DebugDataWriter {
             objective_value,
         };
         self.solver_values_writer.serialize(row)?;
+        self.solver_values_writer.flush()?;
 
         Ok(())
     }

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 use highs::{RowProblem as Problem, Sense};
 use indexmap::IndexMap;
 use itertools::{chain, iproduct};
-use log::info;
+use log::debug;
 use std::ops::Range;
 
 mod constraints;
@@ -66,6 +66,8 @@ pub struct Solution<'a> {
     candidate_asset_var_idx: Range<usize>,
     time_slice_info: &'a TimeSliceInfo,
     constraint_keys: ConstraintKeys,
+    /// The objective value for the solution
+    pub objective_value: Money,
 }
 
 impl Solution<'_> {
@@ -227,7 +229,7 @@ fn perform_dispatch_optimisation_no_save<'a>(
         .map_err(|err| anyhow!("Could not solve: {err:?}"))?;
 
     let objective_value = Money(solution.objective_value());
-    info!("Objective value: {objective_value}");
+    debug!("Objective value: {objective_value}");
 
     Ok(Solution {
         solution: solution.get_solution(),
@@ -236,6 +238,7 @@ fn perform_dispatch_optimisation_no_save<'a>(
         candidate_asset_var_idx,
         time_slice_info: &model.time_slice_info,
         constraint_keys,
+        objective_value,
     })
 }
 

--- a/tests/data/simple/debug_solver.csv
+++ b/tests/data/simple/debug_solver.csv
@@ -1,0 +1,3 @@
+milestone_year,run_number,objective_value
+2020,0,4161.39238403039
+2020,1,4161.360353332642

--- a/tests/data/simple_mc/debug_solver.csv
+++ b/tests/data/simple_mc/debug_solver.csv
@@ -1,0 +1,3 @@
+milestone_year,run_number,objective_value
+2020,0,4161.39238403039
+2020,1,4161.360039666866


### PR DESCRIPTION
# Description

@ahawkes mentioned that it's useful to be able to see the objective value for a dispatch optimisation. Up until the latest release of the `highs` crate though, it was not possible to get the objective value from the solution, so we had a nasty hack where we enabled the HiGHS logger to dump many things, including the objective value, to the console. This is output not saved into the program log file and will only get harder to read as we add more dispatch optimisations per milestone year (#651).

I made an upstream PR and now we can get the objective value from the HiGHS solver. So I've turned off the logger and now write this value to an output file instead.

We could also potentially use the objective value to calculate profitability index/LCOX more quickly or cleanly, but that's for another PR.

Closes #428.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
