### PR TITLE
Fix typo in `pre-commit-autoupdate` workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@v5
-      - uses: browniebroke/pre-commit-autoupdate-action@1
+      - uses: browniebroke/pre-commit-autoupdate-action@v1
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# Description

Looks like I made a mistake in the workflow. Oops...

I'm going to merge this directly as it's just a typo fix.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
