### PR TITLE
Fix: Need to check optimisation status is optimal

### DIFF
--- a/src/simulation/investment/appraisal/optimisation.rs
+++ b/src/simulation/investment/appraisal/optimisation.rs
@@ -6,9 +6,10 @@ use super::constraints::{
 use super::DemandMap;
 use crate::asset::AssetRef;
 use crate::commodity::Commodity;
+use crate::simulation::optimisation::solve_optimal;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Activity, Capacity, Flow};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use highs::{RowProblem as Problem, Sense};
 use indexmap::IndexMap;
 
@@ -120,11 +121,7 @@ pub fn perform_optimisation(
     );
 
     // Solve model
-    let solution = problem
-        .optimise(sense)
-        .try_solve()
-        .map_err(|status| anyhow!("Could not solve: {status:?}"))?
-        .get_solution();
+    let solution = solve_optimal(problem.optimise(sense))?.get_solution();
     let solution_values = solution.columns();
     Ok(ResultsMap {
         capacity: Capacity::new(solution_values[0]),


### PR DESCRIPTION
# Description

In both the places in the code where we run a HiGHS model, we're not handling errors properly. I assumed the `try_solve` method would return an error if the status was not optimal, but actually it only does so if the model is "not coherent". (I wasn't able to make a model that seemed to trigger this error, but let's assume that it can happen.) This makes sense because you might want to do something with the result of an LP problem even if the result is non-optimal.

Fix by adding a helper function -- `solve_optimal` -- which includes the proper check. I've stuck it in `src/simulation/optimisation.rs`, which may not be the best place for it, but other suggestions are welcome!

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
