### PR TITLE
Replace `get` + `unwrap` with square brackets where possible

### DIFF
--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -109,10 +109,7 @@ mod tests {
         let mut map = DemandMap::new();
         map.insert(("North".into(), 2020, ts_selection.clone()), value);
 
-        assert_eq!(
-            map.get(&("North".into(), 2020, ts_selection)).unwrap(),
-            &value
-        )
+        assert_eq!(map[&("North".into(), 2020, ts_selection)], value)
     }
 
     #[test]
@@ -130,6 +127,6 @@ mod tests {
             map.insert(("GBR".into(), 2010, ts.clone()), value.clone())
                 .is_none()
         );
-        assert_eq!(map.get(&("GBR".into(), 2010, ts)).unwrap(), &value);
+        assert_eq!(map[&("GBR".into(), 2010, ts)], value);
     }
 }

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -40,7 +40,7 @@ pub fn profitability_index(
     // Calculate the total annualised surplus
     let mut total_annualised_surplus = Money(0.0);
     for (time_slice, activity) in activity.iter() {
-        let activity_surplus = *activity_surpluses.get(time_slice).unwrap();
+        let activity_surplus = activity_surpluses[time_slice];
         total_annualised_surplus += activity_surplus * *activity;
     }
 
@@ -61,7 +61,7 @@ pub fn lcox(
     let mut total_activity_costs = Money(0.0);
     let mut total_activity = Activity(0.0);
     for (time_slice, activity) in activity.iter() {
-        let activity_cost = *activity_costs.get(time_slice).unwrap();
+        let activity_cost = activity_costs[time_slice];
         total_activity += *activity;
         total_activity_costs += activity_cost * *activity;
     }

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -197,7 +197,7 @@ fn compute_demand_maps(
             );
 
             // NB: This has already been checked, so shouldn't fail
-            let demand_fraction = slices.get(&slice_key).unwrap();
+            let demand_fraction = slices[&slice_key];
 
             // Get or create entry
             let map = map
@@ -207,7 +207,7 @@ fn compute_demand_maps(
             // Add a new demand entry
             map.insert(
                 (region_id.clone(), *year, ts_selection.clone()),
-                *annual_demand * *demand_fraction,
+                *annual_demand * demand_fraction,
             );
         }
     }

--- a/src/simulation/investment/appraisal/constraints.rs
+++ b/src/simulation/investment/appraisal/constraints.rs
@@ -113,10 +113,10 @@ pub fn add_demand_constraints(
         let mut demand_for_ts_selection = Flow(0.0);
         let mut terms = Vec::new();
         for (time_slice, _) in ts_selection.iter(time_slice_info) {
-            demand_for_ts_selection += *demand.get(time_slice).unwrap();
+            demand_for_ts_selection += demand[time_slice];
             let flow_coeff = asset.get_flow(&commodity.id).unwrap().coeff;
-            terms.push((*activity_vars.get(time_slice).unwrap(), flow_coeff.value()));
-            terms.push((*unmet_demand_vars.get(time_slice).unwrap(), 1.0));
+            terms.push((activity_vars[time_slice], flow_coeff.value()));
+            terms.push((unmet_demand_vars[time_slice], 1.0));
         }
         problem.add_row(
             demand_for_ts_selection.value()..=demand_for_ts_selection.value(),

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -105,7 +105,7 @@ impl TimeSliceSelection {
             Self::Season(season) => {
                 Box::new(ts_info.iter().filter(move |(ts, _)| ts.season == *season))
             }
-            Self::Single(ts) => Box::new(iter::once((ts, *ts_info.time_slices.get(ts).unwrap()))),
+            Self::Single(ts) => Box::new(iter::once((ts, ts_info.time_slices[ts]))),
         }
     }
 
@@ -146,10 +146,9 @@ impl TimeSliceSelection {
                 ),
             },
             Self::Season(season) => match level {
-                TimeSliceLevel::Season => Box::new(iter::once((
-                    self.clone(),
-                    *ts_info.seasons.get(season).unwrap(),
-                ))),
+                TimeSliceLevel::Season => {
+                    Box::new(iter::once((self.clone(), ts_info.seasons[season])))
+                }
                 TimeSliceLevel::DayNight => Box::new(
                     ts_info
                         .time_slices
@@ -161,7 +160,7 @@ impl TimeSliceSelection {
             },
             Self::Single(time_slice) => Box::new(iter::once((
                 time_slice.clone().into(),
-                *ts_info.time_slices.get(time_slice).unwrap(),
+                ts_info.time_slices[time_slice],
             ))),
         };
 


### PR DESCRIPTION
# Description

This is just a small cleanup. It turns out you can use square brackets to get items from a map rather than having to use the `get` method, which makes things a bit cleaner, so I've done a find and replace.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
