### PR TITLE
Disallow `inf` and `NaN` as values for unit types in input files

### DIFF
--- a/src/units.rs
+++ b/src/units.rs
@@ -53,7 +53,6 @@ macro_rules! base_unit_struct {
             PartialOrd,
             Default,
             Serialize,
-            Deserialize,
             derive_more::Add,
             derive_more::Sub,
         )]
@@ -129,6 +128,19 @@ macro_rules! base_unit_struct {
             /// Returns ordering between self and other
             pub fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
                 self.0.total_cmp(&other.0)
+            }
+        }
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = f64::deserialize(deserializer)?;
+                if !value.is_finite() {
+                    Err(serde::de::Error::custom("Value cannot be NaN or infinite"))?;
+                }
+
+                Ok($name(value))
             }
         }
         impl UnitType for $name {


### PR DESCRIPTION
# Description

Technically users can provide values of `inf` or `NaN` for any field in a CSV file representing a floating-point number. These values will often be rejected by subsequent validation checks, but not every number is validated (for example, the levies in `commodity_levies.csv`) and there it is possible that users could provide `NaN` or `inf` and it would lead to some pretty weird consequences. You'd have to be pretty daft to try it, but I figure it's worth prohibiting it explicitly, even if it is a bit of an edge case.

One way around this would be to validate unit types when we create them and reject infinite or NaN values there, but I can imagine we might want these values to be set within the program itself (e.g. as placeholder values in a `Vec` to be filled). It doesn't seem likely that we will want users to be able to provide these values as inputs though, so the way I've tackled this is to write a custom `Deserialize` implementation for unit types that forbids NaN and inf as inputs. In the rare cases where we might want to allow a field to be inf or something, we can provide a custom deserialiser for that specific field with `#[serde(deserialize_with = ...)]`, but it seems sensible to disallow it by default.

Fixes #426.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
