### PR TITLE
Fix workflow to auto-update Rust toolchain version

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -14,4 +14,5 @@ jobs:
       - name: update rust toolchain
         uses: a-kenji/update-rust-toolchain@v1
         with:
+          toolchain-path: ./rust-toolchain.toml
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# Description

It seems that for the `update-rust-toolchain` workflow, you need to specify the `toolchain-path` input if you're using a `rust-toolchain.toml` file, which isn't well documented. I noticed because v1.90 was released last week and we didn't get a PR for it.

I tested it locally with [`act`](https://github.com/nektos/act) and it seemed to notice the new version, at least.

(For context, I pinned the Rust toolchain in #824.)

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
