### PR TITLE
Fix: Program fails to run if no `settings.toml` file present

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,26 +14,29 @@ const DEFAULT_SETTINGS_FILE_HEADER: &str = "# This file contains the program set
 # \thttps://energysystemsmodellinglab.github.io/MUSE_2.0/file_formats/program_settings.html
 ";
 
-/// Default log level for program
-fn default_log_level() -> String {
-    DEFAULT_LOG_LEVEL.to_string()
-}
-
 /// Program settings from config file
 ///
 /// NOTE: If you add or change a field in this struct, you must also update the schema in
 /// `schemas/settings.yaml`.
-#[derive(Debug, DocumentedFields, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, DocumentedFields, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
 pub struct Settings {
     /// The default program log level
-    #[serde(default = "default_log_level")]
     pub log_level: String,
     /// Whether to overwrite output files by default
-    #[serde(default)]
     pub overwrite: bool,
     /// Whether to write additional information to CSV files
-    #[serde(default)]
     pub debug_model: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            log_level: DEFAULT_LOG_LEVEL.to_string(),
+            overwrite: false,
+            debug_model: false,
+        }
+    }
 }
 
 impl Settings {
@@ -59,9 +62,8 @@ impl Settings {
 
     /// The contents of the default settings file
     pub fn default_file_contents() -> String {
-        // Settings object with default values set by serde
-        let settings: Settings =
-            toml::from_str("").expect("Cannot create settings from empty TOML file");
+        // Settings object with default values for params
+        let settings = Settings::default();
 
         // Convert to TOML
         let settings_raw = toml::to_string(&settings).expect("Could not convert settings to TOML");


### PR DESCRIPTION
# Description

Looks like I broke things in my last PR (#857). Oops.

Now, if you run `muse2` and **don't** have a `settings.toml` file, you'll see an error like this:

```
Error: Failed to initialise logging.

Caused by:
    Unknown log level:
```

The problem is that `Settings::log_level` is set to an empty string by default when you call `Settings::default()`, which is what's used if there is no settings file.

The solution is to apply the `#[serde(default)]` attribute to the whole `Settings` struct, rather than individual fields, and implement the `Default` trait manually for it.

This is actually pretty clean and would maybe be a nicer way of setting default values of params for `ModelParameters` too, rather than all that macro business.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
