### PR TITLE
Create `AssetState` enum

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -936,8 +936,8 @@ mod tests {
         asset_pool.extend(existing_assets.clone()).unwrap();
 
         assert_eq!(asset_pool.active.len(), 2);
-        assert_eq!(asset_pool.active[0].id(), Some(&AssetID(0)));
-        assert_eq!(asset_pool.active[1].id(), Some(&AssetID(1)));
+        assert_eq!(asset_pool.active[0].id(), Some(AssetID(0)));
+        assert_eq!(asset_pool.active[1].id(), Some(AssetID(1)));
     }
 
     #[rstest]
@@ -973,11 +973,8 @@ mod tests {
 
         assert_eq!(asset_pool.active.len(), original_count + 2);
         // New assets should get IDs 2 and 3
-        assert_eq!(asset_pool.active[original_count].id(), Some(&AssetID(2)));
-        assert_eq!(
-            asset_pool.active[original_count + 1].id(),
-            Some(&AssetID(3))
-        );
+        assert_eq!(asset_pool.active[original_count].id(), Some(AssetID(2)));
+        assert_eq!(asset_pool.active[original_count + 1].id(), Some(AssetID(3)));
         assert_eq!(
             asset_pool.active[original_count].agent_id(),
             Some(&"agent2".into())
@@ -1009,18 +1006,9 @@ mod tests {
 
         assert_eq!(asset_pool.active.len(), 3);
         // Check that we have the original assets plus the new one
-        assert!(asset_pool
-            .active
-            .iter()
-            .any(|a| a.id() == Some(&AssetID(0))));
-        assert!(asset_pool
-            .active
-            .iter()
-            .any(|a| a.id() == Some(&AssetID(1))));
-        assert!(asset_pool
-            .active
-            .iter()
-            .any(|a| a.id() == Some(&AssetID(2))));
+        assert!(asset_pool.active.iter().any(|a| a.id() == Some(AssetID(0))));
+        assert!(asset_pool.active.iter().any(|a| a.id() == Some(AssetID(1))));
+        assert!(asset_pool.active.iter().any(|a| a.id() == Some(AssetID(2))));
         // Check that the new asset has the correct agent
         assert!(asset_pool
             .active
@@ -1117,8 +1105,8 @@ mod tests {
 
         // next_id should have incremented for each new asset
         assert_eq!(asset_pool.next_id, 4);
-        assert_eq!(asset_pool.active[2].id(), Some(&AssetID(2)));
-        assert_eq!(asset_pool.active[3].id(), Some(&AssetID(3)));
+        assert_eq!(asset_pool.active[2].id(), Some(AssetID(2)));
+        assert_eq!(asset_pool.active[3].id(), Some(AssetID(3)));
     }
 
     #[rstest]
@@ -1215,7 +1203,7 @@ mod tests {
         .unwrap();
         asset1.commission_future(AssetID(1));
         assert!(asset1.is_commissioned());
-        assert_eq!(asset1.id(), Some(&AssetID(1)));
+        assert_eq!(asset1.id(), Some(AssetID(1)));
 
         // Test successful commissioning of Candidate asset
         let mut asset2 = Asset::new_candidate(
@@ -1228,7 +1216,7 @@ mod tests {
         .unwrap();
         asset2.commission_candidate(AssetID(2)).unwrap();
         assert!(asset2.is_commissioned());
-        assert_eq!(asset2.id(), Some(&AssetID(2)));
+        assert_eq!(asset2.id(), Some(AssetID(2)));
 
         // Test successful decommissioning
         asset1.decommission(2025);

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -943,7 +943,7 @@ mod tests {
         let original_count = asset_pool.active.len();
 
         // Extend with empty iterator
-        asset_pool.extend(Vec::<AssetRef>::new()).unwrap();
+        asset_pool.extend(Vec::<AssetRef>::new());
 
         assert_eq!(asset_pool.active.len(), original_count);
     }
@@ -956,7 +956,7 @@ mod tests {
         let existing_assets = asset_pool.take();
 
         // Extend with the same assets (should maintain their IDs)
-        asset_pool.extend(existing_assets.clone()).unwrap();
+        asset_pool.extend(existing_assets.clone());
 
         assert_eq!(asset_pool.active.len(), 2);
         assert_eq!(asset_pool.active[0].id(), Some(AssetID(0)));
@@ -992,7 +992,7 @@ mod tests {
             .into(),
         ];
 
-        asset_pool.extend(new_assets).unwrap();
+        asset_pool.extend(new_assets);
 
         assert_eq!(asset_pool.active.len(), original_count + 2);
         // New assets should get IDs 2 and 3
@@ -1025,7 +1025,7 @@ mod tests {
         .into();
 
         // Extend with just the new asset (not mixing with existing to avoid duplicates)
-        asset_pool.extend(vec![new_asset]).unwrap();
+        asset_pool.extend(vec![new_asset]);
 
         assert_eq!(asset_pool.active.len(), 3);
         // Check that we have the original assets plus the new one
@@ -1067,7 +1067,7 @@ mod tests {
             .into(),
         ];
 
-        asset_pool.extend(new_assets).unwrap();
+        asset_pool.extend(new_assets);
 
         // Check that assets are sorted by ID
         let ids: Vec<u32> = asset_pool
@@ -1085,7 +1085,7 @@ mod tests {
 
         // The extend method expects unique assets - adding duplicates would violate
         // the debug assertion, so this test verifies the normal case
-        asset_pool.extend(Vec::new()).unwrap();
+        asset_pool.extend(Vec::new());
 
         assert_eq!(asset_pool.active.len(), original_count);
         // Verify all assets are still unique (this is what the debug_assert checks)
@@ -1124,7 +1124,7 @@ mod tests {
             .into(),
         ];
 
-        asset_pool.extend(new_assets).unwrap();
+        asset_pool.extend(new_assets);
 
         // next_id should have incremented for each new asset
         assert_eq!(asset_pool.next_id, 4);

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -626,14 +626,15 @@ impl AssetPool {
     /// Extend the active pool with existing or candidate assets
     ///
     /// Returns the same assets after ID assignment.
-    pub fn extend(&mut self, mut assets: Vec<AssetRef>) -> Result<Vec<AssetRef>> {
+    pub fn extend(&mut self, mut assets: Vec<AssetRef>) -> Vec<AssetRef> {
         for asset in assets.iter_mut() {
             match &asset.state {
                 AssetState::Commissioned { .. } => {}
                 AssetState::Candidate { .. } => {
                     asset
                         .make_mut()
-                        .commission_candidate(AssetID(self.next_id))?;
+                        .commission_candidate(AssetID(self.next_id))
+                        .unwrap();
                     self.next_id += 1;
                 }
                 _ => {}
@@ -646,7 +647,7 @@ impl AssetPool {
 
         // Sanity check: all assets should be unique
         debug_assert_eq!(self.active.iter().unique().count(), self.active.len());
-        Ok(assets)
+        assets
     }
 }
 

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -103,9 +103,9 @@ pub fn get_svd_map(commodity: &Commodity) -> HashMap<CommodityID, &Commodity> {
 #[fixture]
 pub fn asset(process: Process) -> Asset {
     let region_id: RegionID = "GBR".into();
-    let agent_id = Some("agent1".into());
+    let agent_id = "agent1".into();
     let commission_year = 2015;
-    Asset::new(
+    Asset::new_future(
         agent_id,
         process.into(),
         region_id,

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -149,7 +149,7 @@ pub fn process(
     Process {
         id: "process1".into(),
         description: "Description".into(),
-        years: vec![2010, 2020],
+        years: (2010..=2020).collect(),
         activity_limits: ProcessActivityLimitsMap::new(),
         flows: ProcessFlowsMap::new(),
         parameters: process_parameter_map,

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -76,12 +76,12 @@ where
             .with_context(|| format!("Invalid process ID: {}", &asset.process_id))?;
         let region_id = region_ids.get_id(&asset.region_id)?;
 
-        Asset::new(
-            Some(agent_id.clone()),
+        Asset::new_future(
+            agent_id.clone(),
             Rc::clone(process),
             region_id.clone(),
-            asset.capacity,
             asset.commission_year,
+            asset.capacity,
         )
     })
     .try_collect()

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -80,8 +80,8 @@ where
             agent_id.clone(),
             Rc::clone(process),
             region_id.clone(),
-            asset.commission_year,
             asset.capacity,
+            asset.commission_year,
         )
     })
     .try_collect()
@@ -114,8 +114,8 @@ mod tests {
             capacity: Capacity(1.0),
             commission_year: 2010,
         };
-        let asset_out = Asset::new(
-            Some("agent1".into()),
+        let asset_out = Asset::new_future(
+            "agent1".into(),
             Rc::clone(processes.values().next().unwrap()),
             "GBR".into(),
             Capacity(1.0),

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -174,14 +174,12 @@ fn candidate_assets_for_year(
     {
         for region_id in process.regions.iter() {
             candidates.push(
-                Asset::new(
-                    None,
+                Asset::new_mock(
                     Rc::clone(process),
                     region_id.clone(),
-                    candidate_asset_capacity,
                     year,
+                    candidate_asset_capacity,
                 )
-                .unwrap()
                 .into(),
             );
         }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -123,7 +123,7 @@ fn run_dispatch_for_year(
     // Get candidate assets for next year, if any
     let candidates = next_year
         .map(|next_year| {
-            candidate_assets_for_year(
+            mock_candidate_assets_for_year(
                 &model.processes,
                 next_year,
                 model.parameters.candidate_asset_capacity,
@@ -161,8 +161,8 @@ fn run_dispatch_for_year(
     Ok((flow_map, prices, reduced_costs))
 }
 
-/// Get all candidate assets for a specified year
-fn candidate_assets_for_year(
+/// Create mock assets for all potential candidates in a specified year
+fn mock_candidate_assets_for_year(
     processes: &ProcessMap,
     year: u32,
     candidate_asset_capacity: Capacity,
@@ -180,6 +180,7 @@ fn candidate_assets_for_year(
                     year,
                     candidate_asset_capacity,
                 )
+                .unwrap()
                 .into(),
             );
         }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -308,7 +308,8 @@ fn get_candidate_assets<'a>(
                 region_id.clone(),
                 Capacity(0.0),
                 year,
-            );
+            )
+            .unwrap();
             asset.set_capacity(get_demand_limiting_capacity(
                 time_slice_info,
                 &asset,

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -306,8 +306,8 @@ fn get_candidate_assets<'a>(
                 agent.id.clone(),
                 process.clone(),
                 region_id.clone(),
-                year,
                 Capacity(0.0),
+                year,
             );
             asset.set_capacity(get_demand_limiting_capacity(
                 time_slice_info,

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -105,7 +105,7 @@ pub fn perform_agent_investment(
             }
 
             // Add assets to pool
-            new_assets = assets.extend(new_assets);
+            new_assets = assets.extend(new_assets)?;
 
             // Perform dispatch optimisation with assets that have been selected so far
             // **TODO**: presumably we only need to do this for new_assets, as assets added in

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -105,7 +105,7 @@ pub fn perform_agent_investment(
             }
 
             // Add assets to pool
-            new_assets = assets.extend(new_assets)?;
+            new_assets = assets.extend(new_assets);
 
             // Perform dispatch optimisation with assets that have been selected so far
             // **TODO**: presumably we only need to do this for new_assets, as assets added in

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -302,13 +302,13 @@ fn get_candidate_assets<'a>(
     agent
         .iter_possible_producers_of(region_id, &commodity.id, year)
         .map(move |process| {
-            let mut asset = Asset::new_without_capacity(
-                Some(agent.id.clone()),
+            let mut asset = Asset::new_candidate(
+                agent.id.clone(),
                 process.clone(),
                 region_id.clone(),
                 year,
-            )
-            .unwrap();
+                Capacity(0.0),
+            );
             asset.set_capacity(get_demand_limiting_capacity(
                 time_slice_info,
                 &asset,


### PR DESCRIPTION
This creates an `AssetState` enum which captures the state of the asset as it gets commissioned and decommissioned. All the fields that were once optional (`id`, `agent_id`, `decommission_year`) are now held in this enum within the appropriate states.

There are two pathways that an asset can follow in its life cycle:

`Future` -> `Commissioned` -> `Decommissioned`
`Candidate` -> `Commissioned` -> `Decommissioned`

The first pathway is for assets defined in the input data. The second pathway is for assets selected by the investment algorithm, which also determines the level of capacity.

The methods performing these transitions (`commission_future`, `commission_candidate` and `decommission`) have checks in place to ensure that they are only called on assets of the appropriate state

I've also added a `Mock` state which is for candidates in the dispatch. These are kinda similar to the `Candidate` state, but distinct in the sense that they're not allocated to an agent, and are not part of one of the lifecycles above (i.e. will never be commissioned directly) 