### PR TITLE
Give candidate assets an agent ID

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -53,28 +53,18 @@ pub enum AssetState {
     Commissioned {
         /// The ID of the asset
         id: AssetID,
-        /// The ID of the agent that owns the asset
-        agent_id: AgentID,
     },
     /// The asset has been decommissioned
     Decommissioned {
         /// The ID of the asset
         id: AssetID,
-        /// The ID of the agent that owned the asset
-        agent_id: AgentID,
         /// The year the asset was decommissioned
         decommission_year: u32,
     },
     /// The asset is planned for commissioning in the future
-    Future {
-        /// The ID of the agent that will own the asset
-        agent_id: AgentID,
-    },
+    Future,
     /// The asset has been selected for investment, but not yet confirmed
-    Selected {
-        /// The ID of the agent that would own the asset
-        agent_id: AgentID,
-    },
+    Selected,
     /// The asset is a candidate for investment but has not yet been selected by an agent
     Candidate,
 }
@@ -84,6 +74,8 @@ pub enum AssetState {
 pub struct Asset {
     /// The status of the asset
     state: AssetState,
+    /// The ID of the agent that owns the asset
+    agent_id: AgentID,
     /// The [`Process`] that this asset corresponds to
     process: Rc<Process>,
     /// Activity limits for this asset
@@ -103,6 +95,7 @@ pub struct Asset {
 impl Asset {
     /// Create a new candidate asset
     pub fn new_candidate(
+        agent_id: AgentID,
         process: Rc<Process>,
         region_id: RegionID,
         capacity: Capacity,
@@ -110,6 +103,7 @@ impl Asset {
     ) -> Result<Self> {
         Self::new_with_state(
             AssetState::Candidate,
+            agent_id,
             process,
             region_id,
             capacity,
@@ -137,7 +131,8 @@ impl Asset {
     ) -> Result<Self> {
         check_capacity_valid_for_asset(capacity)?;
         Self::new_with_state(
-            AssetState::Future { agent_id },
+            AssetState::Future,
+            agent_id,
             process,
             region_id,
             capacity,
@@ -158,7 +153,8 @@ impl Asset {
         commission_year: u32,
     ) -> Result<Self> {
         Self::new_with_state(
-            AssetState::Selected { agent_id },
+            AssetState::Selected,
+            agent_id,
             process,
             region_id,
             capacity,
@@ -169,6 +165,7 @@ impl Asset {
     /// Private helper to create an asset with the given state
     fn new_with_state(
         state: AssetState,
+        agent_id: AgentID,
         process: Rc<Process>,
         region_id: RegionID,
         capacity: Capacity,
@@ -219,6 +216,7 @@ impl Asset {
 
         Ok(Self {
             state,
+            agent_id,
             process,
             activity_limits,
             flows,
@@ -364,14 +362,8 @@ impl Asset {
     }
 
     /// Get the agent ID for this asset
-    pub fn agent_id(&self) -> Option<&AgentID> {
-        match &self.state {
-            AssetState::Commissioned { agent_id, .. }
-            | AssetState::Decommissioned { agent_id, .. }
-            | AssetState::Future { agent_id }
-            | AssetState::Selected { agent_id } => Some(agent_id),
-            AssetState::Candidate => None,
-        }
+    pub fn agent_id(&self) -> &AgentID {
+        &self.agent_id
     }
 
     /// Get the capacity for this asset
@@ -401,21 +393,20 @@ impl Asset {
 
     /// Decommission this asset
     fn decommission(&mut self, decommission_year: u32, reason: &str) {
-        let (id, agent_id) = match &self.state {
-            AssetState::Commissioned { id, agent_id } => (*id, agent_id.clone()),
+        let id = match &self.state {
+            AssetState::Commissioned { id } => *id,
             _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
         };
         debug!(
             "Decommissioning '{}' asset (ID: {}) for agent '{}' (reason: {})",
             self.process_id(),
             id,
-            agent_id,
+            self.agent_id,
             reason
         );
 
         self.state = AssetState::Decommissioned {
             id,
-            agent_id,
             decommission_year,
         };
     }
@@ -430,31 +421,29 @@ impl Asset {
     /// * `id` - The ID to give the newly commissioned asset
     /// * `reason` - The reason for commissioning (included in log)
     fn commission(&mut self, id: AssetID, reason: &str) {
-        let agent_id = match &self.state {
-            AssetState::Future { agent_id } | AssetState::Selected { agent_id } => agent_id,
-            state => panic!("Assets with state {state} cannot be commissioned"),
-        };
+        assert!(
+            matches!(self.state, AssetState::Future | AssetState::Selected),
+            "Assets with state {} cannot be commissioned",
+            self.state
+        );
         debug!(
             "Commissioning '{}' asset (ID: {}) for agent '{}' (reason: {})",
             self.process_id(),
             id,
-            agent_id,
+            self.agent_id,
             reason
         );
-        self.state = AssetState::Commissioned {
-            id,
-            agent_id: agent_id.clone(),
-        };
+        self.state = AssetState::Commissioned { id };
     }
 
     /// Select a Candidate asset for investment, converting it to a Selected state
-    pub fn select_candidate_for_investment(&mut self, agent_id: AgentID) {
+    pub fn select_candidate_for_investment(&mut self) {
         assert!(
             self.state == AssetState::Candidate,
             "select_candidate_for_investment can only be called on Candidate assets"
         );
         check_capacity_valid_for_asset(self.capacity).unwrap();
-        self.state = AssetState::Selected { agent_id };
+        self.state = AssetState::Selected;
     }
 }
 
@@ -559,8 +548,8 @@ impl Eq for AssetRef {}
 impl Hash for AssetRef {
     /// Hash an asset according to its state:
     /// - Commissioned assets are hashed based on their ID alone
-    /// - Selected assets are hashed based on `process_id`, `region_id`, `commission_year` and `agent_id`
-    /// - Candidate assets are hashed based on `process_id`, `region_id` and `commission_year`
+    /// - Candidate and Selected assets are hashed based on `state`, `process_id`, `region_id`,
+    ///   `commission_year` and `agent_id`
     /// - Future and Decommissioned assets cannot currently be hashed
     fn hash<H: Hasher>(&self, state: &mut H) {
         match &self.0.state {
@@ -569,15 +558,14 @@ impl Hash for AssetRef {
                 // asset
                 id.hash(state);
             }
-            AssetState::Candidate | AssetState::Selected { .. } => {
-                // Hashed based on process_id, region_id, commission_year and (for Selected assets)
-                // agent_id
+            AssetState::Candidate | AssetState::Selected => {
+                self.0.state.hash(state);
                 self.0.process.id.hash(state);
                 self.0.region_id.hash(state);
                 self.0.commission_year.hash(state);
-                self.0.agent_id().hash(state);
+                self.0.agent_id.hash(state);
             }
-            AssetState::Future { .. } | AssetState::Decommissioned { .. } => {
+            AssetState::Future | AssetState::Decommissioned { .. } => {
                 // We shouldn't currently need to hash Future or Decommissioned assets
                 unimplemented!("Cannot hash Future or Decommissioned assets");
             }
@@ -761,7 +749,7 @@ impl AssetPool {
         // then commission them
         let assets = assets.into_iter().map(|mut asset| match &asset.state {
             AssetState::Commissioned { .. } => asset,
-            AssetState::Selected { .. } => {
+            AssetState::Selected => {
                 asset
                     .make_mut()
                     .commission(AssetID(self.next_id), "selected");
@@ -791,7 +779,7 @@ where
 {
     /// Filter assets by the agent that owns them
     fn filter_agent(self, agent_id: &'a AgentID) -> impl Iterator<Item = &'a AssetRef> + 'a {
-        self.filter(move |asset| asset.agent_id() == Some(agent_id))
+        self.filter(move |asset| asset.agent_id() == agent_id)
     }
 
     /// Iterate over assets that have the given commodity as a primary output
@@ -827,7 +815,8 @@ mod tests {
     use super::*;
     use crate::commodity::{Commodity, CommodityID, CommodityType};
     use crate::fixture::{
-        assert_error, asset, commodity_id, process, process_parameter_map, region_id, time_slice,
+        agent_id, assert_error, asset, commodity_id, process, process_parameter_map, region_id,
+        time_slice,
     };
     use crate::process::{
         FlowType, Process, ProcessActivityLimitsMap, ProcessFlow, ProcessFlowsMap, ProcessID,
@@ -849,6 +838,7 @@ mod tests {
 
     #[rstest]
     fn test_get_input_cost_from_prices(
+        agent_id: AgentID,
         region_id: RegionID,
         commodity_id: CommodityID,
         mut process_parameter_map: ProcessParameterMap,
@@ -904,7 +894,8 @@ mod tests {
         });
 
         // Create asset
-        let asset = Asset::new_candidate(process, region_id.clone(), Capacity(1.0), 2020).unwrap();
+        let asset = Asset::new_candidate(agent_id, process, region_id.clone(), Capacity(1.0), 2020)
+            .unwrap();
 
         // Set input prices
         let mut input_prices = HashMap::new();
@@ -1224,11 +1215,11 @@ mod tests {
         assert_eq!(asset_pool.active[original_count + 1].id(), Some(AssetID(3)));
         assert_eq!(
             asset_pool.active[original_count].agent_id(),
-            Some(&"agent2".into())
+            &"agent2".into()
         );
         assert_eq!(
             asset_pool.active[original_count + 1].agent_id(),
-            Some(&"agent3".into())
+            &"agent3".into()
         );
     }
 
@@ -1261,7 +1252,7 @@ mod tests {
             asset_pool
                 .active
                 .iter()
-                .any(|a| a.agent_id() == Some(&"agent_new".into()))
+                .any(|a| a.agent_id() == &"agent_new".into())
         );
     }
 
@@ -1439,13 +1430,13 @@ mod tests {
     }
 
     #[rstest]
-    fn test_asset_state_transitions(process: Process) {
+    fn test_asset_state_transitions(agent_id: AgentID, process: Process, region_id: RegionID) {
         // Test successful commissioning of Future asset
-        let process_rc = Rc::new(process);
+        let process = Rc::new(process);
         let mut asset1 = Asset::new_future(
-            "agent1".into(),
-            Rc::clone(&process_rc),
-            "GBR".into(),
+            agent_id.clone(),
+            Rc::clone(&process),
+            region_id.clone(),
             Capacity(1.0),
             2020,
         )
@@ -1455,14 +1446,8 @@ mod tests {
         assert_eq!(asset1.id(), Some(AssetID(1)));
 
         // Test successful commissioning of Selected asset
-        let mut asset2 = Asset::new_selected(
-            "agent1".into(),
-            Rc::clone(&process_rc),
-            "GBR".into(),
-            Capacity(1.0),
-            2020,
-        )
-        .unwrap();
+        let mut asset2 =
+            Asset::new_selected(agent_id, process, region_id, Capacity(1.0), 2020).unwrap();
         asset2.commission(AssetID(2), "");
         assert!(asset2.is_commissioned());
         assert_eq!(asset2.id(), Some(AssetID(2)));
@@ -1475,17 +1460,17 @@ mod tests {
 
     #[rstest]
     #[should_panic(expected = "Assets with state Candidate cannot be commissioned")]
-    fn test_commission_wrong_states(process: Process) {
+    fn test_commission_wrong_states(agent_id: AgentID, process: Process, region_id: RegionID) {
         let mut asset =
-            Asset::new_candidate(process.into(), "GBR".into(), Capacity(1.0), 2020).unwrap();
+            Asset::new_candidate(agent_id, process.into(), region_id, Capacity(1.0), 2020).unwrap();
         asset.commission(AssetID(1), "");
     }
 
     #[rstest]
     #[should_panic(expected = "Cannot decommission an asset that hasn't been commissioned")]
-    fn test_decommission_wrong_state(process: Process) {
+    fn test_decommission_wrong_state(agent_id: AgentID, process: Process, region_id: RegionID) {
         let mut asset =
-            Asset::new_candidate(process.into(), "GBR".into(), Capacity(1.0), 2020).unwrap();
+            Asset::new_candidate(agent_id, process.into(), region_id, Capacity(1.0), 2020).unwrap();
         asset.decommission(2025, "");
     }
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -45,7 +45,7 @@ pub struct AssetID(u32);
 /// `commission_future` or `commission_candidate` respectively.
 ///
 /// `Commissioned` assets can be decommissioned by calling `decommission`.
-#[derive(Clone, Debug, Hash, PartialEq, strum::Display)]
+#[derive(Clone, Debug, PartialEq, strum::Display)]
 pub enum AssetState {
     /// The asset has been commissioned
     Commissioned {

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -45,9 +45,7 @@ pub struct AssetID(u32);
 /// `commission_future` or `commission_candidate` respectively.
 ///
 /// `Commissioned` assets can be decommissioned by calling `decommission`.
-#[derive(
-    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize, strum::Display,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, strum::Display)]
 pub enum AssetState {
     /// The asset has been commissioned
     Commissioned {

--- a/src/output.rs
+++ b/src/output.rs
@@ -124,7 +124,7 @@ impl AssetRow {
             asset_id: asset.id().unwrap(),
             process_id: asset.process_id().clone(),
             region_id: asset.region_id().clone(),
-            agent_id: asset.agent_id().clone(),
+            agent_id: asset.agent_id().unwrap().clone(),
             commission_year: asset.commission_year(),
             decommission_year: asset.decommission_year(),
             capacity: asset.capacity(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -124,7 +124,7 @@ impl AssetRow {
             asset_id: asset.id().unwrap(),
             process_id: asset.process_id().clone(),
             region_id: asset.region_id().clone(),
-            agent_id: asset.agent_id().unwrap().clone(),
+            agent_id: asset.agent_id().clone(),
             commission_year: asset.commission_year(),
             decommission_year: asset.decommission_year(),
             capacity: asset.capacity(),

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,11 +1,14 @@
 //! Functionality for running the MUSE 2.0 simulation.
+use crate::agent::Agent;
 use crate::asset::{Asset, AssetPool, AssetRef};
+use crate::commodity::CommodityID;
 use crate::model::Model;
 use crate::output::DataWriter;
-use crate::process::ProcessMap;
+use crate::process::Process;
+use crate::region::RegionID;
 use crate::simulation::prices::{ReducedCosts, calculate_prices_and_reduced_costs};
-use crate::units::Capacity;
 use anyhow::{Context, Result};
+use itertools::iproduct;
 use log::info;
 use std::path::Path;
 use std::rc::Rc;
@@ -47,11 +50,7 @@ pub fn run(
 
     // Gather candidates for the next year, if any
     let next_year = year_iter.peek().copied();
-    let mut candidates = candidate_assets_for_next_year(
-        &model.processes,
-        next_year,
-        model.parameters.candidate_asset_capacity,
-    );
+    let mut candidates = candidate_assets_for_next_year(model, next_year);
 
     // Run dispatch optimisation
     info!("Running dispatch optimisation...");
@@ -151,11 +150,7 @@ pub fn run(
 
         // Gather candidates for the next year, if any
         let next_year = year_iter.peek().copied();
-        candidates = candidate_assets_for_next_year(
-            &model.processes,
-            next_year,
-            model.parameters.candidate_asset_capacity,
-        );
+        candidates = candidate_assets_for_next_year(model, next_year);
 
         // Run dispatch optimisation
         info!("Running final dispatch optimisation for year {year}...");
@@ -206,32 +201,53 @@ fn run_dispatch_for_year(
     Ok((flow_map, prices, reduced_costs))
 }
 
+/// Get search spaces for specified agents for given region, commodity and milestone year
+fn get_search_spaces<'a, I>(
+    agents: I,
+    region_id: &'a RegionID,
+    commodity_id: &'a CommodityID,
+    year: u32,
+) -> impl Iterator<Item = (&'a Agent, &'a Rc<Process>)>
+where
+    I: Iterator<Item = &'a Agent>,
+{
+    agents
+        // Only include agents which operate in this region
+        .filter(|agent| agent.regions.contains(region_id))
+        .filter_map(move |agent| {
+            let processes = agent
+                .search_space
+                // Should be responsible for some of this commodity in this year
+                .get(&(commodity_id.clone(), year))?
+                .iter()
+                // Only interested in processes which can operate in this region
+                .filter(|process| process.regions.contains(region_id))
+                .map(move |process| (agent, process));
+            Some(processes)
+        })
+        .flatten()
+}
+
 /// Create candidate assets for all potential processes in a specified year
-fn candidate_assets_for_next_year(
-    processes: &ProcessMap,
-    next_year: Option<u32>,
-    candidate_asset_capacity: Capacity,
-) -> Vec<AssetRef> {
+fn candidate_assets_for_next_year(model: &Model, next_year: Option<u32>) -> Vec<AssetRef> {
     let mut candidates = Vec::new();
     let Some(next_year) = next_year else {
         return candidates;
     };
 
-    for process in processes
-        .values()
-        .filter(move |process| process.active_for_year(next_year))
-    {
-        for region_id in &process.regions {
-            candidates.push(
-                Asset::new_candidate(
-                    Rc::clone(process),
-                    region_id.clone(),
-                    candidate_asset_capacity,
-                    next_year,
-                )
-                .unwrap()
-                .into(),
-            );
+    for (region_id, commodity_id) in iproduct!(model.iter_regions(), model.commodities.keys()) {
+        for (agent, process) in
+            get_search_spaces(model.agents.values(), region_id, commodity_id, next_year)
+        {
+            let asset = Asset::new_candidate(
+                agent.id.clone(),
+                process.clone(),
+                region_id.clone(),
+                model.parameters.candidate_asset_capacity,
+                next_year,
+            )
+            .unwrap(); // safe: arguments should all be valid
+            candidates.push(asset.into());
         }
     }
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -327,9 +327,14 @@ fn get_candidate_assets<'a>(
     agent
         .iter_possible_producers_of(region_id, &commodity.id, year)
         .map(move |process| {
-            let mut asset =
-                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
-                    .unwrap();
+            let mut asset = Asset::new_candidate(
+                agent.id.clone(),
+                process.clone(),
+                region_id.clone(),
+                Capacity(0.0),
+                year,
+            )
+            .unwrap();
             asset.set_capacity(get_demand_limiting_capacity(
                 time_slice_info,
                 &asset,
@@ -465,12 +470,9 @@ fn select_best_assets(
     }
 
     // Convert Candidate assets to Selected
-    // At this point we also assign the agent ID to the asset
     for asset in &mut best_assets {
-        if let AssetState::Candidate = asset.state() {
-            asset
-                .make_mut()
-                .select_candidate_for_investment(agent.id.clone());
+        if asset.state() == &AssetState::Candidate {
+            asset.make_mut().select_candidate_for_investment();
         }
     }
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -327,14 +327,9 @@ fn get_candidate_assets<'a>(
     agent
         .iter_possible_producers_of(region_id, &commodity.id, year)
         .map(move |process| {
-            let mut asset = Asset::new_candidate(
-                agent.id.clone(),
-                process.clone(),
-                region_id.clone(),
-                Capacity(0.0),
-                year,
-            )
-            .unwrap();
+            let mut asset =
+                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
+                    .unwrap();
             asset.set_capacity(get_demand_limiting_capacity(
                 time_slice_info,
                 &asset,
@@ -470,9 +465,12 @@ fn select_best_assets(
     }
 
     // Convert Candidate assets to Selected
+    // At this point we also assign the agent ID to the asset
     for asset in &mut best_assets {
-        if asset.state() == &AssetState::Candidate {
-            asset.make_mut().select_candidate_for_investment();
+        if let AssetState::Candidate = asset.state() {
+            asset
+                .make_mut()
+                .select_candidate_for_investment(agent.id.clone());
         }
     }
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -381,6 +381,7 @@ fn select_best_assets(
     );
 
     let mut round = 0;
+    let objective_type = &agent.objectives[&year];
     while is_any_remaining_demand(&demand) {
         ensure!(
             !opt_assets.is_empty(),
@@ -402,7 +403,7 @@ fn select_best_assets(
                 asset,
                 max_capacity,
                 commodity,
-                &agent.objectives[&year],
+                objective_type,
                 reduced_costs,
                 &demand,
             )?;


### PR DESCRIPTION
# Description

As part of the series of fixes for reduced costs (#876), we will soon be transitioning to using the same method for calculating reduced costs as we currently do for existing costs (#879). This means that candidate assets will need to be associated with a particular agent, as the reduced cost calculation will vary depending on the agent's objective (see my other PR: #882). Currently, candidate assets are agent-less unless and until they are selected by an agent, at which point their `state` is changed to `AssetState::Selected` and they are assigned an agent ID. All other asset types already have an associated agent ID; this PR just changes things so candidates have one too, by making `agent_id` a field of `Asset` rather than a value embedded in different `AssetState` variants.

This means we have to use a different method for generating candidate assets for a given year: now we iterate over agents and look at their search spaces, so we have a corresponding agent for each, rather than just looking at the set of processes which can be commissioned in a given year instead.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
