### PR TITLE
Fix `pre-commit` autoupdate workflow by forking one of the hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       - id: codespell
         args: [--ignore-words, .codespell_ignore.txt]
         exclude: \.svg$
-  - repo: https://github.com/citation-file-format/cffconvert
-    rev: b6045d78aac9e02b039703b030588d54d53262ac
+  - repo: https://github.com/EnergySystemsModellingLab/cffconvert
+    rev: 2.1.0
     hooks:
       - id: validate-cff


### PR DESCRIPTION
# Description

One of the hooks we are using appears to be unmaintained ([`cffconvert`]) and there is unfortunately an issue that means that `pre-commit autoupdate` falls over when it hits this repo. There doesn't appear to be any way to get the GitHub Action we are using to ignore this repo either.

We could just drop the hook, but I think it's useful, so instead I forked it here and made a new release: https://github.com/EnergySystemsModellingLab/cffconvert

Note that I didn't change any code; just making the release is enough to fix the problem.

We can always change back to using the upstream version if someone else takes over maintainership (though the last release was in 2021...).

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
