### PR TITLE
Fix release date in `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ message: |
   expressed herein do not necessarily reflect the UK government’s official policies.
 title: MUSE2
 version: 2.0.0
-date-released: 2025-10-13
+date-released: 2025-10-14
 authors:
   - family-names: Dewar
     given-names: Alex


### PR DESCRIPTION
# Description

I just remembered that the release date in the `CITATION.cff` file is for yesterday not today when I actually made the release. It doesn't seem to be a problem (the date on the Zenodo page is ok), but it'll annoy me if it's wrong :laughing: so I thought I'd fix it.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
