### PR TITLE
Fix equal metrics logging

### DIFF
--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -652,7 +652,7 @@ fn get_candidate_assets<'a>(
 }
 
 /// Print debug message if there are multiple equally good outputs
-fn warn_on_equal_appraisal_outputs(
+fn log_on_equal_appraisal_outputs(
     outputs: &[AppraisalOutput],
     agent_id: &AgentID,
     commodity_id: &CommodityID,
@@ -826,7 +826,7 @@ fn select_best_assets(
         }
 
         // Warn if there are multiple equally good assets
-        warn_on_equal_appraisal_outputs(&outputs_for_opts, &agent.id, &commodity.id, region_id);
+        log_on_equal_appraisal_outputs(&outputs_for_opts, &agent.id, &commodity.id, region_id);
 
         let best_output = outputs_for_opts.into_iter().next().unwrap();
 

--- a/src/simulation/investment/appraisal.rs
+++ b/src/simulation/investment/appraisal.rs
@@ -379,8 +379,11 @@ pub fn sort_appraisal_outputs_by_investment_priority(outputs_for_opts: &mut Vec<
 }
 
 /// Counts the number of top appraisal outputs in a sorted slice that are indistinguishable
-/// by both metric and fallback ordering.
+/// by both metric and fallback ordering. Excludes the first element from the count.
 pub fn count_equal_and_best_appraisal_outputs(outputs: &[AppraisalOutput]) -> usize {
+    if outputs.is_empty() {
+        return 0;
+    }
     outputs[1..]
         .iter()
         .take_while(|output| {
@@ -954,5 +957,138 @@ mod tests {
 
         // The invalid output should have been filtered out
         assert_eq!(outputs.len(), 0);
+    }
+
+    /// Tests for counting number of equal metrics using identical assets so only metric values
+    /// affect the count.
+    #[rstest]
+    #[case(vec![5.0], 0, "single_element")]
+    #[case(vec![5.0, 5.0, 5.0], 2, "all_equal_returns_len_minus_one")]
+    #[case(vec![1.0, 2.0, 3.0], 0, "none_equal_to_best")]
+    #[case(vec![5.0, 5.0, 9.0], 1, "partial_equality_stops_at_first_difference")]
+    #[case(vec![5.0, 5.0, 9.0, 5.0], 1, "equality_does_not_resume_after_gap")]
+    fn count_equal_best_lcox_metric(
+        asset: Asset,
+        #[case] metric_values: Vec<f64>,
+        #[case] expected_count: usize,
+        #[case] description: &str,
+    ) {
+        let metrics: Vec<Box<dyn MetricTrait>> = metric_values
+            .into_iter()
+            .map(|v| Box::new(LCOXMetric::new(MoneyPerActivity(v))) as Box<dyn MetricTrait>)
+            .collect();
+
+        let outputs =
+            appraisal_outputs_with_investment_priority_invariant_to_assets(metrics, &asset);
+
+        assert_eq!(
+            count_equal_and_best_appraisal_outputs(&outputs),
+            expected_count,
+            "Failed for case: {description}"
+        );
+    }
+
+    /// Empty slice count should return 0.
+    #[test]
+    fn count_equal_best_empty_slice_returns_zero() {
+        let outputs: Vec<AppraisalOutput> = vec![];
+        assert_eq!(count_equal_and_best_appraisal_outputs(&outputs), 0);
+    }
+
+    /// Equal metrics but differing asset fallback (commissioned vs. candidate) →
+    /// outputs are distinguishable, so count should be 0.
+    #[rstest]
+    fn count_equal_best_equal_metric_different_fallback_returns_zero(
+        process: Process,
+        region_id: RegionID,
+        agent_id: AgentID,
+    ) {
+        let process_rc = Rc::new(process);
+        let capacity = Capacity(10.0);
+
+        let commissioned = Asset::new_commissioned(
+            agent_id.clone(),
+            process_rc.clone(),
+            region_id.clone(),
+            capacity,
+            2020,
+        )
+        .unwrap();
+        let candidate =
+            Asset::new_candidate(process_rc.clone(), region_id.clone(), capacity, 2020).unwrap();
+
+        let metric_value = MoneyPerActivity(5.0);
+        let outputs = appraisal_outputs(
+            vec![commissioned, candidate],
+            vec![
+                Box::new(LCOXMetric::new(metric_value)),
+                Box::new(LCOXMetric::new(metric_value)),
+            ],
+        );
+
+        assert_eq!(count_equal_and_best_appraisal_outputs(&outputs), 0);
+    }
+
+    /// Equal metrics and equal asset fallback (same commissioned status and commission year) →
+    /// the second element is indistinguishable, so count should be 1.
+    #[rstest]
+    fn count_equal_best_equal_metric_and_equal_fallback_returns_one(
+        process: Process,
+        region_id: RegionID,
+        agent_id: AgentID,
+    ) {
+        let process_rc = Rc::new(process);
+        let capacity = Capacity(10.0);
+        let year = 2020;
+
+        let asset1 = Asset::new_commissioned(
+            agent_id.clone(),
+            process_rc.clone(),
+            region_id.clone(),
+            capacity,
+            year,
+        )
+        .unwrap();
+        let asset2 = Asset::new_commissioned(
+            agent_id.clone(),
+            process_rc.clone(),
+            region_id.clone(),
+            capacity,
+            year,
+        )
+        .unwrap();
+
+        let metric_value = MoneyPerActivity(5.0);
+        let outputs = appraisal_outputs(
+            vec![asset1, asset2],
+            vec![
+                Box::new(LCOXMetric::new(metric_value)),
+                Box::new(LCOXMetric::new(metric_value)),
+            ],
+        );
+
+        assert_eq!(count_equal_and_best_appraisal_outputs(&outputs), 1);
+    }
+
+    /// Equal NPV metrics and identical assets → second element should be counted.
+    #[rstest]
+    fn count_equal_best_equal_npv_metrics(asset: Asset) {
+        let make_npv = |surplus: f64, fixed_cost: f64| {
+            Box::new(NPVMetric::new(ProfitabilityIndex {
+                total_annualised_surplus: Money(surplus),
+                annualised_fixed_cost: Money(fixed_cost),
+            })) as Box<dyn MetricTrait>
+        };
+
+        let metrics = vec![
+            make_npv(200.0, 100.0),
+            make_npv(200.0, 100.0), // Equal to best
+            make_npv(100.0, 100.0), // Worse
+        ];
+
+        let outputs =
+            appraisal_outputs_with_investment_priority_invariant_to_assets(metrics, &asset);
+
+        assert_eq!(count_equal_and_best_appraisal_outputs(&outputs), 1);
     }
 }


### PR DESCRIPTION
# Description

Add the fallback check before we report the nondeterministic behaviour of two metrics being equal to minimise unnecessary logs

Fixes #1133

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
