### PR TITLE
Group dependabot dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      rust:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
# Description

It seems you can group the PRs you get for dependabot version bumps. Let's do this to reduce the number of PRs opened by bots and make the commit history a bit tidier.

Closes #1144.