### PR TITLE
Tidy model params code and add missing validation checks

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,7 @@
 use crate::asset::AssetPool;
 use crate::graph::build_and_validate_commodity_graphs_for_model;
 use crate::id::{HasID, IDLike};
-use crate::model::{Model, ModelFile};
+use crate::model::{Model, ModelParameters};
 use crate::units::UnitType;
 use anyhow::{Context, Result, bail, ensure};
 use float_cmp::approx_eq;
@@ -172,12 +172,12 @@ where
 ///
 /// The static model data ([`Model`]) and an [`AssetPool`] struct or an error.
 pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
-    let model_file = ModelFile::from_path(&model_dir)?;
+    let model_params = ModelParameters::from_path(&model_dir)?;
 
     let time_slice_info = read_time_slice_info(model_dir.as_ref())?;
     let regions = read_regions(model_dir.as_ref())?;
     let region_ids = regions.keys().cloned().collect();
-    let years = &model_file.milestone_years;
+    let years = &model_params.milestone_years;
 
     let commodities = read_commodities(model_dir.as_ref(), &region_ids, &time_slice_info, years)?;
     let processes = read_processes(
@@ -213,7 +213,7 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<(Model, AssetPool)> {
         .context("Could not parse path to model")?;
     let model = Model {
         model_path,
-        parameters: model_file,
+        parameters: model_params,
         agents,
         commodities,
         processes,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,44 +1,14 @@
 //! The model represents the static input data provided by the user.
 use crate::agent::AgentMap;
-use crate::asset::check_capacity_valid_for_asset;
 use crate::commodity::{CommodityID, CommodityMap};
-use crate::input::{
-    deserialise_proportion_nonzero, input_err_msg, is_sorted_and_unique, read_toml,
-};
 use crate::process::ProcessMap;
 use crate::region::{RegionID, RegionMap};
 use crate::time_slice::TimeSliceInfo;
-use crate::units::{Capacity, Dimensionless, MoneyPerFlow};
-use anyhow::{Context, Result, ensure};
-use log::warn;
-use serde::Deserialize;
-use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-const MODEL_PARAMETERS_FILE_NAME: &str = "model.toml";
-
-macro_rules! define_unit_param_default {
-    ($name:ident, $type: ty, $value: expr) => {
-        fn $name() -> $type {
-            <$type>::new($value)
-        }
-    };
-}
-
-macro_rules! define_param_default {
-    ($name:ident, $type: ty, $value: expr) => {
-        fn $name() -> $type {
-            $value
-        }
-    };
-}
-
-define_unit_param_default!(default_candidate_asset_capacity, Capacity, 0.0001);
-define_unit_param_default!(default_capacity_limit_factor, Dimensionless, 0.1);
-define_unit_param_default!(default_value_of_lost_load, MoneyPerFlow, 1e9);
-define_unit_param_default!(default_price_tolerance, Dimensionless, 1e-6);
-define_param_default!(default_max_ironing_out_iterations, u32, 10);
+pub mod parameters;
+pub use parameters::{ModelParameters, PricingStrategy};
 
 /// Model definition
 pub struct Model {
@@ -60,105 +30,6 @@ pub struct Model {
     pub commodity_order: HashMap<(RegionID, u32), Vec<CommodityID>>,
 }
 
-/// Represents the contents of the entire model file.
-#[derive(Debug, Deserialize, PartialEq)]
-pub struct ModelParameters {
-    /// Milestone years
-    pub milestone_years: Vec<u32>,
-    /// The (small) value of capacity given to candidate assets.
-    ///
-    /// Don't change unless you know what you're doing.
-    #[serde(default = "default_candidate_asset_capacity")]
-    pub candidate_asset_capacity: Capacity,
-    /// Defines the strategy used for calculating commodity prices
-    #[serde(default)]
-    pub pricing_strategy: PricingStrategy,
-    /// Affects the maximum capacity that can be given to a newly created asset.
-    ///
-    /// It is the proportion of maximum capacity that could be required across time slices.
-    #[serde(default = "default_capacity_limit_factor")]
-    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
-    pub capacity_limit_factor: Dimensionless,
-    /// The cost applied to unmet demand.
-    ///
-    /// Currently this only applies to the LCOX appraisal.
-    #[serde(default = "default_value_of_lost_load")]
-    pub value_of_lost_load: MoneyPerFlow,
-    /// The maximum number of iterations to run the "ironing out" step of agent investment for
-    #[serde(default = "default_max_ironing_out_iterations")]
-    pub max_ironing_out_iterations: u32,
-    /// The relative tolerance for price convergence in the ironing out loop
-    #[serde(default = "default_price_tolerance")]
-    pub price_tolerance: Dimensionless,
-}
-
-/// The strategy used for calculating commodity prices
-#[derive(DeserializeLabeledStringEnum, Debug, PartialEq, Default)]
-pub enum PricingStrategy {
-    /// Take commodity prices directly from the shadow prices
-    #[default]
-    #[string = "shadow_prices"]
-    ShadowPrices,
-    /// Adjust shadow prices for scarcity
-    #[string = "scarcity_adjusted"]
-    ScarcityAdjusted,
-}
-
-/// Check that the milestone years parameter is valid
-///
-/// # Arguments
-///
-/// * `years` - Integer list of milestone years
-///
-/// # Returns
-///
-/// An error if the milestone years are invalid
-fn check_milestone_years(years: &[u32]) -> Result<()> {
-    ensure!(!years.is_empty(), "`milestone_years` is empty");
-
-    ensure!(
-        is_sorted_and_unique(years),
-        "`milestone_years` must be composed of unique values in order"
-    );
-
-    Ok(())
-}
-
-impl ModelParameters {
-    /// Read a model file from the specified directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `model_dir` - Folder containing model configuration files
-    ///
-    /// # Returns
-    ///
-    /// The model file contents as a [`ModelParameters`] struct or an error if the file is invalid
-    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelParameters> {
-        let file_path = model_dir.as_ref().join(MODEL_PARAMETERS_FILE_NAME);
-        let model_params: ModelParameters = read_toml(&file_path)?;
-
-        if model_params.pricing_strategy == PricingStrategy::ScarcityAdjusted {
-            warn!(
-                "The pricing strategy is set to 'scarcity_adjusted'. Commodity prices may be \
-                incorrect if assets have more than one output commodity. See: {}/issues/677",
-                env!("CARGO_PKG_REPOSITORY")
-            );
-        }
-
-        let validate = || -> Result<()> {
-            check_milestone_years(&model_params.milestone_years)?;
-            check_capacity_valid_for_asset(model_params.candidate_asset_capacity)
-                .context("Invalid value for candidate_asset_capacity")?;
-
-            Ok(())
-        };
-        validate().with_context(|| input_err_msg(file_path))?;
-
-        Ok(model_params)
-    }
-}
-
 impl Model {
     /// Iterate over the model's milestone years.
     pub fn iter_years(&self) -> impl Iterator<Item = u32> + '_ {
@@ -168,37 +39,5 @@ impl Model {
     /// Iterate over the model's regions (region IDs).
     pub fn iter_regions(&self) -> impl Iterator<Item = &RegionID> + '_ {
         self.regions.keys()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::tempdir;
-
-    #[test]
-    fn test_check_milestone_years() {
-        // Valid
-        assert!(check_milestone_years(&[1]).is_ok());
-        assert!(check_milestone_years(&[1, 2]).is_ok());
-
-        // Invalid
-        assert!(check_milestone_years(&[]).is_err());
-        assert!(check_milestone_years(&[1, 1]).is_err());
-        assert!(check_milestone_years(&[2, 1]).is_err());
-    }
-
-    #[test]
-    fn test_model_params_from_path() {
-        let dir = tempdir().unwrap();
-        {
-            let mut file = File::create(dir.path().join(MODEL_PARAMETERS_FILE_NAME)).unwrap();
-            writeln!(file, "milestone_years = [2020, 2100]").unwrap();
-        }
-
-        let model_params = ModelParameters::from_path(dir.path()).unwrap();
-        assert_eq!(model_params.milestone_years, [2020, 2100]);
     }
 }

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -111,7 +111,7 @@ fn check_max_ironing_out_iterations(value: u32) -> Result<()> {
 fn check_price_tolerance(value: Dimensionless) -> Result<()> {
     ensure!(
         value.is_finite() && value >= Dimensionless(0.0),
-        "price_tolerance must be a finite number greater than zero"
+        "price_tolerance must be a finite number greater than or equal to zero"
     );
 
     Ok(())
@@ -290,7 +290,7 @@ mod tests {
             result,
             expected_valid,
             value,
-            "price_tolerance must be a finite number greater than zero",
+            "price_tolerance must be a finite number greater than or equal to zero",
         );
     }
 }

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -1,0 +1,166 @@
+//! Defines the `ModelParameters` struct, which represents the contents of `model.toml`.
+use crate::asset::check_capacity_valid_for_asset;
+use crate::input::{
+    deserialise_proportion_nonzero, input_err_msg, is_sorted_and_unique, read_toml,
+};
+use crate::units::{Capacity, Dimensionless, MoneyPerFlow};
+use anyhow::{Context, Result, ensure};
+use log::warn;
+use serde::Deserialize;
+use serde_string_enum::DeserializeLabeledStringEnum;
+use std::path::Path;
+
+const MODEL_PARAMETERS_FILE_NAME: &str = "model.toml";
+
+macro_rules! define_unit_param_default {
+    ($name:ident, $type: ty, $value: expr) => {
+        fn $name() -> $type {
+            <$type>::new($value)
+        }
+    };
+}
+
+macro_rules! define_param_default {
+    ($name:ident, $type: ty, $value: expr) => {
+        fn $name() -> $type {
+            $value
+        }
+    };
+}
+
+define_unit_param_default!(default_candidate_asset_capacity, Capacity, 0.0001);
+define_unit_param_default!(default_capacity_limit_factor, Dimensionless, 0.1);
+define_unit_param_default!(default_value_of_lost_load, MoneyPerFlow, 1e9);
+define_unit_param_default!(default_price_tolerance, Dimensionless, 1e-6);
+define_param_default!(default_max_ironing_out_iterations, u32, 10);
+
+/// Represents the contents of the entire model file.
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct ModelParameters {
+    /// Milestone years
+    pub milestone_years: Vec<u32>,
+    /// The (small) value of capacity given to candidate assets.
+    ///
+    /// Don't change unless you know what you're doing.
+    #[serde(default = "default_candidate_asset_capacity")]
+    pub candidate_asset_capacity: Capacity,
+    /// Defines the strategy used for calculating commodity prices
+    #[serde(default)]
+    pub pricing_strategy: PricingStrategy,
+    /// Affects the maximum capacity that can be given to a newly created asset.
+    ///
+    /// It is the proportion of maximum capacity that could be required across time slices.
+    #[serde(default = "default_capacity_limit_factor")]
+    #[serde(deserialize_with = "deserialise_proportion_nonzero")]
+    pub capacity_limit_factor: Dimensionless,
+    /// The cost applied to unmet demand.
+    ///
+    /// Currently this only applies to the LCOX appraisal.
+    #[serde(default = "default_value_of_lost_load")]
+    pub value_of_lost_load: MoneyPerFlow,
+    /// The maximum number of iterations to run the "ironing out" step of agent investment for
+    #[serde(default = "default_max_ironing_out_iterations")]
+    pub max_ironing_out_iterations: u32,
+    /// The relative tolerance for price convergence in the ironing out loop
+    #[serde(default = "default_price_tolerance")]
+    pub price_tolerance: Dimensionless,
+}
+
+/// The strategy used for calculating commodity prices
+#[derive(DeserializeLabeledStringEnum, Debug, PartialEq, Default)]
+pub enum PricingStrategy {
+    /// Take commodity prices directly from the shadow prices
+    #[default]
+    #[string = "shadow_prices"]
+    ShadowPrices,
+    /// Adjust shadow prices for scarcity
+    #[string = "scarcity_adjusted"]
+    ScarcityAdjusted,
+}
+
+/// Check that the milestone years parameter is valid
+///
+/// # Arguments
+///
+/// * `years` - Integer list of milestone years
+///
+/// # Returns
+///
+/// An error if the milestone years are invalid
+fn check_milestone_years(years: &[u32]) -> Result<()> {
+    ensure!(!years.is_empty(), "`milestone_years` is empty");
+
+    ensure!(
+        is_sorted_and_unique(years),
+        "`milestone_years` must be composed of unique values in order"
+    );
+
+    Ok(())
+}
+
+impl ModelParameters {
+    /// Read a model file from the specified directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `model_dir` - Folder containing model configuration files
+    ///
+    /// # Returns
+    ///
+    /// The model file contents as a [`ModelParameters`] struct or an error if the file is invalid
+    pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelParameters> {
+        let file_path = model_dir.as_ref().join(MODEL_PARAMETERS_FILE_NAME);
+        let model_params: ModelParameters = read_toml(&file_path)?;
+
+        if model_params.pricing_strategy == PricingStrategy::ScarcityAdjusted {
+            warn!(
+                "The pricing strategy is set to 'scarcity_adjusted'. Commodity prices may be \
+                incorrect if assets have more than one output commodity. See: {}/issues/677",
+                env!("CARGO_PKG_REPOSITORY")
+            );
+        }
+
+        let validate = || -> Result<()> {
+            check_milestone_years(&model_params.milestone_years)?;
+            check_capacity_valid_for_asset(model_params.candidate_asset_capacity)
+                .context("Invalid value for candidate_asset_capacity")?;
+
+            Ok(())
+        };
+        validate().with_context(|| input_err_msg(file_path))?;
+
+        Ok(model_params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_check_milestone_years() {
+        // Valid
+        assert!(check_milestone_years(&[1]).is_ok());
+        assert!(check_milestone_years(&[1, 2]).is_ok());
+
+        // Invalid
+        assert!(check_milestone_years(&[]).is_err());
+        assert!(check_milestone_years(&[1, 1]).is_err());
+        assert!(check_milestone_years(&[2, 1]).is_err());
+    }
+
+    #[test]
+    fn test_model_params_from_path() {
+        let dir = tempdir().unwrap();
+        {
+            let mut file = File::create(dir.path().join(MODEL_PARAMETERS_FILE_NAME)).unwrap();
+            writeln!(file, "milestone_years = [2020, 2100]").unwrap();
+        }
+
+        let model_params = ModelParameters::from_path(dir.path()).unwrap();
+        assert_eq!(model_params.milestone_years, [2020, 2100]);
+    }
+}


### PR DESCRIPTION
# Description

There are currently some missing validation checks for some model parameters. This PR adds the missing checks.

While I was at it, I reorganised the model params code, by renaming some things and moving the model parameter-specific code into a new `model::parameters` submodule.

Fixes #853.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
