### PR TITLE
Fix: Don't commission already-decommissioned assets from input file

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -640,10 +640,11 @@ impl AssetPool {
             // Ignore assets that have already been decommissioned
             if asset.max_decommission_year() <= year {
                 warn!(
-                    "Asset '{}' with commission year {} was decommissioned before the start of \
-                    the simulation",
+                    "Asset '{}' with commission year {} and lifetime {} was decommissioned before \
+                    the start of the simulation",
                     asset.process_id(),
-                    asset.commission_year
+                    asset.commission_year,
+                    asset.process_parameter().lifetime
                 );
                 continue;
             }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -8,7 +8,7 @@ use crate::units::{Activity, ActivityPerCapacity, Capacity, MoneyPerActivity, Mo
 use anyhow::{Context, Result, ensure};
 use indexmap::IndexMap;
 use itertools::{Itertools, chain};
-use log::debug;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -639,6 +639,12 @@ impl AssetPool {
         for mut asset in self.future.drain(0..count) {
             // Ignore assets that have already been decommissioned
             if asset.max_decommission_year() <= year {
+                warn!(
+                    "Asset '{}' with commission year {} was decommissioned before the start of \
+                    the simulation",
+                    asset.process_id(),
+                    asset.commission_year
+                );
                 continue;
             }
 


### PR DESCRIPTION
# Description

If an asset defined in the `assets.csv` input file has a decommission year (== commission year + lifetime) less than or equal to the first milestone year, then it will be commissioned in the first milestone year and included in the simulation for that year before being decommissioned in the second milestone year. This is a bug.

Easy to fix: we just need another check in `AssetPool::commission_new` to ignore future assets which have already been decommissioned.

Fixes #862.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
