### PR TITLE
Fix: If lower bound specified for availability, upper bound should be 1.0

### DIFF
--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -44,9 +44,10 @@ impl ProcessAvailabilityRaw {
     /// `capacity_to_activity` units of capacity.
     fn to_bounds(&self, ts_length: Year) -> RangeInclusive<Dimensionless> {
         // We know ts_length also represents a fraction of a year, so this is ok.
-        let value = self.value * ts_length / Year(1.0);
+        let ts_frac = ts_length / Year(1.0);
+        let value = self.value * ts_frac;
         match self.limit_type {
-            LimitType::LowerBound => value..=Dimensionless(f64::INFINITY),
+            LimitType::LowerBound => value..=ts_frac,
             LimitType::UpperBound => Dimensionless(0.0)..=value,
             LimitType::Equality => value..=value,
         }
@@ -310,7 +311,7 @@ mod tests {
         // Lower bound
         let raw = create_process_availability_raw(LimitType::LowerBound, Dimensionless(0.5));
         let bounds = raw.to_bounds(ts_length);
-        assert_eq!(bounds, Dimensionless(0.05)..=Dimensionless(f64::INFINITY));
+        assert_eq!(bounds, Dimensionless(0.05)..=Dimensionless(0.1));
 
         // Upper bound
         let raw = create_process_availability_raw(LimitType::UpperBound, Dimensionless(0.5));


### PR DESCRIPTION
# Description

I stumbled across this while I was looking something up and it seemed fishy to me.

If you specify a lower bound for a process availability, the upper bound is set to infinity, whereas it should be 100% instead. It would be ok if we had other constraints which prevented activity from exceeding 100%, but we don't. In practice this hasn't proven to be a problem because all the examples only specify upper bounds. Also, the optimiser will generally try to minimise activity anyway, because less activity means lower cost, but we shouldn't rely on this.

Fix by setting the upper limit to 100%.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
