### PR TITLE
Fix `update-rust-toolchain` workflow

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: update rust toolchain
         uses: a-kenji/update-rust-toolchain@v1
         with:


### PR DESCRIPTION
# Description

The new `checkout` action (v6) causes problems with the `update-rust-toolchain`, leading to multiple authentication headers being sent to git, which then fails. Fix by not persisting credentials.

I hacked the workflow to make it run and confirmed that it now works and opens a PR successfully (which I then closed without merging).

Credit goes to the author of `update-rust-toolchain` for the fix: https://github.com/a-kenji/update-rust-toolchain/issues/75#issuecomment-3670129602

Fixes #1029.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
