### PR TITLE
Update macOS readme instructions to work around malware error message

### DIFF
--- a/assets/readme/readme_macos_arm.txt
+++ b/assets/readme/readme_macos_arm.txt
@@ -1,10 +1,10 @@
 This folder contains the MUSE2 executable for macOS (Apple Silicon), called `muse2`.
 
-When you first attempt to run muse2 from the console, you will probably see an error message about possible malware (this is because it is unsigned code). To fix this, you first need to run:
+When you first attempt to run `muse2` from the console, you will probably see an error message about possible malware (this is because it is unsigned code). To fix this, you first need to run:
 
     xattr -d com.apple.quarantine ./muse2
 
-After this step, you should be able to run muse2 as normal.
+After this step, you should be able to run `muse2` as normal.
 
 For more information on how to use MUSE2, you can consult the program help:
 


### PR DESCRIPTION
# Description

If you try to open the prebuilt `muse2` binary on macOS you get a scary-looking error message about it being possible malware and it won't run. Unfortunately, the only way to truly get rid of this message is to provide binaries signed with a developer key and those are expensive.

You can mark the `muse2` program as safe manually though and it should work fine after that point. Update the macOS readme instructions to tell users how to do this.

@AdrianDAlessandro has verified that this method works.

Closes #943. Closes #948.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
