### PR TITLE
Warn about use of NPV rather than LCOX

### DIFF
--- a/schemas/input/agent_objectives.yaml
+++ b/schemas/input/agent_objectives.yaml
@@ -22,7 +22,7 @@ fields:
     enum: [lcox, npv]
     description: The type of objective
     notes: |
-      Must be `npv` (net present value) or `lcox` (levelised cost of X). Note that support for LCOX
+      Must be `npv` (net present value) or `lcox` (levelised cost of X). Note that support for NPV
       is experimental and may give bad results.
   - name: decision_weight
     type: number

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -91,15 +91,15 @@ where
             missing_years
         );
 
-        let lcox_years = milestone_years
+        let npv_years = milestone_years
             .iter()
             .copied()
-            .filter(|year| agent_objectives[year] == ObjectiveType::LevelisedCostOfX)
+            .filter(|year| agent_objectives[year] == ObjectiveType::NetPresentValue)
             .collect_vec();
-        if !lcox_years.is_empty() {
+        if !npv_years.is_empty() {
             warn!(
-                "Agent {agent_id} is using LCOX in years {lcox_years:?}. \
-                Support for LCOX is currently experimental and may give bad results."
+                "Agent {agent_id} is using NPV in years {npv_years:?}. \
+                Support for NPV is currently experimental and may give bad results."
             );
         }
     }


### PR DESCRIPTION
# Description

We've flipflopped on this a bit, but for a time we were planning to use NPV rather than LCOX for the example models, as we thought that there were problems with the LCOX implementation. I updated the docs and changed the code to issue a warning if the user chose the LCOX option. As it happened, it turned out that the LCOX implementation was basically fine and using NPV sometimes caused problems (e.g. a fatal error if used with the `simple` example: #716), so we switched the examples back to LCOX instead. There was some discussion about fixing NPV and reverting this change (#718) but we decided against it (at least in the short term).

This PR changes the documentation and the in-program warning about LCOX to warn about NPV instead, so that it's clear to users what they "should" be doing. Users can still try to use NPV if they want, but we should flag that it might not work.
