### PR TITLE
update appraisal documentation

### DIFF
--- a/docs/model/investment.md
+++ b/docs/model/investment.md
@@ -75,7 +75,7 @@ providing investment and dynamic decommissioning decisions.
 
 #### Coefficients of activity
 
-- Calculate net revenue per unit of activity \\(AC_{t}^{NPV} \\) (Tool A):
+- Calculate net revenue per unit of activity \\(AC\_{t}^{NPV} \\) (Tool A):
   \\[
     \begin{aligned}
           AC\_{t}^{NPV} = &-cost\_{\text{var}}[t] \\\\
@@ -86,16 +86,16 @@ providing investment and dynamic decommissioning decisions.
     \end{aligned}
   \\]
   \\(\varepsilon \approx 1\times 10^{-14}\\) is added to
-  each \\(AC_{t}^{NPV} \\) to allow assets which are breakeven (or very close to breakeven) to be
+  each \\(AC\_{t}^{NPV} \\) to allow assets which are breakeven (or very close to breakeven) to be
   dispatched.
 
-- Calculate cost per unit of activity \\( AC_{t}^{LCOX} \\) (Tool B). Note that the commodity
-  of interest (primary output \\( c_{primary} \\)) is excluded from the price term:
+- Calculate cost per unit of activity \\( AC\_{t}^{LCOX} \\) (Tool B). Note that the commodity
+  of interest (primary output \\( c\_{primary} \\)) is excluded from the price term:
   \\[
     \begin{aligned}
           AC\_{t}^{LCOX} = & \quad cost\_{\text{var}}[t] \\\\
             &+ \text{SPCF}\_{t} \\\\
-            &- \sum\_{c \neq c_{primary}} \Big( output\_{\text{coeff}}[c] - input\_{\text{coeff}}
+            &- \sum\_{c \neq c\_{primary}} \Big( output\_{\text{coeff}}[c] - input\_{\text{coeff}}
             [c] \Big)
               \cdot \lambda\_{c,r,t} \\\\
     \end{aligned}


### PR DESCRIPTION
# Description

I went through the documentation for npv and tried to ensure that it accurately reflects what is done in the code. I think there was a couple of erroneous `-` signs in the docs but please double check. When we choose the best asset using profitability index we used to negate them so that the smallest is best, but this was just to allow us to deal with NPV and LCOX metrics in the same way. When it comes to calculating activity coefficients, I don't see a negation like this in the code, and it makes sense that we would want to maximise annualised revenue rather than minimise it. 

I modified/added a couple of bits to try and make the documentation clearer but let me know what you think:
- Split up the NPV and LCOX activity coefficients into separate expressions, they are very similar but for me the subtle differences make it harder to register what the activity coefficients actually represent.
- Added an example subsection at the end to help the reader understand the different interpretations (maximise profit vs minimise cost). Maybe this should be in it's own file though.

Fixes #1103

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [X] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
