### PR TITLE
Cap error messages

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -163,14 +163,15 @@ where
 }
 
 /// Format a list of items with a cap on display count for error messages
-pub fn format_items_with_cap<T: std::fmt::Debug>(items: &[T], max_display: usize) -> String {
-    if items.len() <= max_display {
+pub fn format_items_with_cap<T: std::fmt::Debug>(items: &[T]) -> String {
+    const MAX_DISPLAY: usize = 10;
+    if items.len() <= MAX_DISPLAY {
         format!("{items:?}")
     } else {
         format!(
             "{:?} and {} more",
-            &items[..max_display],
-            items.len() - max_display
+            &items[..MAX_DISPLAY],
+            items.len() - MAX_DISPLAY
         )
     }
 }
@@ -390,7 +391,13 @@ mod tests {
     #[test]
     fn test_format_items_with_cap() {
         let items = vec!["a", "b", "c"];
-        assert_eq!(format_items_with_cap(&items, 10), r#"["a", "b", "c"]"#);
-        assert_eq!(format_items_with_cap(&items, 2), r#"["a", "b"] and 1 more"#);
+        assert_eq!(format_items_with_cap(&items), r#"["a", "b", "c"]"#);
+
+        // Test with more than 10 items to trigger the cap
+        let many_items = vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+        assert_eq!(
+            format_items_with_cap(&many_items),
+            r#"["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"] and 2 more"#
+        );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -162,6 +162,19 @@ where
     Ok(())
 }
 
+/// Format a list of items with a cap on display count for error messages
+pub fn format_items_with_cap<T: std::fmt::Debug>(items: &[T], max_display: usize) -> String {
+    if items.len() <= max_display {
+        format!("{items:?}")
+    } else {
+        format!(
+            "{:?} and {} more",
+            &items[..max_display],
+            items.len() - max_display
+        )
+    }
+}
+
 /// Read a model from the specified directory.
 ///
 /// # Arguments

--- a/src/input.rs
+++ b/src/input.rs
@@ -386,4 +386,11 @@ mod tests {
     fn test_is_sorted_and_unique(#[case] values: &[u32], #[case] expected: bool) {
         assert_eq!(is_sorted_and_unique(values), expected)
     }
+
+    #[test]
+    fn test_format_items_with_cap() {
+        let items = vec!["a", "b", "c"];
+        assert_eq!(format_items_with_cap(&items, 10), r#"["a", "b", "c"]"#);
+        assert_eq!(format_items_with_cap(&items, 2), r#"["a", "b"] and 1 more"#);
+    }
 }

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -1,6 +1,6 @@
 //! Code for working with demand for a given commodity. Demand can vary by region, year and time
 //! slice.
-use super::super::{input_err_msg, read_csv};
+use super::super::{format_items_with_cap, input_err_msg, read_csv};
 use super::demand_slicing::{DemandSliceMap, read_demand_slices};
 use crate::commodity::{Commodity, CommodityID, CommodityType, DemandMap};
 use crate::id::IDCollection;
@@ -162,7 +162,8 @@ where
         }
         ensure!(
             missing_keys.is_empty(),
-            "Commodity {commodity_id} is missing demand data for {missing_keys:?}"
+            "Commodity {commodity_id} is missing demand data for {}",
+            format_items_with_cap(&missing_keys, 10)
         );
     }
 

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -163,7 +163,7 @@ where
         ensure!(
             missing_keys.is_empty(),
             "Commodity {commodity_id} is missing demand data for {}",
-            format_items_with_cap(&missing_keys, 10)
+            format_items_with_cap(&missing_keys)
         );
     }
 

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -173,7 +173,7 @@ fn validate_activity_limits_maps(
         ensure!(
             missing_keys.is_empty(),
             "Process {process_id} is missing availabilities for the following regions, years and timeslice: {}",
-            format_items_with_cap(&missing_keys, 10)
+            format_items_with_cap(&missing_keys)
         );
     }
 

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -1,5 +1,5 @@
 //! Code for reading process availabilities CSV file
-use super::super::{input_err_msg, read_csv, try_insert};
+use super::super::{format_items_with_cap, input_err_msg, read_csv, try_insert};
 use crate::process::{ProcessActivityLimitsMap, ProcessID, ProcessMap};
 use crate::region::parse_region_str;
 use crate::time_slice::TimeSliceInfo;
@@ -172,7 +172,8 @@ fn validate_activity_limits_maps(
         }
         ensure!(
             missing_keys.is_empty(),
-            "Process {process_id} is missing availabilities for the following regions, years and timeslice: {missing_keys:?}"
+            "Process {process_id} is missing availabilities for the following regions, years and timeslice: {}",
+            format_items_with_cap(&missing_keys, 10)
         );
     }
 

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -1,5 +1,5 @@
 //! Code for reading process parameters CSV file
-use super::super::{input_err_msg, read_csv, try_insert};
+use super::super::{format_items_with_cap, input_err_msg, read_csv, try_insert};
 use crate::process::{ProcessID, ProcessMap, ProcessParameter, ProcessParameterMap};
 use crate::region::parse_region_str;
 use crate::units::{
@@ -180,7 +180,8 @@ fn check_process_parameters(
         }
         ensure!(
             missing_keys.is_empty(),
-            "Process {process_id} is missing parameters for the following regions and years: {missing_keys:?}"
+            "Process {process_id} is missing parameters for the following regions and years: {}",
+            format_items_with_cap(&missing_keys, 10)
         );
     }
 

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -181,7 +181,7 @@ fn check_process_parameters(
         ensure!(
             missing_keys.is_empty(),
             "Process {process_id} is missing parameters for the following regions and years: {}",
-            format_items_with_cap(&missing_keys, 10)
+            format_items_with_cap(&missing_keys)
         );
     }
 


### PR DESCRIPTION
# Description

Some of the error messages displaying missing keys could end up being extremely long if there's lots of missing data, so I've introduced a cap of 10 items to prevent messages getting too long. If there are more than 10 missing items it will print the first 10, followed by "...and x more"

I haven't made the cap configurable as it seems a bit niche to want to change this, but can do if you think it would be useful

Hopefully this is all the places where this could be a problem (I didn't look through every single error message in the code, just did a search for "missing_keys")

Fixes #852 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
