### PR TITLE
Temporarily disable broken `markdownlint-cli` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,10 +30,12 @@ repos:
         args: ["--schemafile", "schemas/settings.yaml"]
         files: /settings\.toml$
         types_or: [toml]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
-    hooks:
-      - id: markdownlint-fix
+  # Currently broken on fresh installs:
+  #   https://github.com/igorshubovych/markdownlint-cli/issues/605
+  # - repo: https://github.com/igorshubovych/markdownlint-cli
+  #   rev: v0.48.0
+  #   hooks:
+  #     - id: markdownlint-fix
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"
     hooks:


### PR DESCRIPTION
# Description

The `markdownlint-cli` hook is currently broken due to an upstream bug. Let's just disable it for now as it's causing CI failures. We can re-enable it later and re-run it over any markdown files we've changed.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
