### PR TITLE
Add helper macros for default param values

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -18,10 +18,17 @@ use std::path::{Path, PathBuf};
 
 const MODEL_FILE_NAME: &str = "model.toml";
 
-// Default parameter values
-const DEFAULT_CANDIDATE_ASSET_CAPACITY: Capacity = Capacity(0.0001);
-const DEFAULT_CAPACITY_LIMIT_FACTOR: Dimensionless = Dimensionless(0.1);
-const DEFAULT_VALUE_OF_LOST_LOAD: MoneyPerFlow = MoneyPerFlow(1e9);
+macro_rules! define_unit_param_default {
+    ($name:ident, $type: ty, $value: expr) => {
+        fn $name() -> $type {
+            <$type>::new($value)
+        }
+    };
+}
+
+define_unit_param_default!(default_candidate_asset_capacity, Capacity, 0.0001);
+define_unit_param_default!(default_capacity_limit_factor, Dimensionless, 0.1);
+define_unit_param_default!(default_value_of_lost_load, MoneyPerFlow, 1e9);
 
 /// Model definition
 pub struct Model {
@@ -79,18 +86,6 @@ pub enum PricingStrategy {
     /// Adjust shadow prices for scarcity
     #[string = "scarcity_adjusted"]
     ScarcityAdjusted,
-}
-
-const fn default_candidate_asset_capacity() -> Capacity {
-    DEFAULT_CANDIDATE_ASSET_CAPACITY
-}
-
-const fn default_capacity_limit_factor() -> Dimensionless {
-    DEFAULT_CAPACITY_LIMIT_FACTOR
-}
-
-const fn default_value_of_lost_load() -> MoneyPerFlow {
-    DEFAULT_VALUE_OF_LOST_LOAD
 }
 
 /// Check that the milestone years parameter is valid

--- a/src/model.rs
+++ b/src/model.rs
@@ -26,6 +26,15 @@ macro_rules! define_unit_param_default {
     };
 }
 
+#[allow(unused_macros)]
+macro_rules! define_param_default {
+    ($name:ident, $type: ty, $value: expr) => {
+        fn $name() -> $type {
+            $value
+        }
+    };
+}
+
 define_unit_param_default!(default_candidate_asset_capacity, Capacity, 0.0001);
 define_unit_param_default!(default_capacity_limit_factor, Dimensionless, 0.1);
 define_unit_param_default!(default_value_of_lost_load, MoneyPerFlow, 1e9);

--- a/src/model.rs
+++ b/src/model.rs
@@ -26,7 +26,6 @@ macro_rules! define_unit_param_default {
     };
 }
 
-#[allow(unused_macros)]
 macro_rules! define_param_default {
     ($name:ident, $type: ty, $value: expr) => {
         fn $name() -> $type {
@@ -38,6 +37,7 @@ macro_rules! define_param_default {
 define_unit_param_default!(default_candidate_asset_capacity, Capacity, 0.0001);
 define_unit_param_default!(default_capacity_limit_factor, Dimensionless, 0.1);
 define_unit_param_default!(default_value_of_lost_load, MoneyPerFlow, 1e9);
+define_param_default!(default_max_ironing_out_iterations, u32, 100);
 
 /// Model definition
 pub struct Model {
@@ -83,6 +83,9 @@ pub struct ModelFile {
     /// Currently this only applies to the LCOX appraisal.
     #[serde(default = "default_value_of_lost_load")]
     pub value_of_lost_load: MoneyPerFlow,
+    /// The maximum number of iterations to run the "ironing out" step of agent investment for
+    #[serde(default = "default_max_ironing_out_iterations")]
+    pub max_ironing_out_iterations: u32,
 }
 
 /// The strategy used for calculating commodity prices


### PR DESCRIPTION
# Description

I've added a couple of macros for defining the helper functions for getting model parameters' default values, because it seemed cleaner: one for unit types and one for regular numbers.

There weren't any params defined for regular numbers, so I added one that we need for #653.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
