### PR TITLE
Fix: Remove use of removed `settings dump-default` from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,6 @@ jobs:
           cp target/release/muse2${{ matrix.exe_suffix }} muse2
           cp LICENSE muse2/LICENCE.txt
           cp assets/readme/readme_${{ matrix.osname }}.txt muse2/README.txt
-
-          # Generate default settings file
-          muse2/muse2 dump-default-settings > muse2/settings.toml
       - uses: actions/upload-artifact@v4
         if: ${{ github.event_name != 'release' }}
         with:


### PR DESCRIPTION
# Description

I accidentally broke the release workflow in #860 (I noticed because we run it on pushes to `main`). I'd changed it to generate the bundled `settings.toml` file using the `settings dump-default` command and forgot to update it after I changed the command's name.

On reflection, though, I don't think we actually need that file anymore anyway: users can get information about the possible settings by just running `muse2 settings edit`. So I've just removed it.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
