### PR TITLE
Fix: Ensure Rust toolchain is present for `pre-commit-autoupdate` workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: browniebroke/pre-commit-autoupdate-action@main
       - uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
# Description

Apologies for all the `pre-commit`-related faffing... it seems the last fix wasn't actually sufficient. I've tested that the workflow runs in this branch now (minus actually getting it to open a PR), so hopefully this is the last one :smile:.

It seems the `pre-commit` autoupdate Action also runs `pre-commit` after updating, so it needs a Rust toolchain for, e.g., the `cargo fmt` hook.

Fix by ensuring the Rust toolchain is present for this workflow.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
