### PR TITLE
Fix non-deterministic rounding of appraisal results

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -560,7 +560,6 @@ mod tests {
     use indexmap::indexmap;
     use itertools::{assert_equal, Itertools};
     use rstest::rstest;
-    use std::collections::HashMap;
     use std::iter;
     use tempfile::tempdir;
 
@@ -817,7 +816,7 @@ mod tests {
             let appraisal = AppraisalOutput {
                 asset: asset.clone(),
                 capacity: Capacity(42.0),
-                unmet_demand: HashMap::new(),
+                unmet_demand: Default::default(),
                 metric: 3.14,
             };
             writer

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -10,6 +10,7 @@ use crate::region::RegionID;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Capacity, Dimensionless, Flow, FlowPerCapacity};
 use anyhow::{ensure, Result};
+use indexmap::IndexMap;
 use itertools::chain;
 use log::debug;
 use std::collections::HashMap;
@@ -18,10 +19,10 @@ pub mod appraisal;
 use appraisal::appraise_investment;
 
 /// A map of demand across time slices for a specific commodity and region
-type DemandMap = HashMap<TimeSliceID, Flow>;
+type DemandMap = IndexMap<TimeSliceID, Flow>;
 
 /// Demand for a given combination of commodity, region and time slice
-type AllDemandMap = HashMap<(CommodityID, RegionID, TimeSliceID), Flow>;
+type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -422,7 +423,7 @@ fn select_best_assets(
 }
 
 /// Check whether there is any remaining demand that is unmet in any time slice
-fn is_any_remaining_demand(demand: &HashMap<TimeSliceID, Flow>) -> bool {
+fn is_any_remaining_demand(demand: &DemandMap) -> bool {
     demand.values().any(|flow| *flow > Flow(0.0))
 }
 
@@ -481,9 +482,9 @@ mod tests {
         ActivityPerCapacity, Dimensionless, Flow, FlowPerActivity, MoneyPerActivity,
         MoneyPerCapacity, MoneyPerCapacityPerYear, MoneyPerFlow,
     };
+    use indexmap::indexmap;
     use itertools::Itertools;
     use rstest::rstest;
-    use std::collections::HashMap;
     use std::rc::Rc;
 
     /// Custom fixture for process parameters with non-zero capacity_to_activity
@@ -544,8 +545,7 @@ mod tests {
         let asset = asset(process);
 
         // Create demand map - demand of 10.0 for our time slice
-        let mut demand = HashMap::new();
-        demand.insert(time_slice.clone(), Flow(10.0));
+        let demand = indexmap! { time_slice.clone() => Flow(10.0)};
 
         // Call the function
         let result = get_demand_limiting_capacity(&time_slice_info, &asset, &commodity_rc, &demand);
@@ -609,9 +609,10 @@ mod tests {
         let asset = asset(process);
 
         // Create demand map with different demands for each time slice
-        let mut demand = HashMap::new();
-        demand.insert(time_slice1.clone(), Flow(4.0)); // Requires capacity of 4.0/2.0 = 2.0
-        demand.insert(time_slice2.clone(), Flow(3.0)); // Would require infinite capacity, but should be skipped
+        let demand = indexmap! {
+            time_slice1.clone() => Flow(4.0), // Requires capacity of 4.0/2.0 = 2.0
+            time_slice2.clone() => Flow(3.0), // Would require infinite capacity, but should be skipped
+        };
 
         // Call the function
         let result =


### PR DESCRIPTION
# Description

I've noticed that every time you run `tests/regenerate_all_data.sh`, the various `debug_appraisal_results.csv` files seem to change. The changes are all caused by small rounding errors in the appraisal results. They occur at random, so if you commit these changes then rerun the script, the files will change again.

This doesn't matter much, because the changes are all smaller than the tolerance we've specified, so tests will still pass. But it does mean that every time someone updates the regression test data, the `debug_appraisal_results.csv` files will also get changed for no particular reason, which is unnecessary churn.

The issue is ultimately caused by the fact that the maps representing demand are iterated over in a non-determinstic order because they are `HashMap`s. This can easily be fixed by switching to `IndexMap`s instead.

Longer term, I think we should move to using `Vec`s instead of maps (#706), but I didn't do that as it was a more invasive change and I suspect would conflict with other work in progress.

I didn't bother regenerating the `debug_appraisal_results.csv` files as they'll probably be updated soon anyway, but hopefully going forward there will be slightly less churn there (and soon we'll be removing most of them anyway: #783).

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
