### PR TITLE
Fix: Only allow one concurrent deployment of Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,12 @@ permissions:
   pages: write
   id-token: write
 
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build docs


### PR DESCRIPTION
I'm seeing CI errors when I merge multiple PRs in quick succession. The problem appears to be that you can't have more than one GitHub Pages deployment in progress at a time. It seems you can fix this by disallowing concurrent runs of the workflow, which is what I've done.

See: https://github.com/orgs/community/discussions/60751