### PR TITLE
Re-enable `markdownlint-cli` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,10 @@ repos:
         args: ["--schemafile", "schemas/settings.yaml"]
         files: /settings\.toml$
         types_or: [toml]
-  # Currently broken on fresh installs:
-  #   https://github.com/igorshubovych/markdownlint-cli/issues/605
-  # - repo: https://github.com/igorshubovych/markdownlint-cli
-  #   rev: v0.48.0
-  #   hooks:
-  #     - id: markdownlint-fix
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint-fix
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"
     hooks:


### PR DESCRIPTION
# Description

It seems the upstream problem has been resolved (see https://github.com/igorshubovych/markdownlint-cli/issues/605), so we can now re-enable the `markdownlint-cli` hook. If I'd known it was going to happen this quickly I wouldn't have reverted it in the first place!

Apologies about the silly quantity of infra-related PRs this week...