### PR TITLE
Fix levies so there's no error if they are missing

### DIFF
--- a/schemas/input/commodity_levies.yaml
+++ b/schemas/input/commodity_levies.yaml
@@ -4,7 +4,9 @@ description: |
 
 notes:
   - If an entry is included for a given combination of commodity and region, entries must be
-    provided covering all milestone years and time slices.
+    provided covering all milestone years and time slices. For those regions not explicitly included
+    for a given commodity, a zero levy/incentive is assumed. At least one levy/incentive entry must
+    be provided for at least one commodity.
 
 fields:
   - name: commodity_id

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -53,7 +53,7 @@ pub fn read_commodity_levies(
     milestone_years: &[u32],
 ) -> Result<HashMap<CommodityID, CommodityLevyMap>> {
     let file_path = model_dir.join(COMMODITY_LEVIES_FILE_NAME);
-    let commodity_levies_csv = read_csv_optional::<CommodityLevyRaw>(&file_path)?;
+    let commodity_levies_csv = read_csv::<CommodityLevyRaw>(&file_path)?;
     read_commodity_levies_iter(
         commodity_levies_csv,
         commodity_ids,

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -52,7 +52,7 @@ pub fn read_commodity_levies(
     milestone_years: &[u32],
 ) -> Result<HashMap<CommodityID, CommodityLevyMap>> {
     let file_path = model_dir.join(COMMODITY_LEVIES_FILE_NAME);
-    let commodity_levies_csv = read_csv::<CommodityLevyRaw>(&file_path)?;
+    let commodity_levies_csv = read_csv_optional::<CommodityLevyRaw>(&file_path)?;
     read_commodity_levies_iter(
         commodity_levies_csv,
         commodity_ids,

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -64,6 +64,19 @@ pub fn read_commodity_levies(
     .with_context(|| input_err_msg(&file_path))
 }
 
+/// Read costs associated with each commodity from an iterator over raw cost entries.
+///
+/// # Arguments
+///
+/// * `iter` - An iterator over raw commodity levy entries
+/// * `commodity_ids` - All possible commodity IDs
+/// * `region_ids` - All possible region IDs
+/// * `time_slice_info` - Information about time slices
+/// * `milestone_years` - All milestone years
+///
+/// # Returns
+///
+/// A map containing levies, grouped by commodity ID.
 fn read_commodity_levies_iter<I>(
     iter: I,
     commodity_ids: &IndexSet<CommodityID>,
@@ -135,6 +148,18 @@ where
     Ok(map)
 }
 
+/// Add missing region to commodity levy map with zero cost for all years and time slices.
+///
+/// # Arguments
+///
+/// * `map` - The commodity levy map to update
+/// * `region_id` - The region ID to add
+/// * `milestone_years` - All milestone years
+/// * `time_slice_info` - Information about time slices
+///
+/// # Returns
+///
+/// Nothing. The map is updated in place.
 fn add_missing_region_to_commodity_levy_map(
     map: &mut CommodityLevyMap,
     region_id: &RegionID,
@@ -154,6 +179,18 @@ fn add_missing_region_to_commodity_levy_map(
     }
 }
 
+/// Validate that the commodity levy map contains entries for all regions, years and time slices.
+///
+/// # Arguments
+///
+/// * `map` - The commodity levy map to validate
+/// * `regions` - The set of regions that should be covered
+/// * `milestone_years` - All milestone years
+/// * `time_slice_info` - Information about time slices
+///
+/// # Returns
+///
+/// Nothing if the map is valid. An error if the map is missing any entries.
 fn validate_commodity_levy_map(
     map: &CommodityLevyMap,
     regions: &IndexSet<RegionID>,

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -121,8 +121,7 @@ where
         validate_commodity_levy_map(map, regions, milestone_years, time_slice_info)
             .with_context(|| format!("Missing costs for commodity {commodity_id}"))?;
 
-        let difference: IndexSet<_> = region_ids.difference(regions).cloned().collect();
-        for region_id in difference.iter() {
+        for region_id in region_ids.difference(regions) {
             add_missing_region_to_commodity_levy_map(
                 map,
                 region_id,

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -284,10 +284,8 @@ mod tests {
         for time_slice in time_slice_info.iter_ids() {
             assert!(cost_map.contains_key(&(region_id.clone(), 2020, time_slice.clone())));
             assert_eq!(
-                cost_map
-                    .get(&(region_id.clone(), 2020, time_slice.clone()))
-                    .unwrap(),
-                &CommodityLevy {
+                cost_map[&(region_id.clone(), 2020, time_slice.clone())],
+                CommodityLevy {
                     balance_type: BalanceType::Net,
                     value: MoneyPerFlow(0.0)
                 }

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -121,7 +121,8 @@ where
         validate_commodity_levy_map(map, regions, milestone_years, time_slice_info)
             .with_context(|| format!("Missing costs for commodity {commodity_id}"))?;
 
-        for region_id in region_ids.difference(regions) {
+        let difference: IndexSet<_> = region_ids.difference(regions).cloned().collect();
+        for region_id in difference.iter() {
             add_missing_region_to_commodity_levy_map(
                 map,
                 region_id,
@@ -283,7 +284,9 @@ mod tests {
         for time_slice in time_slice_info.iter_ids() {
             assert!(cost_map.contains_key(&(region_id.clone(), 2020, time_slice.clone())));
             assert_eq!(
-                cost_map[&(region_id.clone(), 2020, time_slice.clone()))],
+                cost_map
+                    .get(&(region_id.clone(), 2020, time_slice.clone()))
+                    .unwrap(),
                 &CommodityLevy {
                     balance_type: BalanceType::Net,
                     value: MoneyPerFlow(0.0)

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -104,8 +104,11 @@ where
                 .insert(region.clone());
             for year in years.iter() {
                 for (time_slice, _) in ts_selection.iter(time_slice_info) {
-                    let key = (region.clone(), *year, time_slice.clone());
-                    map.insert(key, cost.clone());
+                    try_insert(
+                        map,
+                        (region.clone(), *year, time_slice.clone()),
+                        cost.clone(),
+                    )?;
                 }
             }
         }

--- a/src/input/commodity/levy.rs
+++ b/src/input/commodity/levy.rs
@@ -121,8 +121,7 @@ where
         validate_commodity_levy_map(map, regions, milestone_years, time_slice_info)
             .with_context(|| format!("Missing costs for commodity {commodity_id}"))?;
 
-        let difference: IndexSet<_> = region_ids.difference(regions).cloned().collect();
-        for region_id in difference.iter() {
+        for region_id in region_ids.difference(regions) {
             add_missing_region_to_commodity_levy_map(
                 map,
                 region_id,
@@ -284,9 +283,7 @@ mod tests {
         for time_slice in time_slice_info.iter_ids() {
             assert!(cost_map.contains_key(&(region_id.clone(), 2020, time_slice.clone())));
             assert_eq!(
-                cost_map
-                    .get(&(region_id.clone(), 2020, time_slice.clone()))
-                    .unwrap(),
+                cost_map[&(region_id.clone(), 2020, time_slice.clone()))],
                 &CommodityLevy {
                     balance_type: BalanceType::Net,
                     value: MoneyPerFlow(0.0)

--- a/src/process.rs
+++ b/src/process.rs
@@ -106,7 +106,8 @@ impl ProcessFlow {
         let levy = self
             .commodity
             .levies
-            [&(region_id.clone(), year, time_slice.clone())];
+            .get(&(region_id.clone(), year, time_slice.clone()))
+            .unwrap();
 
         let apply_levy = match levy.balance_type {
             BalanceType::Net => true,

--- a/src/process.rs
+++ b/src/process.rs
@@ -106,8 +106,7 @@ impl ProcessFlow {
         let levy = self
             .commodity
             .levies
-            .get(&(region_id.clone(), year, time_slice.clone()))
-            .unwrap();
+            [&(region_id.clone(), year, time_slice.clone())];
 
         let apply_levy = match levy.balance_type {
             BalanceType::Net => true,

--- a/src/process.rs
+++ b/src/process.rs
@@ -106,12 +106,8 @@ impl ProcessFlow {
         let levy = self
             .commodity
             .levies
-            .get(&(region_id.clone(), year, time_slice.clone()));
-
-        let levy = match levy {
-            Some(levy) => levy,
-            None => return MoneyPerFlow(0.0),
-        };
+            .get(&(region_id.clone(), year, time_slice.clone()))
+            .unwrap();
 
         let apply_levy = match levy.balance_type {
             BalanceType::Net => true,

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -298,7 +298,7 @@ fn reduced_costs_for_existing<'a>(
                 flow.coeff
                     * prices
                         .get(&flow.commodity.id, asset.region_id(), time_slice)
-                        .unwrap_or(MoneyPerFlow(0.0))
+                        .unwrap()
             })
             .sum();
         let reduced_cost = operating_cost - revenue_from_flows;


### PR DESCRIPTION
# Description

This PR aims to fix two issues that might appear in reasonable scenarios

1. Not having any levies at all.
2. Having levies for a commodity in a region but not in other regions.

At the moment, in these two scenarios things fail because of the problem described in [this comment](https://github.com/EnergySystemsModellingLab/MUSE_2.0/pull/778#issuecomment-3224294389). 

The approach has been to:

1. Allow having an empty levies file; and
2. Populate the levies with zeros in all the missing cases. This is done after validating the levies provided, if any, so they are complete - the have been provided for all years and timeslices, but not regions.

This approach might be overkilling in the sense that, most likely, this is going to be a huge vector of zeros, but it seems like the simplest approach if we want all the input data to be "complete" before getting into the simulation part. It is also similar to what is done with the search space. 

- [x] Add tests

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
