### PR TITLE
Pin Rust toolchain version

### DIFF
--- a/.github/actions/generate-docs/action.yml
+++ b/.github/actions/generate-docs/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
     - name: Install just
       shell: bash
       run: cargo install just

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
       - run: cargo test --verbose
 
       - if: ${{ matrix.coverage }}

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -13,6 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
       - run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
           apt update
           apt install -y curl build-essential cmake libclang-16-dev
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
       - run: cargo build --release
       - name: Gather release files
         run: |

--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -1,0 +1,17 @@
+name: Update Rust toolchain
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: "0 0 * * mon"
+
+jobs:
+  update-rust-toolchain:
+    name: "Update rust-toolchain"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: update rust toolchain
+        uses: a-kenji/update-rust-toolchain@v1
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM alpine:3.21
+FROM ubuntu:25.04
+
+# Update list of packages and update base packages
+RUN apt update && apt upgrade -y
 
 # Install dependencies. We need a C++ toolchain to compile the highs crate.
-RUN apk add --no-cache cargo rust-src rustfmt cmake binutils make g++ clang19-libclang git mdbook
+RUN apt install -y rustup cmake build-essential libclang-20-dev git mdbook just curl
+
+# Install uv (required for some scripts + pre-commit)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.89.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.89.0"
+profile = "default"


### PR DESCRIPTION
# Description

It seems that you can pin a specific version of the Rust toolchain that you want to use (in a `rust-toolchain.toml`) and `rustup` will respect it. When you run `cargo` it'll download the requested toolchain if it's not installed and use that for building/linting/etc. your project. Kinda neat.

I think this would be useful for us for a few reasons:

- Sometimes new `clippy` warnings are introduced when the CI runner's toolchain is updated and so CI starts failing
- Developers may see confusing build failures if their toolchain is older than the latest `stable` one being used by the project

I've pinned it to the latest stable toolchain (v1.89.0) for now and I've added a GitHub workflow which purports to be able to automatically bump this when a new version is released. Let's see how well it works in practice.

I've updated the `Dockerfile` to use `rustup` too so that it'll work with devcontainers (actually, the current image was failing because the toolchain was too out of date).

Closes #813.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
