### PR TITLE
replace years column for processes to commission years

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,7 +16,7 @@ becomes an *Asset* that they own and operate. An *Asset* is an instance of a *Pr
 specific capacity, and a decommissioning year. A set of *Assets* must exist in the base year
 sufficient to serve base year demands (i.e. a calibrated base year, based on user input data).
 
-**Availability:** The maximum, minimum or fixed percentage of maximum output (or input) that an
+**Availability:** The maximum, minimum or fixed percentage of maximum output (or input) that a
 *Process* delivers over a period. The time period could be a single time slice, a season, or a year.
 
 **Base Year:** The starting year of a model run. The base year is typically calibrated to known

--- a/examples/missing_commodity/process_availabilities.csv
+++ b/examples/missing_commodity/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,time_slice,limit_type,value
+process_id,regions,commission_years,time_slice,limit_type,value
 GASDRV,all,all,annual,up,0.9
 GASPRC,all,all,annual,up,0.9
 BIOPRO,all,all,annual,up,1.0

--- a/examples/missing_commodity/process_flows.csv
+++ b/examples/missing_commodity/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,years,coeff,type,cost
+process_id,commodity_id,regions,commission_years,coeff,type,cost
 GASDRV,GASPRD,all,all,1.0,fixed,
 GASPRC,GASPRD,all,all,-1.05,fixed,
 GASPRC,GASNAT,all,all,1.0,fixed,

--- a/examples/missing_commodity/process_parameters.csv
+++ b/examples/missing_commodity/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
+process_id,regions,commission_years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
 GASDRV,all,all,10.0,0.3,2.0,25,0.1
 GASPRC,all,all,7.0,0.21,0.5,25,0.1
 BIOPRO,all,all,1.0,0.2,0.25,20,0.09

--- a/examples/muse1_default/process_availabilities.csv
+++ b/examples/muse1_default/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,time_slice,limit_type,value
+process_id,regions,commission_years,time_slice,limit_type,value
 gassupply1,R1,all,annual,up,0.9
 gasCCGT,R1,all,annual,up,0.9
 windturbine,R1,all,annual,up,0.4

--- a/examples/muse1_default/process_flows.csv
+++ b/examples/muse1_default/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,years,coeff,type,cost
+process_id,commodity_id,regions,commission_years,coeff,type,cost
 gassupply1,gas,R1,all,1,fixed,
 gasCCGT,gas,R1,all,-1.67,fixed,
 gasCCGT,electricity,R1,all,1,fixed,

--- a/examples/muse1_default/process_parameters.csv
+++ b/examples/muse1_default/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
+process_id,regions,commission_years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
 gassupply1,R1,all,0,0,2.55,60,0.1
 gasCCGT,R1,all,23.78234399,0,0,60,0.1
 windturbine,R1,all,36.30771182,0,0,60,0.1

--- a/examples/simple/process_availabilities.csv
+++ b/examples/simple/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,time_slice,limit_type,value
+process_id,regions,commission_years,time_slice,limit_type,value
 GASDRV,all,all,annual,up,0.9
 GASPRC,all,all,annual,up,0.9
 GASCGT,all,all,annual,up,0.9

--- a/examples/simple/process_flows.csv
+++ b/examples/simple/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,years,coeff,type,cost
+process_id,commodity_id,regions,commission_years,coeff,type,cost
 GASDRV,GASPRD,all,all,1.0,fixed,
 GASPRC,GASPRD,all,all,-1.05,fixed,
 GASPRC,GASNAT,all,all,1.0,fixed,

--- a/examples/simple/process_parameters.csv
+++ b/examples/simple/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
+process_id,regions,commission_years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
 GASDRV,all,all,10.0,0.3,2.0,25,0.1
 GASPRC,all,all,7.0,0.21,0.5,25,0.1
 WNDFRM,all,all,1000.0,30.0,0.4,25,0.1

--- a/examples/two_outputs/process_availabilities.csv
+++ b/examples/two_outputs/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,time_slice,limit_type,value
+process_id,regions,commission_years,time_slice,limit_type,value
 GASDRV,all,all,annual,up,0.9
 OAGRSV,all,all,annual,up,0.9
 GASPRC,all,all,annual,up,0.9

--- a/examples/two_outputs/process_flows.csv
+++ b/examples/two_outputs/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,years,coeff,type,cost
+process_id,commodity_id,regions,commission_years,coeff,type,cost
 GASDRV,GASPRD,all,all,1,fixed,
 OAGRSV,OILCRD,all,all,1,fixed,
 OAGRSV,GASPRD,all,all,0.1,fixed,

--- a/examples/two_outputs/process_parameters.csv
+++ b/examples/two_outputs/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
+process_id,regions,commission_years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
 GASDRV,GBR,all,10,0.3,2,25,0.1
 OAGRSV,GBR,all,15,0.45,3,25,0.1
 GASPRC,GBR,all,7,0.21,0.5,25,0.1

--- a/examples/two_regions/process_availabilities.csv
+++ b/examples/two_regions/process_availabilities.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,time_slice,limit_type,value
+process_id,regions,commission_years,time_slice,limit_type,value
 gassupply1,R1;R2,all,annual,up,0.9
 gasCCGT,R1;R2,all,annual,up,0.9
 windturbine,R1;R2,all,annual,up,0.4

--- a/examples/two_regions/process_flows.csv
+++ b/examples/two_regions/process_flows.csv
@@ -1,4 +1,4 @@
-process_id,commodity_id,regions,years,coeff
+process_id,commodity_id,regions,commission_years,coeff
 gassupply1,gas,R1;R2,all,1
 gasCCGT,gas,R1;R2,all,-1.67
 gasCCGT,electricity,R1;R2,all,1

--- a/examples/two_regions/process_parameters.csv
+++ b/examples/two_regions/process_parameters.csv
@@ -1,4 +1,4 @@
-process_id,regions,years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
+process_id,regions,commission_years,capital_cost,fixed_operating_cost,variable_operating_cost,lifetime,discount_rate
 gassupply1,R1;R2,all,0,0,2.55,60,0.1
 gasCCGT,R1;R2,all,23.78234399,0,0,60,0.1
 windturbine,R1;R2,all,36.30771182,0,0,60,0.1

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -21,7 +21,7 @@ const PROCESS_AVAILABILITIES_FILE_NAME: &str = "process_availabilities.csv";
 struct ProcessAvailabilityRaw {
     process_id: String,
     regions: String,
-    years: String,
+    commission_years: String,
     time_slice: String,
     limit_type: LimitType,
     value: Dimensionless,
@@ -138,9 +138,10 @@ where
 
         // Get years
         let process_years = &process.years;
-        let record_years = parse_year_str(&record.years, process_years).with_context(|| {
-            format!("Invalid year for process {id}. Valid years are {process_years:?}")
-        })?;
+        let record_years =
+            parse_year_str(&record.commission_years, process_years).with_context(|| {
+                format!("Invalid year for process {id}. Valid years are {process_years:?}")
+            })?;
 
         // Get time slices
         let ts_selection = time_slice_info.get_selection(&record.time_slice)?;
@@ -261,7 +262,7 @@ mod tests {
         ProcessAvailabilityRaw {
             process_id: "process".into(),
             regions: "region".into(),
-            years: "2010".into(),
+            commission_years: "2010".into(),
             time_slice: "day".into(),
             limit_type,
             value,

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -19,7 +19,7 @@ const PROCESS_FLOWS_FILE_NAME: &str = "process_flows.csv";
 struct ProcessFlowRaw {
     process_id: String,
     commodity_id: String,
-    years: String,
+    commission_years: String,
     regions: String,
     coeff: FlowPerActivity,
     #[serde(default)]
@@ -94,9 +94,10 @@ where
 
         // Get years
         let process_years = &process.years;
-        let record_years = parse_year_str(&record.years, process_years).with_context(|| {
-            format!("Invalid year for process {id}. Valid years are {process_years:?}")
-        })?;
+        let record_years =
+            parse_year_str(&record.commission_years, process_years).with_context(|| {
+                format!("Invalid year for process {id}. Valid years are {process_years:?}")
+            })?;
 
         // Get commodity
         let commodity = commodities

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -17,7 +17,7 @@ const PROCESS_PARAMETERS_FILE_NAME: &str = "process_parameters.csv";
 struct ProcessParameterRaw {
     process_id: String,
     regions: String,
-    years: String,
+    commission_years: String,
     capital_cost: MoneyPerCapacity,
     fixed_operating_cost: MoneyPerCapacityPerYear,
     variable_operating_cost: MoneyPerActivity,
@@ -111,8 +111,8 @@ where
 
         // Get years
         let process_years = &process.years;
-        let parameter_years =
-            parse_year_str(&param_raw.years, process_years).with_context(|| {
+        let parameter_years = parse_year_str(&param_raw.commission_years, process_years)
+            .with_context(|| {
                 format!("Invalid year for process {id}. Valid years are {process_years:?}")
             })?;
 
@@ -193,7 +193,7 @@ mod tests {
             variable_operating_cost: MoneyPerActivity(0.0),
             lifetime,
             discount_rate,
-            years: "all".to_string(),
+            commission_years: "all".to_string(),
             regions: "all".to_string(),
         }
     }


### PR DESCRIPTION
# Description

Updated the structs and input csv files for test regression so that for the _process file inputs, we require 'commission years' instead of 'years' to prevent ambiguity.
It's intended that the processes can be commissioned in that set of years - not that the process have the specified characteristics over the years.

Fixes #947

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [X] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
