### PR TITLE
add epsilon term to npv activity coefficients

### DIFF
--- a/src/simulation/investment/appraisal/coefficients.rs
+++ b/src/simulation/investment/appraisal/coefficients.rs
@@ -86,7 +86,7 @@ pub fn calculate_coefficients_for_npv(
     prices: &CommodityPrices,
     year: u32,
 ) -> ObjectiveCoefficients {
-    // Small constant added toeach activity coefficient to ensure break-even/slightly negative
+    // Small constant added to each activity coefficient to ensure break-even/slightly negative
     // assets are still dispatched
     const EPSILON_ACTIVITY_COEFFICIENT: MoneyPerActivity = MoneyPerActivity(f64::EPSILON * 100.0);
 


### PR DESCRIPTION
# Description

Add a small epsilon value to all activity coefficients in the NPV appraisal optimisation to help prevent spurious investment failures.

Fixes #991

see #998 for a results comparison with simple model

## Type of change

- [X] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
