### PR TITLE
Don't load `settings.toml` in tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,7 @@ impl Commands {
                 model_dir,
                 output_dir,
                 debug_model,
-            } => handle_run_command(&model_dir, output_dir.as_deref(), debug_model),
+            } => handle_run_command(&model_dir, output_dir.as_deref(), debug_model, None),
             Self::Example { subcommand } => subcommand.execute(),
         }
     }
@@ -84,9 +84,14 @@ pub fn handle_run_command(
     model_path: &Path,
     output_path: Option<&Path>,
     debug_model: bool,
+    settings: Option<Settings>,
 ) -> Result<()> {
-    // Load program settings
-    let mut settings = Settings::load().context("Failed to load settings.")?;
+    // Load program settings, if not provided
+    let mut settings = if let Some(settings) = settings {
+        settings
+    } else {
+        Settings::load().context("Failed to load settings.")?
+    };
 
     // This setting can be overridden by command-line argument
     if debug_model {

--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -1,5 +1,6 @@
 //! Code related to the example models and the CLI commands for interacting with them.
 use super::handle_run_command;
+use crate::settings::Settings;
 use anyhow::{Context, Result, ensure};
 use clap::Subcommand;
 use include_dir::{Dir, DirEntry, include_dir};
@@ -54,7 +55,7 @@ impl ExampleSubcommands {
                 name,
                 output_dir,
                 debug_model,
-            } => handle_example_run_command(&name, output_dir.as_deref(), debug_model)?,
+            } => handle_example_run_command(&name, output_dir.as_deref(), debug_model, None)?,
         }
 
         Ok(())
@@ -120,9 +121,10 @@ pub fn handle_example_run_command(
     name: &str,
     output_path: Option<&Path>,
     debug_model: bool,
+    settings: Option<Settings>,
 ) -> Result<()> {
     let temp_dir = TempDir::new().context("Failed to create temporary directory.")?;
     let model_path = temp_dir.path().join(name);
     extract_example(name, &model_path)?;
-    handle_run_command(&model_path, output_path, debug_model)
+    handle_run_command(&model_path, output_path, debug_model, settings)
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -2,6 +2,7 @@
 use float_cmp::approx_eq;
 use itertools::Itertools;
 use muse2::cli::example::handle_example_run_command;
+use muse2::settings::Settings;
 use std::fs::{File, read_dir};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -29,7 +30,13 @@ fn run_regression_test_debug_opt(example_name: &str, debug_model: bool) {
 
     let tempdir = tempdir().unwrap();
     let output_dir = tempdir.path();
-    handle_example_run_command(example_name, Some(output_dir), debug_model).unwrap();
+    handle_example_run_command(
+        example_name,
+        Some(output_dir),
+        debug_model,
+        Some(Settings::default()),
+    )
+    .unwrap();
 
     let test_data_dir = PathBuf::from(format!("tests/data/{example_name}"));
     compare_output_dirs(output_dir, &test_data_dir);

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `run` command.
 use muse2::cli::handle_run_command;
 use muse2::log::is_logger_initialised;
+use muse2::settings::Settings;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -21,7 +22,13 @@ fn test_handle_run_command() {
     // Save results to non-existent directory to check that directory creation works
     let tempdir = tempdir().unwrap();
     let output_dir = tempdir.path().join("results");
-    handle_run_command(&get_model_dir(), Some(&output_dir), false).unwrap();
+    handle_run_command(
+        &get_model_dir(),
+        Some(&output_dir),
+        false,
+        Some(Settings::default()),
+    )
+    .unwrap();
 
     assert!(is_logger_initialised());
 }


### PR DESCRIPTION
# Description

If the `debug_model` setting is set to `true` in the user's `settings.toml` file, then the regression tests will fail. The tests should not depend on user settings. Fix by changing a couple of functions to accept an optional `Settings` struct, to allow tests to provide their own settings.

It's a little ugly, but I couldn't think of a nicer way to do it.

Fixes #814.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
