### PR TITLE
add remaining_demand_absolute_tolerance param

### DIFF
--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -54,7 +54,8 @@ properties:
     type: number
     description: |
       Absolute tolerance when checking if remaining demand is close enough to zero in the
-      investment cycle.
+      investment cycle. Changing the value of this parameter is potentially dangerous,
+      so it requires setting `please_give_me_broken_results` to true.
     default: 1e-12
 
 required: [milestone_years]

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -177,13 +177,11 @@ fn check_remaining_demand_absolute_tolerance(
         "remaining_demand_absolute_tolerance must be a finite number greater than or equal to zero"
     );
 
-    // we already checked value is positive, but if they are
-    // increasing it above the default this is potentially dangerous.
     let default_value = default_remaining_demand_absolute_tolerance();
     if !allow_broken_options {
         ensure!(
-            value <= default_value,
-            "Setting a remaining_demand_absolute_tolerance higher than the default value of {:e} \
+            value == default_value,
+            "Setting a remaining_demand_absolute_tolerance different from the default value of {:e} \
              is potentially dangerous, set please_give_me_broken_results to true \
              if you want to allow this.",
             default_value.0
@@ -392,10 +390,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(false, 0.0, true)] // Valid minimum value (exactly zero)
+    #[case(true, 0.0, true)] // Valid minimum value broken options allowed
     #[case(true, 1e-10, true)] // Valid value with broken options allowed
     #[case(true, 1e-15, true)] // Valid value with broken options allowed
-    #[case(false, 1e-15, true)] // Valid value below default, no broken options needed
+    #[case(false, 1e-12, true)] // Valid value same as default, no broken options needed
     #[case(true, 1.0, true)] // Valid larger value with broken options allowed
     #[case(true, f64::MAX, true)] // Valid maximum finite value with broken options allowed
     #[case(true, -1e-10, false)] // Invalid: negative value
@@ -423,10 +421,11 @@ mod tests {
     }
 
     #[rstest]
+    #[case(0.0)] // smaller than default
     #[case(1e-10)] // Larger than default (1e-12)
     #[case(1.0)] // Well above default
     #[case(f64::MAX)] // Maximum finite value
-    fn check_remaining_demand_absolute_tolerance_requires_broken_options_above_default(
+    fn check_remaining_demand_absolute_tolerance_requires_broken_options_if_non_default(
         #[case] value: f64,
     ) {
         let flow = Flow::new(value);
@@ -435,7 +434,7 @@ mod tests {
             result,
             false,
             value,
-            "Setting a remaining_demand_absolute_tolerance higher than the default value \
+            "Setting a remaining_demand_absolute_tolerance different from the default value \
              of 1e-12 is potentially dangerous, set \
              please_give_me_broken_results to true if you want to allow this.",
         );

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -9,7 +9,7 @@ use crate::region::RegionID;
 use crate::simulation::CommodityPrices;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Capacity, Dimensionless, Flow, FlowPerCapacity};
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use indexmap::IndexMap;
 use itertools::{Itertools, chain};
 use log::debug;
@@ -808,11 +808,24 @@ fn select_best_assets(
         // demand.
         // - known issue with the NPV objective
         // (see https://github.com/EnergySystemsModellingLab/MUSE2/issues/716).
-        ensure!(
-            !outputs_for_opts.is_empty(),
-            "No feasible investment options for commodity '{}' after appraisal",
-            &commodity.id
-        );
+        if outputs_for_opts.is_empty() {
+            let remaining_demands: Vec<_> = demand
+                .iter()
+                .filter(|(_, flow)| **flow > Flow(0.0))
+                .map(|(time_slice, flow)| format!("{} : {:e}", time_slice, flow.value()))
+                .collect();
+
+            bail!(
+                "No feasible investment options left for \
+                commodity '{}', region '{}', year '{}', agent '{}' after appraisal.\n\
+                Remaining unmet demand (time_slice : flow):\n{}",
+                &commodity.id,
+                region_id,
+                year,
+                agent.id,
+                remaining_demands.join("\n")
+            );
+        }
 
         // Warn if there are multiple equally good assets
         warn_on_equal_appraisal_outputs(&outputs_for_opts, &agent.id, &commodity.id, region_id);


### PR DESCRIPTION
# Description

This adds a new configurable model parameter demand_tolerance so that model won't fail if the remaining demand is negligible 

Fixes #1115

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [X] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added that prove fix is effective or that feature works
