### PR TITLE
Use integer capacity variables for dispatch

### DIFF
--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -260,7 +260,16 @@ impl Solution<'_> {
             .capacity_vars
             .keys()
             .zip(self.solution.columns()[self.variables.capacity_var_idx.clone()].iter())
-            .map(|(asset, capacity)| (asset, Capacity(*capacity)))
+            .map(|(asset, capacity)| {
+                // If the asset is divisible, the capacity variable represents number of units,
+                // so convert to total capacity
+                let capacity_value = if let Some(unit_size) = asset.unit_size() {
+                    capacity * unit_size.value()
+                } else {
+                    *capacity
+                };
+                (asset, Capacity(capacity_value))
+            })
     }
 
     /// Keys and dual values for commodity balance constraints.
@@ -655,10 +664,22 @@ fn add_capacity_variables(
         );
 
         let current_capacity = asset.capacity().value();
-        let lower = ((1.0 - capacity_margin) * current_capacity).max(0.0);
-        let upper = (1.0 + capacity_margin) * current_capacity;
         let coeff = calculate_capacity_coefficient(asset);
-        let var = problem.add_column(coeff.value(), lower..=upper);
+
+        let var = if let Some(unit_size) = asset.unit_size() {
+            // Divisible asset: capacity variable represents number of units
+            let unit_size_value = unit_size.value();
+            let current_units = current_capacity / unit_size_value;
+            let lower = ((1.0 - capacity_margin) * current_units).max(0.0);
+            let upper = (1.0 + capacity_margin) * current_units;
+            problem.add_integer_column(coeff.value() * unit_size_value, lower..=upper)
+        } else {
+            // Indivisible asset: capacity variable represents total capacity
+            let lower = ((1.0 - capacity_margin) * current_capacity).max(0.0);
+            let upper = (1.0 + capacity_margin) * current_capacity;
+            problem.add_column(coeff.value(), lower..=upper)
+        };
+
         let existing = variables.insert(asset.clone(), var).is_some();
         assert!(!existing, "Duplicate entry for var");
     }

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -230,8 +230,15 @@ where
         if let Some(&capacity_var) = capacity_vars.get(asset) {
             // Asset with flexible capacity
             for (ts_selection, limits) in asset.iter_activity_per_capacity_limits() {
-                let upper_limit = limits.end().value();
-                let lower_limit = limits.start().value();
+                let mut upper_limit = limits.end().value();
+                let mut lower_limit = limits.start().value();
+
+                // If the asset is divisible, the capacity variable represents number of units,
+                // so we need to multiply the per-capacity limits by the unit size.
+                if let Some(unit_size) = asset.unit_size() {
+                    upper_limit *= unit_size.value();
+                    lower_limit *= unit_size.value();
+                }
 
                 // Collect capacity and activity terms
                 // We have a single capacity term, and activity terms for all time slices in the selection


### PR DESCRIPTION
# Description

Following up from #1075 we can also do the same for the dispatch where we have capacity variables for assets selected as part of a circularity. This affects dispatch that we run after asset selection, but _before_ divisible assets are split into their individual units. The point of this is to allow capacities to change slightly to balance out any demand/supply mismatches that occur as a result of a circularity. Whereas before, this could set capacities to invalid values not a multiple of unit size, capacities are now restricted to a multiple of unit size.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
