### PR TITLE
Fix: Don't sort file format tables by path

### DIFF
--- a/docs/file_formats/format_docs/csv.py
+++ b/docs/file_formats/format_docs/csv.py
@@ -39,7 +39,7 @@ def _load_sections(
         paths: list[str] = []
         for pattern in patterns:
             paths.extend(map(str, schema_dir.glob(f"{pattern}.yaml")))
-        files = (load_file(Path(path)) for path in sorted(paths))
+        files = (load_file(Path(path)) for path in paths)
         yield Section(title, files)
 
 


### PR DESCRIPTION
# Description

The ordering should be determined by the `file_order` argument passed into `generate_for_csv`, but we're later sorting the entries by path, which will cause the tables to be ordered differently. Remove the sorting.

Fixes #842.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
