### PR TITLE
Fix `run_dispatch_for_year` for no existing assets case

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -196,23 +196,35 @@ fn run_dispatch_for_year(
     year: u32,
     writer: &mut DataWriter,
 ) -> Result<(FlowMap, CommodityPrices, ReducedCosts)> {
-    // Dispatch optimisation with existing assets only
-    let solution_existing =
-        DispatchRun::new(model, assets, year).run("final without candidates", writer)?;
-    let flow_map = solution_existing.create_flow_map();
+    // Run dispatch optimisation with existing assets only, if there are any. If not, then assume no
+    // flows (i.e. all are zero)
+    let (solution_existing, flow_map) = (!assets.is_empty())
+        .then(|| -> Result<_> {
+            let solution =
+                DispatchRun::new(model, assets, year).run("final without candidates", writer)?;
+            let flow_map = solution.create_flow_map();
 
-    // Perform a separate dispatch run with existing assets and candidates (if there are any)
-    let solution = if candidates.is_empty() {
-        solution_existing
-    } else {
-        DispatchRun::new(model, assets, year)
-            .with_candidates(candidates)
-            .run("final with candidates", writer)?
-    };
+            Ok((Some(solution), flow_map))
+        })
+        .transpose()?
+        .unwrap_or_default();
 
-    // Calculate commodity prices and asset reduced costs
-    let (prices, reduced_costs) =
-        calculate_prices_and_reduced_costs(model, &solution, assets, year);
+    // Perform a separate dispatch run with both existing assets and candidates to get prices and
+    // reduced costs, if there are any. If not, use the previous solution.
+    let solution_for_prices = (!candidates.is_empty())
+        .then(|| {
+            DispatchRun::new(model, assets, year)
+                .with_candidates(candidates)
+                .run("final with candidates", writer)
+        })
+        .transpose()?
+        .or(solution_existing);
+
+    // If there were either existing or candidate assets, we can calculate prices and reduced costs.
+    // If not, return empty maps.
+    let (prices, reduced_costs) = solution_for_prices
+        .map(|solution| calculate_prices_and_reduced_costs(model, &solution, assets, year))
+        .unwrap_or_default();
 
     Ok((flow_map, prices, reduced_costs))
 }


### PR DESCRIPTION
# Description

@dalonsoa I thought I'd have a look at why you were getting errors for #871 and found a bug (in addition to the one you came across before!). There is a problem where the `run_dispatch_for_year` function in `simulation.rs` doesn't work properly if there are no existing assets provided (it handles missing candidates fine), even though this is something that can happen -- as you've shown!

I've reworked it a bit to handle missing existing assets correctly. Following a suggestion from @tsmbland, I've chosen to return an empty flows map if there are no existing assets (which means all flows will be treated as zero, but nothing will be written to `commodity_flows.csv`) and empty prices and reduced costs maps if neither existing or candidate assets are provided (again, nothing will be written to output files in this case). There _should_ only be no candidates for the final milestone year, so this shouldn't pose a problem.

I can't promise that this won't introduce any other edge cases, but I tried this fix on top of #871 and the simulation ran to the end successfully, which I think is an improvement!

PS -- I've written this using a bunch of lambas, as that seemed clean enough to me. I _think_ it's readable enough, but please say if you think it looks like a mess instead :laughing:.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
