### PR TITLE
Fix `update-rust-toolchain` workflow

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           persist-credentials: false
       - name: update rust toolchain
-        uses: a-kenji/update-rust-toolchain@v1
+        uses: a-kenji/update-rust-toolchain@v1.1
         with:
           toolchain-path: ./rust-toolchain.toml
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# Description

Bump version of `update-rust-toolchain` GitHub Action to fix #1146. For whatever reason, the version of the Action that is being used is older than v1.1, which contains a fix, even though we were pinning to "v1" before.

Fix by bumping explicitly to v1.1.

Fixes #1146.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
