### PR TITLE
Update README to signpost release pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,18 @@ foresight over the whole modelled time horizon.
 
 ## Getting started
 
-To start using MUSE2, please refer to [the documentation]. If you wish to develop MUSE2 or
-build it from source, please see [the developer guide].
+The easiest way to install MUSE2 is to download the latest version for your platform on [our
+releases page]. For information on getting started, please consult [the documentation].
 
+If you wish to develop MUSE2 or build it from source, please see [the developer guide].
+
+You can also install the [`muse2` crate from crates.io][muse2-crate], though this installation
+method is only recommended for developers.
+
+[our releases page]: https://github.com/EnergySystemsModellingLab/MUSE2/releases
 [the documentation]: https://energysystemsmodellinglab.github.io/MUSE2/introduction.html
 [the developer guide]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide.html
+[muse2-crate]: https://crates.io/crates/muse2
 
 ## Citing this repository
 


### PR DESCRIPTION
# Description

Now that we actually have a release out, we can give prospective users more specific guidance on how to get set up with MUSE2.

Specifically, we now have pages on:

- [GitHub](https://github.com/EnergySystemsModellingLab/MUSE2/releases) (the normal release page)
- [Zenodo](https://zenodo.org/records/17350373) (for the DOI)
- [crates.io (the Rust package repository)](https://crates.io/crates/muse2)

I've updated the README to signpost these resources and add badges for Zenodo and crates.io.

PS -- The crates.io package is currently published with my personal account, which is probably fine for now. We may want to consider transferring ownership at some point though, either to an account for the RSE team or to @ahawkes.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
