### PR TITLE
Limit appraisal to one unit per group

### DIFF
--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -720,11 +720,10 @@ fn select_best_assets(
             });
 
             // Skip any assets from groups we've already seen
-            if let Some(group_id) = asset.group_id() {
-                if seen_groups.contains(&group_id) {
-                    continue;
-                }
-                seen_groups.insert(group_id);
+            if let Some(group_id) = asset.group_id()
+                && !seen_groups.insert(group_id)
+            {
+                continue;
             }
 
             let output = appraise_investment(


### PR DESCRIPTION
A very quick and easy way to get considerable speedups in models with divisible assets. Since we know that all assets with the same `group_id` will be identical (as of #1070), there's no need to appraise more than one each appraisal round. 

Did a quick test with the simple example setting `unit_size` of `RGASBR` to 10, and this speeds things up from ~100 seconds to ~15. Pretty good, but I don't think this is a closed problem yet:
- #1043 - we're still running dispatch over each individual unit which is wasteful and clogging up the output files
- We're only retaining a maximum of one unit per appraisal round, so if there are lots of small units then we'll need many appraisal rounds to retain sufficient capacity. My impression from https://github.com/EnergySystemsModellingLab/MUSE2/issues/911#issue-3508578242 is that we ideally want to appraise/retain a variable number of units each round up to the tranche size (i.e. appraising multi-unit assets with a varaible capacity, like we do for new assets)

I tried coming up with an approach that avoids having to divide divisible assets into distinct objects, which I think would make the above two points easier to address, but it became a bit of a mess. Mostly because of the need to track the mothball year and decommission year for each unit, and because in many places the code relies on the fact that an `Asset` object has a single state (commissioned, decommissioned, mothballed etc.). So maybe we shouldn't go down that route after all...

I think point 1 above could be solved by creating a temporary "super asset" out of each asset group when we do the dispatch (or storing the pre-division parent asset somewhere, which we throw away). Not really sure about point 2 but I'll keep thinking... ideas welcome!
