### PR TITLE
Add command to generate placeholder `settings.toml` file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,10 @@ jobs:
           mkdir muse2
           cp target/release/muse2${{ matrix.exe_suffix }} muse2
           cp LICENSE muse2/LICENCE.txt
-          cp assets/settings.toml muse2
           cp assets/readme/readme_${{ matrix.osname }}.txt muse2/README.txt
+
+          # Generate default settings file
+          muse2/muse2 dump-default-settings > muse2/settings.toml
       - uses: actions/upload-artifact@v4
         if: ${{ github.event_name != 'release' }}
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +371,32 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "documented"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6b3e31251e87acd1b74911aed84071c8364fc9087972748ade2f1094ccce34"
+dependencies = [
+ "documented-macros",
+ "phf",
+ "thiserror",
+]
+
+[[package]]
+name = "documented-macros"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1149cf7462e5e79e17a3c05fd5b1f9055092bbfa95e04c319395c3beacc9370f"
+dependencies = [
+ "convert_case",
+ "itertools 0.14.0",
+ "optfield",
+ "proc-macro2",
+ "quote",
+ "strum",
  "syn",
 ]
 
@@ -849,6 +884,7 @@ dependencies = [
  "csv",
  "current_dir",
  "derive_more",
+ "documented",
  "fern",
  "float-cmp",
  "highs",
@@ -916,6 +952,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "optfield"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "os_info"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +990,48 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1215,6 +1304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1381,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1395,6 +1510,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ platform-info = "2.0.5"
 derive_more = {version = "2.0", features = ["add", "display"]}
 petgraph = "0.8.2"
 strum = {version = "0.27.2", features = ["derive"]}
+documented = "0.9.2"
 
 [dev-dependencies]
 current_dir = "0.1.2"

--- a/assets/settings.toml
+++ b/assets/settings.toml
@@ -1,4 +1,0 @@
-# Modify this file if you want to change your program settings
-# log_level = "info"
-# debug_model = false
-# overwrite = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,8 +131,7 @@ pub fn handle_run_command(
         })?;
 
     // Initialise program logger
-    log::init(settings.log_level.as_deref(), Some(output_path))
-        .context("Failed to initialise logging.")?;
+    log::init(&settings.log_level, Some(output_path)).context("Failed to initialise logging.")?;
 
     // Load the model to run
     let (model, assets) = load_model(model_path).context("Failed to load model.")?;
@@ -161,7 +160,7 @@ pub fn handle_validate_command(model_path: &Path, settings: Option<Settings>) ->
     };
 
     // Initialise program logger (we won't save log files when running the validate command)
-    log::init(settings.log_level.as_deref(), None).context("Failed to initialise logging.")?;
+    log::init(&settings.log_level, None).context("Failed to initialise logging.")?;
 
     // Load/validate the model
     load_model(model_path).context("Failed to validate model.")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,16 +59,21 @@ enum Commands {
         /// The path to the model directory.
         model_dir: PathBuf,
     },
+    /// Print default settings file.
+    DumpDefaultSettings,
 }
 
 impl Commands {
     /// Execute the supplied CLI command
     fn execute(self) -> Result<()> {
         match self {
-            Self::Run { model_dir, opts } => handle_run_command(&model_dir, &opts, None),
-            Self::Example { subcommand } => subcommand.execute(),
-            Self::Validate { model_dir } => handle_validate_command(&model_dir, None),
+            Self::Run { model_dir, opts } => handle_run_command(&model_dir, &opts, None)?,
+            Self::Example { subcommand } => subcommand.execute()?,
+            Self::Validate { model_dir } => handle_validate_command(&model_dir, None)?,
+            Self::DumpDefaultSettings => handle_dump_default_settings(),
         }
+
+        Ok(())
     }
 }
 
@@ -167,4 +172,9 @@ pub fn handle_validate_command(model_path: &Path, settings: Option<Settings>) ->
     info!("Model validation successful!");
 
     Ok(())
+}
+
+/// Handle the `dump-default-settings` command
+fn handle_dump_default_settings() {
+    print!("{}", Settings::default_file_contents());
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -22,7 +22,7 @@ static LOGGER_INIT: OnceLock<()> = OnceLock::new();
 ///
 /// Used as a fallback if the user hasn't specified something else with the `MUSE2_LOG_LEVEL`
 /// environment variable or the settings.toml file.
-const DEFAULT_LOG_LEVEL: &str = "info";
+pub const DEFAULT_LOG_LEVEL: &str = "info";
 
 /// The file name for the log file containing messages about the ordinary operation of MUSE 2.0
 const LOG_INFO_FILE_NAME: &str = "muse2_info.log";
@@ -53,13 +53,10 @@ pub fn is_logger_initialised() -> bool {
 ///
 /// * `log_level_from_settings`: The log level specified in `settings.toml`
 /// * `log_file_path`: The location to save log files (if Some, log files will be created)
-pub fn init(log_level_from_settings: Option<&str>, log_file_path: Option<&Path>) -> Result<()> {
+pub fn init(log_level_from_settings: &str, log_file_path: Option<&Path>) -> Result<()> {
     // Retrieve the log level from the environment variable or settings, or use the default
-    let log_level = env::var("MUSE2_LOG_LEVEL").unwrap_or_else(|_| {
-        log_level_from_settings
-            .unwrap_or(DEFAULT_LOG_LEVEL)
-            .to_string()
-    });
+    let log_level =
+        env::var("MUSE2_LOG_LEVEL").unwrap_or_else(|_| log_level_from_settings.to_string());
 
     // Convert the log level string to a log::LevelFilter
     let log_level = match log_level.to_lowercase().as_str() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -72,10 +72,11 @@ impl Settings {
             if let Some(last) = line.find('=') {
                 // Add documentation from doc comments
                 let field = line[..last].trim();
-                if let Ok(docs) = Settings::get_field_docs(field) {
-                    for line in docs.split('\n') {
-                        write!(&mut out, "\n# # {}\n", line.trim()).unwrap();
-                    }
+
+                // Use doc comment to document parameter. All fields should have doc comments.
+                let docs = Settings::get_field_docs(field).expect("Missing doc comment for field");
+                for line in docs.split('\n') {
+                    write!(&mut out, "\n# # {}\n", line.trim()).unwrap();
                 }
 
                 writeln!(&mut out, "# {}", line.trim()).unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,10 +1,16 @@
 //! Code for loading program settings.
 use crate::input::read_toml;
+use crate::log::DEFAULT_LOG_LEVEL;
 use anyhow::Result;
 use serde::Deserialize;
 use std::path::Path;
 
 const SETTINGS_FILE_NAME: &str = "settings.toml";
+
+/// Default log level for program
+fn default_log_level() -> String {
+    DEFAULT_LOG_LEVEL.to_string()
+}
 
 /// Program settings from config file
 ///
@@ -13,7 +19,8 @@ const SETTINGS_FILE_NAME: &str = "settings.toml";
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct Settings {
     /// The user's preferred logging level
-    pub log_level: Option<String>,
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
     /// Whether to overwrite output files by default
     #[serde(default)]
     pub overwrite: bool,
@@ -74,7 +81,7 @@ mod tests {
         assert_eq!(
             Settings::load().unwrap(),
             Settings {
-                log_level: Some("warn".to_string()),
+                log_level: "warn".to_string(),
                 debug_model: false,
                 overwrite: false
             }


### PR DESCRIPTION
# Description

We provide a placeholder `settings.toml` that's bundled with releases with default options commented out, but it's easy to forget to update this file, so it would be better to just generate it instead, which is what I've done in this PR.

I've done this by adding a `dump-default-settings` command to `muse2`, which is then used to generate the placeholder file (though it could also be used by users to see what the default options are).

This is partly in preparation for #255, which should make configuring `muse2` easier. The current approach of having a `settings.toml` file that must be in the CWD is a bit of a hack.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
