### PR TITLE
Validate flows for non-primary outputs/inputs

### DIFF
--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -132,7 +132,7 @@ where
     }
 
     validate_flows_and_update_primary_output(processes, &flows_map)?;
-    validate_secondary_io_flows(processes, &flows_map)?;
+    validate_secondary_flows(processes, &flows_map)?;
 
     Ok(flows_map)
 }
@@ -232,7 +232,7 @@ fn check_flows_primary_output(
 
 /// Checks that non-primary io are defined for all years (within a region) and that
 /// they are only inputs or only outputs in all years.
-fn validate_secondary_io_flows(
+fn validate_secondary_flows(
     processes: &mut ProcessMap,
     flows_map: &HashMap<ProcessID, ProcessFlowsMap>,
 ) -> Result<()> {


### PR DESCRIPTION
# Description

Adds a validation for the non-primary flows of a process, which must exist for all years and be of the same sign, i.e. always inputs or always outputs in all years. They can differ in different regions, though.

### TODO

I've checked that this works as expected by playing around with the `two_outputs` example. It catches the situations described and report the right error. However, I am unable to write a test for it, fighting against borrowing and mutability rules of `rust`. Any advice on this front, @tsmbland , would be most welcomed.

So far, what I've tried is to copy one of the other tests on the topic and manually change the flow of one specific year for one specific region and commodity in the `flow_map` before passing it to the validation function, but that does not seem to be permitted...

Fixes #927 
Fixes #929

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
