### PR TITLE
Add section on flexible assets to docs

### DIFF
--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -275,7 +275,7 @@ in common units, derived from the output and efficiency).
   output parameter:
 
   \\[
-    \sum_{c \in \mathbf{C}^{eff\\_out}\_a} OutputSpec[a,c,r,t] \cdot factor\_{CU}[c]
+    \sum\_{c \in \mathbf{C}^{eff\\_out}\_a} OutputSpec[a,c,r,t] \cdot factor\_{CU}[c]
       = ActualTotalEffOutputCU[a,r,t]
   \\]
 


### PR DESCRIPTION
# Description

I've copied over the section about dispatch for flexible assets from [Adam's LaTeX document](https://www.overleaf.com/project/682d92581b6f0e83d44ac53d). I converted it using `pandoc`, then had to do some fiddling to get the equations to format properly (sadly, this is a bit of an issue with `mdbook`).

While I was at it, I renumbered the sections and removed references to sections which don't exist in our docs (just in the LaTeX version).

I've only skimmed the content, but I figure we can revisit it when we actually start implementing #360. The content might need to change as we go, but I thought it was a good idea to have this as a starting point for now.

Closes #1104.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
