### PR TITLE
Add CI workflow to auto-merge bot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: Auto-merge bot PRs to bump package versions
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write # Needed if in a private repository
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' || github.event.pull_request.user.login == 'rse-ci-imperial' }}
+    steps:
+      - name: Enable auto-merge for bot PRs
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

We use a variation on this workflow in lots of repos to automatically merge bot PRs (from dependabot and pre-commit), to make it easier to stay on top of these version bumps. I figure it's probably safe to add it to this repo too. We've got a pretty good test suite and I haven't noticed any breakage caused by bumping any package versions in the last year, so it's probably fine. I also added @rse-ci-imperial to the list of bots, so that bumps to the Rust toolchain version also get auto-merged.

I think we should remove this between engagements, but we'll be working on MUSE2 for a few months yet.
