### PR TITLE
fix(output): include group_id column in debug_dispatch_assets.csv

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -166,12 +166,18 @@ struct CommodityPriceRow {
     price: MoneyPerFlow,
 }
 
-/// Represents the activity in a row of the activity CSV file
+/// Represents the activity in a row of the activity CSV file.
+///
+/// Dispatch can run at the parent-asset level (and also include candidates),
+/// neither of which has a per-instance `asset_id`, so we also record the
+/// `AssetGroupID` from `AssetRef::group_id()`. That gives a reader a stable
+/// key to distinguish rows that share `asset_id = None`. See #1243.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct ActivityRow {
     milestone_year: u32,
     run_description: String,
     asset_id: Option<AssetID>,
+    group_id: Option<AssetGroupID>,
     process_id: ProcessID,
     region_id: RegionID,
     time_slice: TimeSliceID,
@@ -356,6 +362,7 @@ impl DebugDataWriter {
                 milestone_year,
                 run_description: self.with_context(run_description),
                 asset_id: asset.id(),
+                group_id: asset.group_id(),
                 process_id: asset.process_id().clone(),
                 region_id: asset.region_id().clone(),
                 time_slice: time_slice.clone(),
@@ -874,6 +881,7 @@ mod tests {
             milestone_year,
             run_description,
             asset_id: asset.id(),
+            group_id: asset.group_id(),
             process_id: asset.process_id().clone(),
             region_id: asset.region_id().clone(),
             time_slice,
@@ -918,6 +926,7 @@ mod tests {
             milestone_year,
             run_description,
             asset_id: asset.id(),
+            group_id: asset.group_id(),
             process_id: asset.process_id().clone(),
             region_id: asset.region_id().clone(),
             time_slice,

--- a/tests/data/simple/debug_dispatch_assets.csv
+++ b/tests/data/simple/debug_dispatch_assets.csv
@@ -1,1697 +1,1697 @@
-milestone_year,run_description,asset_id,process_id,region_id,time_slice,activity,activity_dual,column_dual
-2020,final without candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,winter.day,151.10360181069296,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,peak.peak,58.67582562255717,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,summer.evening,0.16861964795988574,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
-2020,final without candidates,0,GASDRV,GBR,autumn.evening,163.3883025525992,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,winter.day,146.06260193273093,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,peak.peak,57.11282996783967,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,summer.evening,0.1605901409141769,-0.0,0.0
-2020,final without candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,autumn.peak,0.0,-0.0,2.220446049250313e-16
-2020,final without candidates,1,GASPRC,GBR,autumn.evening,155.60790719295161,-0.0,0.0
-2020,final without candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2020,final without candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2020,final without candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,summer.day,2.9055524196533997,-0.0,0.0
-2020,final without candidates,2,WNDFRM,GBR,summer.peak,0.9567924409494001,-0.0,0.0
-2020,final without candidates,2,WNDFRM,GBR,summer.evening,0.7124084843502,-0.0,0.0
-2020,final without candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2020,final without candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2020,final without candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2020,final without candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2020,final without candidates,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2020,final without candidates,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2020,final without candidates,3,GASCGT,GBR,summer.night,0.1070600939427846,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2020,final without candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2020,final without candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2020,final without candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2020,final without candidates,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2020,final without candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2020,final without candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2020,final without candidates,4,RGASBR,GBR,winter.night,31.576407455399995,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,winter.day,168.06063872919998,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,winter.peak,90.62498238363999,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,winter.evening,54.453452143199996,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,peak.night,16.975889145204558,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,peak.day,71.46451164847998,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,peak.peak,50.688067492440005,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,peak.evening,23.428970354436764,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2020,final without candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2020,final without candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2020,final without candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2020,final without candidates,4,RGASBR,GBR,autumn.night,7.920835851889748,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,autumn.day,49.29932468263999,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,autumn.peak,38.591500913875095,-0.0,0.0
-2020,final without candidates,4,RGASBR,GBR,autumn.evening,14.815369859166085,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,summer.night,5.28455066108,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,summer.day,8.80470430198,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,summer.peak,2.89937103318,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,summer.evening,2.1588135889399998,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2020,final without candidates,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2020,final without candidates,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,winter.day,151.1029469806843,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,peak.peak,58.67429209279453,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,summer.evening,0.16855462584153408,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
-2020,final with candidates,0,GASDRV,GBR,autumn.evening,163.38648438726446,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,winter.day,146.06195328510356,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,peak.peak,57.11139327282777,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,summer.evening,0.1605032150870753,-0.0,0.0
-2020,final with candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,autumn.peak,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,1,GASPRC,GBR,autumn.evening,155.60615060691842,-0.0,0.0
-2020,final with candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2020,final with candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2020,final with candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,summer.day,2.90543744625399,-0.0,0.0
-2020,final with candidates,2,WNDFRM,GBR,summer.peak,0.9567587035813536,-0.0,0.0
-2020,final with candidates,2,WNDFRM,GBR,summer.evening,0.7123818495857518,-0.0,0.0
-2020,final with candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2020,final with candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2020,final with candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2020,final with candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2020,final with candidates,3,GASCGT,GBR,winter.night,5.188866559524632,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,winter.day,6.67342905326312,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,winter.peak,2.153494936918241,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,winter.evening,2.9299962478971167,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2020,final with candidates,3,GASCGT,GBR,peak.day,7.377793253082274,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,peak.peak,2.3471047442443087,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2020,final with candidates,3,GASCGT,GBR,summer.night,0.10701881005811686,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2020,final with candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2020,final with candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2020,final with candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2020,final with candidates,3,GASCGT,GBR,autumn.day,7.747083429990085,-0.0,0.0
-2020,final with candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2020,final with candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2020,final with candidates,4,RGASBR,GBR,winter.night,31.5763928720666,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,winter.day,168.06061789586659,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,winter.peak,90.62497613363998,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,winter.evening,54.4534438098666,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,peak.night,16.974967026169374,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,peak.day,71.46449081514659,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,peak.peak,50.68806124244001,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,peak.evening,23.428436126811356,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2020,final with candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2020,final with candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2020,final with candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2020,final with candidates,4,RGASBR,GBR,autumn.night,7.919886829052455,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,autumn.day,49.2993038493066,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,autumn.peak,38.591080737902736,-0.0,0.0
-2020,final with candidates,4,RGASBR,GBR,autumn.evening,14.814822179639375,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,summer.night,5.2845433694133,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,summer.day,8.804693885313299,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,summer.peak,2.89936790818,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,summer.evening,2.1588094222732996,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2020,final with candidates,5,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
-2020,final with candidates,5,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,winter.day,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,winter.peak,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,winter.evening,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
-2020,final with candidates,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,,GASPRC,GBR,peak.peak,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,,GASPRC,GBR,peak.evening,0.0,-0.0,2.220446049250313e-16
-2020,final with candidates,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.86223303030303,0.0
-2020,final with candidates,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.86223303030303,0.0
-2020,final with candidates,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
-2020,final with candidates,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
-2020,final with candidates,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
-2020,final with candidates,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.86223303030303,0.0
-2020,final with candidates,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593308999999999,0.0
-2020,final with candidates,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.86223303030303,0.0
-2020,final with candidates,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.86223303030303,0.0
-2020,final with candidates,,GASCGT,GBR,winter.night,0.00022997916771800003,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.26892403030303,0.0
-2020,final with candidates,,GASCGT,GBR,peak.day,0.0,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,peak.peak,0.0,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,peak.evening,0.000131416667718,-9.26892403030303,0.0
-2020,final with candidates,,GASCGT,GBR,summer.night,0.0,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2020,final with candidates,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2020,final with candidates,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2020,final with candidates,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.26892403030303,0.0
-2020,final with candidates,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
-2020,final with candidates,,GASCGT,GBR,autumn.peak,0.0000985625,-9.26892403030303,0.0
-2020,final with candidates,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.26892403030303,0.0
-2020,final with candidates,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2020,final with candidates,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2020,final with candidates,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2020,final with candidates,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2020,final with candidates,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,winter.peak,3.125e-6,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,peak.peak,3.125e-6,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.05874493,0.0
-2020,final with candidates,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2020,final with candidates,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,peak.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,autumn.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,5,RELCHP,GBR,autumn.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,winter.night,12.179665608293831,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,winter.day,153.60894769845382,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,winter.evening,47.29569147973385,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,peak.night,21.192683870313836,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,peak.day,46.59679621773381,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,peak.peak,46.3816611088,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,peak.evening,27.63966804055385,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,autumn.night,12.342934260933838,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,autumn.day,22.041522451893826,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,autumn.peak,44.87284439557999,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,4,RGASBR,GBR,autumn.evening,18.688115346973845,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,winter.night,12.179665608293831,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,winter.day,153.60894769845382,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,winter.evening,47.29569147973385,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,peak.day,46.59679621773381,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,peak.peak,46.3816611088,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,peak.evening,12.735822890970612,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,autumn.day,22.041522451893826,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,autumn.peak,32.92160763023509,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,4,RGASBR,GBR,autumn.evening,3.250923295699936,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,peak.night,21.564185045204564,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,autumn.night,11.647741651889753,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593308999999999
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593308999999999
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593308999999999
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,ironing out iteration 0; post ELCTRI|GBR investment,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,peak.evening,27.562423254436766,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,4,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.night,11.64774165188975,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303031,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303031,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303031,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303031,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303031,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.day,201.2090417177309,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.peak,89.0070195528397,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
-2030,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,peak.evening,27.562423254436766,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,4,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.night,11.64774165188975,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.day,201.20904171773094,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.peak,89.0070195528397,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.peak,92.16472468680718,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.evening,0.464792220809886,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
-2030,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,peak.evening,27.562423254436766,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,4,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.night,11.64774165188975,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,ironing out iteration 0; final without candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,ironing out iteration 0; final without candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.day,201.20904171773094,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.peak,89.0070195528397,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.peak,92.16472468680718,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.evening,0.464792220809886,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
-2030,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,summer.night,5.8543799694133005,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,summer.day,9.7541109853133,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,summer.peak,3.2120090081800003,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,summer.evening,2.3915957222733,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,5,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,winter.night,12.179651024960432,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,winter.day,153.60892686512042,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,winter.peak,90.62499374999999,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,winter.evening,47.29568314640045,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,peak.day,46.596775384400416,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,peak.peak,46.381654858800005,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,peak.evening,12.735288663345202,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,autumn.day,22.041501618560424,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,autumn.peak,32.92118745426273,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,4,RGASBR,GBR,autumn.evening,3.2503756161732227,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.night,21.56326292616938,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.night,11.646792629052456,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,summer.day,3.2187450892539897,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,summer.peak,1.059930266581354,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,summer.evening,0.7892013285857518,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,winter.night,5.1890965386923495,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,winter.day,6.67342905326312,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,winter.peak,2.153494936918241,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,winter.evening,2.9299962478971167,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,peak.day,7.3774647114145555,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,peak.peak,2.3470061817443093,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,summer.night,0.294834908890399,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,autumn.day,7.747083429990085,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.day,201.2083930701036,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.peak,89.00558285782782,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.evening,0.4425973320871755,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.peak,23.602386596208433,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.day,209.00668375493427,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.peak,92.1631911570446,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.evening,0.4647271986915343,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.peak,23.48988633234447,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.peak,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.evening,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.evening,0.0,-0.0,2.220446049250313e-16
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593308999999999,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.86223303030303,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.night,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.day,0.00032854166771800004,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.peak,0.0000985625,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.evening,0.000131416667718,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.night,0.00022997916771800003,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.peak,0.0000985625,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.26892403030303,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.peak,3.125e-6,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.peak,3.125e-6,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.05874493,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,peak.peak,92.16472468680718,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,summer.evening,0.464792220809886,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
-2030,final without candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,winter.day,201.2090417177309,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,peak.peak,89.00701955283967,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2030,final without candidates,1,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
-2030,final without candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,final without candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,final without candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,final without candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
-2030,final without candidates,2,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
-2030,final without candidates,2,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
-2030,final without candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,final without candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,final without candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,final without candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,final without candidates,3,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,final without candidates,3,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,final without candidates,3,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,final without candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,final without candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,final without candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,final without candidates,3,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
-2030,final without candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,final without candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,final without candidates,4,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,peak.evening,27.562423254436766,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,final without candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,final without candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,final without candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,final without candidates,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
-2030,final without candidates,4,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,final without candidates,5,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
-2030,final without candidates,5,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,final without candidates,6,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,final without candidates,6,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,final without candidates,6,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,final without candidates,6,RGASBR,GBR,autumn.night,11.64774165188975,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2030,final without candidates,6,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,winter.day,209.00670875493444,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,peak.peak,92.16319115704454,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,summer.evening,0.46472719869153434,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,autumn.peak,23.48988633234447,-0.0,0.0
-2030,final with candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,winter.day,201.20839307010365,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,peak.peak,89.00558285782776,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,summer.evening,0.4425723320870756,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,autumn.day,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,1,GASPRC,GBR,autumn.peak,23.602386596208447,-0.0,0.0
-2030,final with candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2030,final with candidates,2,WNDFRM,GBR,winter.night,4.435312795545212,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,winter.day,7.075379933645912,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
-2030,final with candidates,2,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
-2030,final with candidates,2,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,summer.day,3.21874508925399,-0.0,0.0
-2030,final with candidates,2,WNDFRM,GBR,summer.peak,1.0599302665813537,-0.0,0.0
-2030,final with candidates,2,WNDFRM,GBR,summer.evening,0.7892013285857519,-0.0,0.0
-2030,final with candidates,2,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
-2030,final with candidates,2,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593308999999999,0.0
-2030,final with candidates,2,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
-2030,final with candidates,2,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
-2030,final with candidates,3,GASCGT,GBR,winter.night,5.188866559524632,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,winter.day,6.67342905326312,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,winter.peak,2.153494936918241,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,winter.evening,2.9299962478971167,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
-2030,final with candidates,3,GASCGT,GBR,peak.day,7.377793253082274,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,peak.peak,2.3471047442443087,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,final with candidates,3,GASCGT,GBR,summer.night,0.29506488805811704,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,final with candidates,3,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,final with candidates,3,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,final with candidates,3,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
-2030,final with candidates,3,GASCGT,GBR,autumn.day,7.747083429990085,-0.0,0.0
-2030,final with candidates,3,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
-2030,final with candidates,3,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
-2030,final with candidates,4,RGASBR,GBR,winter.night,12.179651024960421,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,winter.day,153.60892686512045,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,winter.peak,90.62499374999999,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,winter.evening,47.29568314640045,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,peak.day,46.596775384400416,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,peak.peak,46.38165485879999,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,peak.evening,12.735288663345202,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,final with candidates,4,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,final with candidates,4,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,final with candidates,4,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,final with candidates,4,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,autumn.day,22.04150161856043,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,autumn.peak,32.92118745426273,-0.0,0.0
-2030,final with candidates,4,RGASBR,GBR,autumn.evening,3.2503756161732227,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,winter.night,29.165208466660005,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,winter.day,41.664583466660005,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,winter.peak,12.499375,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,winter.evening,16.66583346666,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,peak.day,41.664583466660005,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,peak.peak,12.499375,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,summer.night,5.8543799694133005,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,summer.day,9.7541109853133,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,summer.peak,3.2120090081800003,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,summer.evening,2.3915957222733,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,autumn.day,41.664583466660005,-3.05874493,0.0
-2030,final with candidates,5,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
-2030,final with candidates,5,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,peak.night,21.563262926169372,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,final with candidates,6,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,final with candidates,6,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,final with candidates,6,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,final with candidates,6,RGASBR,GBR,autumn.night,11.646792629052456,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2030,final with candidates,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,winter.day,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,winter.peak,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,winter.evening,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
-2030,final with candidates,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,,GASPRC,GBR,peak.peak,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,,GASPRC,GBR,peak.evening,0.0,-0.0,2.220446049250313e-16
-2030,final with candidates,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.86223303030303,0.0
-2030,final with candidates,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.86223303030303,0.0
-2030,final with candidates,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
-2030,final with candidates,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
-2030,final with candidates,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
-2030,final with candidates,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.86223303030303,0.0
-2030,final with candidates,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593308999999999,0.0
-2030,final with candidates,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.86223303030303,0.0
-2030,final with candidates,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.86223303030303,0.0
-2030,final with candidates,,GASCGT,GBR,winter.night,0.00022997916771800003,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.26892403030303,0.0
-2030,final with candidates,,GASCGT,GBR,peak.day,0.0,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,peak.peak,0.0,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,peak.evening,0.000131416667718,-9.26892403030303,0.0
-2030,final with candidates,,GASCGT,GBR,summer.night,0.0,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2030,final with candidates,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2030,final with candidates,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2030,final with candidates,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.26892403030303,0.0
-2030,final with candidates,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
-2030,final with candidates,,GASCGT,GBR,autumn.peak,0.0000985625,-9.26892403030303,0.0
-2030,final with candidates,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.26892403030303,0.0
-2030,final with candidates,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
-2030,final with candidates,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
-2030,final with candidates,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
-2030,final with candidates,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
-2030,final with candidates,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,winter.peak,3.125e-6,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,peak.peak,3.125e-6,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.05874493,0.0
-2030,final with candidates,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2030,final with candidates,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,6,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.night,73.84123332206,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.day,254.95484159586002,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,winter.evening,86.45696500986001,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.night,51.727530317420005,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.day,137.52666571514,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.peak,76.81453009244001,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,peak.evening,46.59972130402001,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.night,42.016390608040005,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.day,110.58130514930001,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.peak,61.44285147922,-0.0,0.0
-2040,ironing out iteration 0; post RSHEAT|GBR investment,,RGASBR,GBR,autumn.evening,36.77686951044,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASNAT|GBR investment,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.day,360.9639698231196,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.day,85.71569060312169,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,summer.evening,28.106738155604855,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.day,11.030571054582538,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; post GASPRD|GBR investment,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.day,360.9639698231196,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.day,85.71569060312169,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,summer.evening,28.106738155604855,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.day,11.030571054582538,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final without candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,winter.peak,11.119943933640016,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.night,47.89467548328714,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.day,217.88833044844714,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.evening,71.63036047972716,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.night,25.780972478647133,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.day,100.46015456772713,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.peak,65.69457678379999,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.evening,31.773116773887153,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.night,6.424209277746601,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.day,10.7035176686466,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.peak,3.5246469831800002,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.evening,2.6243778556065998,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.night,16.069832769267133,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.day,73.51479400188713,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.peak,50.32289817057999,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.evening,21.950264980307146,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.day,345.9295903374229,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.day,83.78837203266289,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,summer.evening,26.76826830295678,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.day,12.659661748339765,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.day,360.96391463561946,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.day,85.71566041562158,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,summer.evening,28.106682968104625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.day,11.030515867082215,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,winter.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,peak.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASDRV,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.day,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.peak,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,winter.evening,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.day,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.peak,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,peak.evening,0.0,-0.0,2.220446049250313e-16
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.night,2.406250011e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.day,3.4375000110000007e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.peak,1.03125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,winter.evening,1.3750000110000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.night,2.406250011e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.day,3.4375000110000007e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.peak,1.03125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,peak.evening,1.3750000110000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.night,2.406250011e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.day,3.4375000110000007e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.peak,1.03125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,summer.evening,1.3750000110000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.night,2.406250011e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.day,3.4375000110000007e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.peak,1.03125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,WNDFRM,GBR,autumn.evening,1.3750000110000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.night,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.day,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.peak,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,winter.evening,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.night,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.day,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.peak,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,peak.evening,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.night,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.night,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.day,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.peak,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,GASCGT,GBR,autumn.evening,0.0,-0.0,7.593309
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.day,0.000010416666700000001,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.peak,3.125e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,summer.evening,4.1666667e-6,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.night,7.291666700000001e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.day,0.000010416666700000001,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.peak,3.125e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,winter.evening,4.1666667e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.night,7.291666700000001e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.day,0.000010416666700000001,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.peak,3.125e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,peak.evening,4.1666667e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.night,7.291666700000001e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.day,0.000010416666700000001,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.peak,3.125e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,summer.evening,4.1666667e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.day,0.000010416666700000001,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.peak,3.125e-6,-5.5645369,0.0
-2040,ironing out iteration 0; final with candidates,,RELCHP,GBR,autumn.evening,4.1666667e-6,-5.5645369,0.0
-2040,final without candidates,0,GASDRV,GBR,winter.night,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,winter.day,360.96396982311984,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,peak.night,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,peak.day,85.71569060312174,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,summer.night,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,summer.day,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,summer.evening,28.106738155604855,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,autumn.day,11.030571054582595,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
-2040,final without candidates,0,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,winter.day,70.14930532671303,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,peak.night,0.0,-0.0,2.220446049250313e-16
-2040,final without candidates,1,GASPRC,GBR,peak.day,83.78840078266308,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,summer.night,0.0,-0.0,2.220446049250313e-16
-2040,final without candidates,1,GASPRC,GBR,summer.day,0.0,-0.0,2.220446049250313e-16
-2040,final without candidates,1,GASPRC,GBR,summer.peak,0.0,-0.0,2.220446049250313e-16
-2040,final without candidates,1,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,autumn.night,0.0,-0.0,2.220446049250313e-16
-2040,final without candidates,1,GASPRC,GBR,autumn.day,12.659715498340063,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
-2040,final without candidates,1,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,summer.night,0.0,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,summer.day,0.0,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
-2040,final without candidates,6,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
-2040,final without candidates,7,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
+milestone_year,run_description,asset_id,group_id,process_id,region_id,time_slice,activity,activity_dual,column_dual
+2020,final without candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,winter.day,151.10360181069285,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,peak.peak,58.67582562255714,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,summer.evening,0.16861964795988577,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
+2020,final without candidates,0,,GASDRV,GBR,autumn.evening,163.3883025525992,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,winter.day,146.06260193273081,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,peak.peak,57.11282996783967,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,summer.evening,0.16059014091417692,-0.0,0.0
+2020,final without candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,autumn.peak,0.0,-0.0,-2.220446049250313e-16
+2020,final without candidates,1,,GASPRC,GBR,autumn.evening,155.60790719295161,-0.0,0.0
+2020,final without candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2020,final without candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2020,final without candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,summer.day,2.9055524196533997,-0.0,0.0
+2020,final without candidates,2,,WNDFRM,GBR,summer.peak,0.9567924409494001,-0.0,0.0
+2020,final without candidates,2,,WNDFRM,GBR,summer.evening,0.7124084843502,-0.0,0.0
+2020,final without candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2020,final without candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2020,final without candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2020,final without candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2020,final without candidates,3,,GASCGT,GBR,winter.night,5.18920599845259,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,winter.day,6.673932610351891,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,winter.evening,2.930059684157267,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2020,final without candidates,3,,GASCGT,GBR,peak.day,7.377950511993824,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2020,final without candidates,3,,GASCGT,GBR,summer.night,0.10706009394278461,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2020,final without candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2020,final without candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2020,final without candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2020,final without candidates,3,,GASCGT,GBR,autumn.day,7.7475599084019136,-0.0,0.0
+2020,final without candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2020,final without candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2020,final without candidates,4,,RGASBR,GBR,winter.night,31.576407455399995,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,winter.day,168.06063872919998,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,winter.peak,90.62498238363999,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,winter.evening,54.453452143199996,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,peak.night,16.975889145204558,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,peak.day,71.46451164847998,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,peak.peak,50.688067492440005,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,peak.evening,23.428970354436764,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2020,final without candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2020,final without candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2020,final without candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2020,final without candidates,4,,RGASBR,GBR,autumn.night,7.920835851889748,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,autumn.day,49.29932468263999,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,autumn.peak,38.591500913875095,-0.0,0.0
+2020,final without candidates,4,,RGASBR,GBR,autumn.evening,14.815369859166085,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,summer.night,5.28455066108,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,summer.day,8.80470430198,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,summer.peak,2.89937103318,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,summer.evening,2.1588135889399998,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final without candidates,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2020,final without candidates,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,winter.day,151.10294698068435,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,peak.peak,58.6742920927945,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,summer.evening,0.16855462584153424,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
+2020,final with candidates,0,,GASDRV,GBR,autumn.evening,163.38648438726443,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,winter.day,146.06195328510356,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,peak.peak,57.11139327282774,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,summer.evening,0.16050321508707546,-0.0,0.0
+2020,final with candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,autumn.peak,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,1,,GASPRC,GBR,autumn.evening,155.6061506069184,-0.0,0.0
+2020,final with candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2020,final with candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2020,final with candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,summer.day,2.9054374462539894,-0.0,0.0
+2020,final with candidates,2,,WNDFRM,GBR,summer.peak,0.9567587035813536,-0.0,0.0
+2020,final with candidates,2,,WNDFRM,GBR,summer.evening,0.7123818495857518,-0.0,0.0
+2020,final with candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2020,final with candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2020,final with candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2020,final with candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2020,final with candidates,3,,GASCGT,GBR,winter.night,5.188866559524631,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,winter.day,6.673429053263119,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,winter.peak,2.1534949369182415,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,winter.evening,2.929996247897116,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2020,final with candidates,3,,GASCGT,GBR,peak.day,7.377793253082273,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,peak.peak,2.347104744244309,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2020,final with candidates,3,,GASCGT,GBR,summer.night,0.10701881005811698,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2020,final with candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2020,final with candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2020,final with candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2020,final with candidates,3,,GASCGT,GBR,autumn.day,7.747083429990084,-0.0,0.0
+2020,final with candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2020,final with candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2020,final with candidates,4,,RGASBR,GBR,winter.night,31.5763928720666,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,winter.day,168.06061789586659,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,winter.peak,90.62497613363998,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,winter.evening,54.4534438098666,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,peak.night,16.974967026169374,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,peak.day,71.46449081514659,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,peak.peak,50.68806124244001,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,peak.evening,23.428436126811356,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2020,final with candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2020,final with candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2020,final with candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2020,final with candidates,4,,RGASBR,GBR,autumn.night,7.919886829052455,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,autumn.day,49.2993038493066,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,autumn.peak,38.591080737902736,-0.0,0.0
+2020,final with candidates,4,,RGASBR,GBR,autumn.evening,14.814822179639375,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,summer.night,5.2845433694133,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,summer.day,8.804693885313299,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,summer.peak,2.89936790818,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,summer.evening,2.1588094222732996,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2020,final with candidates,5,,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
+2020,final with candidates,5,,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,winter.day,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,winter.peak,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,winter.evening,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
+2020,final with candidates,,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,,,GASPRC,GBR,peak.peak,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,,,GASPRC,GBR,peak.evening,0.0,-0.0,-2.220446049250313e-16
+2020,final with candidates,,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.862233030303035,0.0
+2020,final with candidates,,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.862233030303035,0.0
+2020,final with candidates,,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
+2020,final with candidates,,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
+2020,final with candidates,,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
+2020,final with candidates,,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.862233030303035,0.0
+2020,final with candidates,,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593309,0.0
+2020,final with candidates,,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.862233030303035,0.0
+2020,final with candidates,,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.862233030303035,0.0
+2020,final with candidates,,,GASCGT,GBR,winter.night,0.00022997916771800003,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.268924030303033,0.0
+2020,final with candidates,,,GASCGT,GBR,peak.day,0.0,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,peak.peak,0.0,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,peak.evening,0.000131416667718,-9.268924030303033,0.0
+2020,final with candidates,,,GASCGT,GBR,summer.night,0.0,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2020,final with candidates,,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2020,final with candidates,,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2020,final with candidates,,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.268924030303033,0.0
+2020,final with candidates,,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
+2020,final with candidates,,,GASCGT,GBR,autumn.peak,0.0000985625,-9.268924030303033,0.0
+2020,final with candidates,,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.268924030303033,0.0
+2020,final with candidates,,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2020,final with candidates,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2020,final with candidates,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2020,final with candidates,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2020,final with candidates,,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,winter.peak,3.125e-6,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,peak.peak,3.125e-6,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.0587449300000005,0.0
+2020,final with candidates,,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2020,final with candidates,,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,peak.night,0.0,-0.0,8.881784197001252e-16
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,peak.evening,0.0,-0.0,8.881784197001252e-16
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,autumn.night,0.0,-0.0,8.881784197001252e-16
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,autumn.peak,0.0,-0.0,8.881784197001252e-16
+2030,ironing out iteration 0; post RSHEAT|GBR investment,5,,RELCHP,GBR,autumn.evening,0.0,-0.0,8.881784197001252e-16
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,winter.night,12.179665608293831,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,winter.day,153.60894769845382,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,winter.evening,47.29569147973385,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,peak.night,21.192683870313836,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,peak.day,46.59679621773381,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,peak.peak,46.3816611088,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,peak.evening,27.63966804055385,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,autumn.night,12.342934260933838,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,autumn.day,22.041522451893826,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,autumn.peak,44.87284439557999,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,4,,RGASBR,GBR,autumn.evening,18.688115346973845,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,winter.night,12.179665608293831,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,winter.day,153.60894769845382,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,winter.evening,47.29569147973385,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,peak.day,46.59679621773381,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,peak.peak,46.3816611088,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,peak.evening,12.735822890970612,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,autumn.day,22.041522451893826,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,autumn.peak,32.92160763023509,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,4,,RGASBR,GBR,autumn.evening,3.250923295699936,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,peak.night,21.564185045204564,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,autumn.night,11.647741651889753,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.26892403030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.26892403030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.26892403030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.26892403030303,0.0
+2030,ironing out iteration 0; post ELCTRI|GBR investment,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.26892403030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449299999996,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,peak.evening,27.562423254436762,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,4,,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.night,0.0,-0.0,3.0587449299999996
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.night,11.647741651889751,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.86223303030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.86223303030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.86223303030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.86223303030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.86223303030303,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303031,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303031,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303031,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303031,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303031,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.day,201.2090417177309,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.peak,89.00701955283967,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
+2030,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,peak.evening,27.562423254436762,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,4,,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.peak,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.night,11.647741651889751,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.peak,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.night,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.day,201.20904171773094,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.night,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.day,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.peak,89.00701955283965,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.night,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.day,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-1.1102230246251565e-16
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.peak,92.16472468680712,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.evening,0.464792220809886,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
+2030,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,peak.evening,27.562423254436762,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,4,,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.peak,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.night,11.647741651889751,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.day,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.peak,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.evening,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2030,ironing out iteration 0; final without candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,winter.night,5.189205998452591,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,winter.day,6.6739326103518914,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,winter.evening,2.9300596841572673,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,peak.day,7.3779505119938245,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,summer.night,0.29510617194278477,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,autumn.day,7.747559908401914,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2030,ironing out iteration 0; final without candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.day,201.20904171773094,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.peak,89.00701955283965,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.evening,0.44265925791417715,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.peak,92.16472468680712,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.evening,0.464792220809886,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
+2030,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,summer.night,5.8543799694133005,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,summer.day,9.7541109853133,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,summer.peak,3.2120090081800003,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,summer.evening,2.3915957222733,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,5,,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,winter.night,12.179651024960432,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,winter.day,153.60892686512042,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,winter.peak,90.62499374999999,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,winter.evening,47.29568314640045,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,peak.day,46.596775384400416,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,peak.peak,46.381654858800005,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,peak.evening,12.735288663345202,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,autumn.day,22.041501618560424,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,autumn.peak,32.92118745426273,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,4,,RGASBR,GBR,autumn.evening,3.2503756161732227,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.night,21.56326292616938,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.night,11.646792629052458,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,summer.day,3.2187450892539897,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,summer.peak,1.059930266581354,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,summer.evening,0.7892013285857518,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,winter.night,5.1890965386923495,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,winter.day,6.67342905326312,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,winter.peak,2.153494936918241,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,winter.evening,2.9299962478971167,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,peak.day,7.3774647114145555,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,peak.peak,2.3470061817443093,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,summer.night,0.29483490889039904,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,autumn.day,7.747083429990085,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.day,201.2083930701036,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.peak,89.0055828578278,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.evening,0.44259733208717555,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.peak,23.602386596208433,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.day,209.00668375493427,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.peak,92.1631911570446,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.evening,0.46472719869153434,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.peak,23.48988633234444,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.peak,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.evening,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.evening,0.0,-0.0,-2.220446049250313e-16
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593309,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.862233030303035,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.night,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.day,0.00032854166771800004,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.peak,0.0000985625,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.evening,0.000131416667718,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.night,0.00022997916771800003,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.peak,0.0000985625,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.268924030303033,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.peak,3.125e-6,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.peak,3.125e-6,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,winter.day,209.007363584943,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,peak.peak,92.16472468680718,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,summer.evening,0.4647922208098859,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,autumn.peak,23.49170449767925,-0.0,0.0
+2030,final without candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,winter.day,201.2090417177309,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,peak.peak,89.0070195528397,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,summer.evening,0.44265925791417704,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2030,final without candidates,1,,GASPRC,GBR,autumn.peak,23.60414318224167,-0.0,0.0
+2030,final without candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,final without candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2030,final without candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2030,final without candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,summer.day,3.2188600626534005,-0.0,0.0
+2030,final without candidates,2,,WNDFRM,GBR,summer.peak,1.0599640039494003,-0.0,0.0
+2030,final without candidates,2,,WNDFRM,GBR,summer.evening,0.7892279633502001,-0.0,0.0
+2030,final without candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2030,final without candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,final without candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2030,final without candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2030,final without candidates,3,,GASCGT,GBR,winter.night,5.18920599845259,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,winter.day,6.673932610351891,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,winter.peak,2.1535436238948877,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,winter.evening,2.930059684157267,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2030,final without candidates,3,,GASCGT,GBR,peak.day,7.377950511993824,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,peak.peak,2.3471485481808085,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,final without candidates,3,,GASCGT,GBR,summer.night,0.2951061719427847,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,final without candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,final without candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,final without candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2030,final without candidates,3,,GASCGT,GBR,autumn.day,7.7475599084019136,-0.0,0.0
+2030,final without candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2030,final without candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,final without candidates,4,,RGASBR,GBR,winter.night,38.1262161554,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,winter.day,190.6754484292,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,winter.peak,90.625,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,winter.evening,62.1222918432,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,4,,RGASBR,GBR,peak.day,83.66329694848,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,peak.peak,57.50161129244002,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,peak.evening,27.562423254436766,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,final without candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,final without candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,final without candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,final without candidates,4,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,4,,RGASBR,GBR,autumn.day,59.10802318264001,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,autumn.peak,44.0415578138751,-0.0,0.0
+2030,final without candidates,4,,RGASBR,GBR,autumn.evening,18.07752365916609,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,peak.night,25.575049372215442,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,peak.evening,14.903845149583242,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,summer.night,5.85438726108,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,summer.day,9.75412140198,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,summer.peak,3.2120121331800005,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,summer.evening,2.39159988894,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,autumn.night,26.641743156150255,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final without candidates,5,,RELCHP,GBR,autumn.peak,11.9512367653449,-0.0,0.0
+2030,final without candidates,5,,RELCHP,GBR,autumn.evening,15.437192051273913,-0.0,0.0
+2030,final without candidates,6,,RGASBR,GBR,winter.night,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,winter.day,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,final without candidates,6,,RGASBR,GBR,winter.evening,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,peak.night,21.56418504520456,-0.0,0.0
+2030,final without candidates,6,,RGASBR,GBR,peak.day,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,peak.peak,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,peak.evening,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,final without candidates,6,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,final without candidates,6,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,final without candidates,6,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,final without candidates,6,,RGASBR,GBR,autumn.night,11.647741651889751,-0.0,0.0
+2030,final without candidates,6,,RGASBR,GBR,autumn.day,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,autumn.peak,0.0,-0.0,-4.440892098500626e-16
+2030,final without candidates,6,,RGASBR,GBR,autumn.evening,0.0,-0.0,-4.440892098500626e-16
+2030,final with candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,winter.day,209.00670875493432,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,peak.peak,92.16319115704454,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,summer.evening,0.46472719869153445,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,autumn.peak,23.48988633234447,-0.0,0.0
+2030,final with candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,winter.day,201.20839307010354,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,peak.peak,89.00558285782776,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,summer.evening,0.44257233208707564,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,autumn.day,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,1,,GASPRC,GBR,autumn.peak,23.602386596208447,-0.0,0.0
+2030,final with candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2030,final with candidates,2,,WNDFRM,GBR,winter.night,4.435312795545212,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,winter.day,7.075379933645912,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,winter.peak,1.9712501261051125,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,winter.evening,2.5696653598405335,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,peak.night,2.851272517283696,-16.862233030303035,0.0
+2030,final with candidates,2,,WNDFRM,GBR,peak.day,6.3713620320039785,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,peak.peak,1.7776452018191917,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,peak.evening,1.72484387381507,-16.862233030303035,0.0
+2030,final with candidates,2,,WNDFRM,GBR,summer.night,1.6368416242136155,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,summer.day,3.21874508925399,-0.0,0.0
+2030,final with candidates,2,,WNDFRM,GBR,summer.peak,1.0599302665813537,-0.0,0.0
+2030,final with candidates,2,,WNDFRM,GBR,summer.evening,0.7892013285857519,-0.0,0.0
+2030,final with candidates,2,,WNDFRM,GBR,autumn.night,3.203281465982185,-16.862233030303035,0.0
+2030,final with candidates,2,,WNDFRM,GBR,autumn.day,6.001752635595889,-7.593309,0.0
+2030,final with candidates,2,,WNDFRM,GBR,autumn.peak,1.5488393825638174,-16.862233030303035,0.0
+2030,final with candidates,2,,WNDFRM,GBR,autumn.evening,1.9008483513729915,-16.862233030303035,0.0
+2030,final with candidates,3,,GASCGT,GBR,winter.night,5.188866559524631,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,winter.day,6.673429053263119,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,winter.peak,2.1534949369182415,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,winter.evening,2.929996247897116,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,peak.night,5.5884937755474,-9.268924030303033,0.0
+2030,final with candidates,3,,GASCGT,GBR,peak.day,7.377793253082273,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,peak.peak,2.347104744244309,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,peak.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,final with candidates,3,,GASCGT,GBR,summer.night,0.2950648880581171,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,final with candidates,3,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,final with candidates,3,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,final with candidates,3,,GASCGT,GBR,autumn.night,5.5884937755474,-9.268924030303033,0.0
+2030,final with candidates,3,,GASCGT,GBR,autumn.day,7.747083429990084,-0.0,0.0
+2030,final with candidates,3,,GASCGT,GBR,autumn.peak,2.39506875,-9.268924030303033,0.0
+2030,final with candidates,3,,GASCGT,GBR,autumn.evening,3.1934250255473997,-9.268924030303033,0.0
+2030,final with candidates,4,,RGASBR,GBR,winter.night,12.179651024960421,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,winter.day,153.60892686512045,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,winter.peak,90.62499374999999,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,winter.evening,47.29568314640045,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2030,final with candidates,4,,RGASBR,GBR,peak.day,46.596775384400416,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,peak.peak,46.38165485879999,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,peak.evening,12.735288663345202,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,final with candidates,4,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,final with candidates,4,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,final with candidates,4,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,final with candidates,4,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2030,final with candidates,4,,RGASBR,GBR,autumn.day,22.04150161856043,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,autumn.peak,32.92118745426273,-0.0,0.0
+2030,final with candidates,4,,RGASBR,GBR,autumn.evening,3.2503756161732227,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,winter.night,29.165208466660005,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,winter.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,winter.peak,12.499375,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,winter.evening,16.66583346666,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,peak.night,25.57595690791723,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,peak.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,peak.peak,12.499375,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,peak.evening,14.904371043875251,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,summer.night,5.8543799694133005,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,summer.day,9.7541109853133,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,summer.peak,3.2120090081800003,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,summer.evening,2.3915957222733,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,autumn.night,26.642677595654153,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,autumn.day,41.664583466660005,-3.0587449300000005,0.0
+2030,final with candidates,5,,RELCHP,GBR,autumn.peak,11.951650691317264,-0.0,0.0
+2030,final with candidates,5,,RELCHP,GBR,autumn.evening,15.437731397467225,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,peak.night,21.563262926169372,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,final with candidates,6,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,final with candidates,6,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,final with candidates,6,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,final with candidates,6,,RGASBR,GBR,autumn.night,11.646792629052456,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2030,final with candidates,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,winter.day,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,winter.peak,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,winter.evening,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,peak.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,summer.evening,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,autumn.day,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,autumn.peak,0.0,-0.0,0.0
+2030,final with candidates,,,GASDRV,GBR,autumn.evening,0.0,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,winter.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,,,GASPRC,GBR,peak.peak,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,,,GASPRC,GBR,peak.evening,0.0,-0.0,-2.220446049250313e-16
+2030,final with candidates,,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,WNDFRM,GBR,winter.night,0.00011186601025274165,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,winter.day,0.00017845292106438267,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,winter.peak,0.000049718226646625005,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,winter.evening,0.00006481126016157341,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,peak.night,0.00007191386388174911,-16.862233030303035,0.0
+2030,final with candidates,,,WNDFRM,GBR,peak.day,0.00016069641156131185,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,peak.peak,0.000044835186499625,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,peak.evening,0.00004350344865561091,-16.862233030303035,0.0
+2030,final with candidates,,,WNDFRM,GBR,summer.night,0.00004128388466768467,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,summer.day,0.00011497339941020655,-0.0,0.0
+2030,final with candidates,,,WNDFRM,GBR,summer.peak,0.0000337373680464375,-0.0,0.0
+2030,final with candidates,,,WNDFRM,GBR,summer.evening,0.000026634764448161445,-0.0,0.0
+2030,final with candidates,,,WNDFRM,GBR,autumn.night,0.00008079211857975206,-16.862233030303035,0.0
+2030,final with candidates,,,WNDFRM,GBR,autumn.day,0.00015137424412148091,-7.593309,0.0
+2030,final with candidates,,,WNDFRM,GBR,autumn.peak,0.000039064320880312505,-16.862233030303035,0.0
+2030,final with candidates,,,WNDFRM,GBR,autumn.evening,0.0000479425760855406,-16.862233030303035,0.0
+2030,final with candidates,,,GASCGT,GBR,winter.night,0.00022997916771800003,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,winter.day,0.00032854166771800004,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,winter.peak,0.0,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,winter.evening,0.0,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,peak.night,0.00022997916771800003,-9.268924030303033,0.0
+2030,final with candidates,,,GASCGT,GBR,peak.day,0.0,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,peak.peak,0.0,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,peak.evening,0.000131416667718,-9.268924030303033,0.0
+2030,final with candidates,,,GASCGT,GBR,summer.night,0.0,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2030,final with candidates,,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2030,final with candidates,,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2030,final with candidates,,,GASCGT,GBR,autumn.night,0.00022997916771800003,-9.268924030303033,0.0
+2030,final with candidates,,,GASCGT,GBR,autumn.day,0.00032854166771800004,-0.0,0.0
+2030,final with candidates,,,GASCGT,GBR,autumn.peak,0.0000985625,-9.268924030303033,0.0
+2030,final with candidates,,,GASCGT,GBR,autumn.evening,0.000131416667718,-9.268924030303033,0.0
+2030,final with candidates,,,RGASBR,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,peak.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,peak.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,summer.night,0.0,-0.0,3.05874493
+2030,final with candidates,,,RGASBR,GBR,summer.day,0.0,-0.0,5.5645369
+2030,final with candidates,,,RGASBR,GBR,summer.peak,0.0,-0.0,5.5645369
+2030,final with candidates,,,RGASBR,GBR,summer.evening,0.0,-0.0,5.5645369
+2030,final with candidates,,,RGASBR,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,RGASBR,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,winter.night,7.291666700000001e-6,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,winter.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,winter.peak,3.125e-6,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,winter.evening,4.1666667e-6,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,peak.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,peak.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,peak.peak,3.125e-6,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,peak.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,summer.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,autumn.day,0.000010416666700000001,-3.0587449300000005,0.0
+2030,final with candidates,,,RELCHP,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2030,final with candidates,,,RELCHP,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,winter.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,winter.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,winter.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,peak.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,peak.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,peak.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,autumn.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,autumn.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,autumn.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,6,,RGASBR,GBR,autumn.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.night,73.84123332206,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.day,254.95484159586002,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,winter.evening,86.45696500986001,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.night,51.727530317420005,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.day,137.52666571514,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.peak,76.81453009244001,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,peak.evening,46.59972130402001,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.night,42.016390608040005,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.day,110.58130514930001,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.peak,61.44285147922,-0.0,0.0
+2040,ironing out iteration 0; post RSHEAT|GBR investment,,,RGASBR,GBR,autumn.evening,36.77686951044,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,summer.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASNAT|GBR investment,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,summer.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,summer.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,summer.peak,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,summer.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.night,0.0,-0.0,-1.1102230246251565e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.night,0.0,-0.0,-1.1102230246251565e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.day,0.0,-0.0,-1.1102230246251565e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-1.1102230246251565e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-1.1102230246251565e-16
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.day,360.9639698231196,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.day,85.71569060312169,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,summer.evening,28.106738155604855,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.day,11.030571054582538,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; post GASPRD|GBR investment,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,summer.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,summer.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,summer.peak,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,summer.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.day,70.14930532671298,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.day,83.78840078266302,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,summer.evening,26.768322052957004,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.day,12.659715498340006,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.day,360.9639698231196,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.day,85.71569060312169,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,summer.evening,28.106738155604855,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.day,11.030571054582538,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final without candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,winter.peak,11.119943933640016,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,summer.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,summer.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,summer.peak,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,summer.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.night,47.89467548328714,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.day,217.88833044844714,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.evening,71.63036047972716,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.night,25.780972478647133,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.day,100.46015456772713,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.peak,65.69457678379999,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.evening,31.773116773887153,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.night,6.424209277746601,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.day,10.7035176686466,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.peak,3.5246469831800002,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.evening,2.6243778556065998,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.night,16.069832769267133,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.day,73.51479400188713,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.peak,50.32289817057999,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.evening,21.950264980307146,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.day,345.9295903374229,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.day,83.78837203266289,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,summer.evening,26.768268302956784,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.day,12.659661748339765,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.day,360.96391463561946,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.day,85.71566041562153,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,summer.evening,28.10668296810463,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.day,11.030515867082215,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,winter.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.day,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.peak,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,peak.evening,0.0,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASDRV,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.day,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.peak,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,winter.evening,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.day,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.peak,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,peak.evening,0.0,-0.0,-2.220446049250313e-16
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASPRC,GBR,autumn.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.night,2.406250011e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.day,3.4375000110000007e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.peak,1.03125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,winter.evening,1.3750000110000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.night,2.406250011e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.day,3.4375000110000007e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.peak,1.03125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,peak.evening,1.3750000110000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.night,2.406250011e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.day,3.4375000110000007e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.peak,1.03125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,summer.evening,1.3750000110000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.night,2.406250011e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.day,3.4375000110000007e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.peak,1.03125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,WNDFRM,GBR,autumn.evening,1.3750000110000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.night,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.day,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.peak,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,winter.evening,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.night,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.day,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.peak,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,peak.evening,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.night,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.day,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.peak,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,summer.evening,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.night,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.day,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.peak,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,GASCGT,GBR,autumn.evening,0.0,-0.0,7.593309
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,winter.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.peak,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,peak.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.night,7.291666700000001e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.day,0.000010416666700000001,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.peak,3.125e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,summer.evening,4.1666667e-6,-0.0,0.0
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.night,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.day,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.peak,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RGASBR,GBR,autumn.evening,0.0,-0.0,-4.440892098500626e-16
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.night,7.291666700000001e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.day,0.000010416666700000001,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.peak,3.125e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,winter.evening,4.1666667e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.night,7.291666700000001e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.day,0.000010416666700000001,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.peak,3.125e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,peak.evening,4.1666667e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.night,7.291666700000001e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.day,0.000010416666700000001,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.peak,3.125e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,summer.evening,4.1666667e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.night,7.291666700000001e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.day,0.000010416666700000001,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.peak,3.125e-6,-5.5645369,0.0
+2040,ironing out iteration 0; final with candidates,,,RELCHP,GBR,autumn.evening,4.1666667e-6,-5.5645369,0.0
+2040,final without candidates,0,,GASDRV,GBR,winter.night,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,winter.day,360.9639698231197,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,winter.peak,125.070625,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,winter.evening,166.76083466742,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,peak.night,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,peak.day,85.71569060312174,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,peak.peak,125.070625,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,peak.evening,166.76083466742,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,summer.night,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,summer.day,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,summer.peak,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,summer.evening,28.10673815560485,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,autumn.night,0.0,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,autumn.day,11.030571054582595,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,autumn.peak,125.070625,-0.0,0.0
+2040,final without candidates,0,,GASDRV,GBR,autumn.evening,166.76083466742,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,winter.night,275.78031376071004,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,winter.day,70.14930532671303,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,winter.peak,118.1915625,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,winter.evening,157.58875126070998,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,peak.night,0.0,-0.0,-2.220446049250313e-16
+2040,final without candidates,1,,GASPRC,GBR,peak.day,83.78840078266308,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,peak.peak,118.1915625,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,peak.evening,157.58875126070998,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,summer.night,0.0,-0.0,-2.220446049250313e-16
+2040,final without candidates,1,,GASPRC,GBR,summer.day,0.0,-0.0,-2.220446049250313e-16
+2040,final without candidates,1,,GASPRC,GBR,summer.peak,0.0,-0.0,-2.220446049250313e-16
+2040,final without candidates,1,,GASPRC,GBR,summer.evening,26.768322052957,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,autumn.night,0.0,-0.0,-2.220446049250313e-16
+2040,final without candidates,1,,GASPRC,GBR,autumn.day,12.659715498340063,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,autumn.peak,118.1915625,-0.0,0.0
+2040,final without candidates,1,,GASPRC,GBR,autumn.evening,157.58875126070998,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,winter.night,25.94655054710617,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,winter.day,37.066500730746185,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,winter.peak,11.119950183640015,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,winter.evening,14.826600363466154,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,peak.night,25.94655054710617,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,peak.day,37.066500730746185,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,peak.peak,11.119950183640015,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,peak.evening,14.826600363466154,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,summer.night,0.0,-0.0,-4.440892098500626e-16
+2040,final without candidates,6,,RGASBR,GBR,summer.day,0.0,-0.0,-4.440892098500626e-16
+2040,final without candidates,6,,RGASBR,GBR,summer.peak,0.0,-0.0,-4.440892098500626e-16
+2040,final without candidates,6,,RGASBR,GBR,summer.evening,0.0,-0.0,-4.440892098500626e-16
+2040,final without candidates,6,,RGASBR,GBR,autumn.night,25.94655054710617,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,autumn.day,37.066500730746185,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,autumn.peak,11.119950183640015,-0.0,0.0
+2040,final without candidates,6,,RGASBR,GBR,autumn.evening,14.826600363466154,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,winter.night,47.894682774953836,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,winter.day,217.88834086511383,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,winter.peak,114.2443428,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,winter.evening,71.63036464639386,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,peak.night,25.780979770313834,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,peak.day,100.46016498439383,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,peak.peak,65.6945799088,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,peak.evening,31.773120940553852,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,summer.night,6.424223861080001,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,summer.day,10.70353850198,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,summer.peak,3.5246532331800005,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,summer.evening,2.62438618894,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,autumn.night,16.069840060933835,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,autumn.day,73.51480441855382,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,autumn.peak,50.32290129557999,-0.0,0.0
+2040,final without candidates,7,,RGASBR,GBR,autumn.evening,21.950269146973845,-0.0,0.0


### PR DESCRIPTION
## Summary

Add `group_id` to `ActivityRow` / `debug_dispatch_assets.csv` so rows for parent assets (and future candidates) carry the stable `AssetGroupID` key already recorded in `assets.csv`. Addresses #1243.

## Why

`#1124` shifted dispatch to run at the parent-asset level rather than their children. Since then, `ActivityRow::asset_id` is `Option<AssetID>` and any row for a parent asset has `asset_id = None`. Candidates will have the same shape. Two such rows that differ only by their `AssetGroupID` (or differ from an unrelated parent in the same region/process/time_slice) collapse to identical-looking records in `debug_dispatch_assets.csv` -- there is no key the reader can use to tell them apart.

`AssetRow` (in `assets.csv`) already persists `group_id: Option<AssetGroupID>` via `AssetRef::group_id()`. The dispatch CSV just didn't get the same treatment.

## Changes

- `src/output.rs`: add `group_id: Option<AssetGroupID>` to `ActivityRow` (right after `asset_id`, mirroring the field order in `AssetRow`). Populate it from `asset.group_id()` in `write_activity`. Update both test expectations (`write_activity`, `write_activity_with_missing_keys`) to include the new field.
- `tests/data/simple/debug_dispatch_assets.csv`: regenerate the regression golden so the header gains the `group_id` column and each data row gains the empty trailing value after `asset_id` (the `simple` example dispatches individual assets, so `group_id` is `None` for every row -- matching the existing pre-#1124 serialization of children).

The serialization order is chosen so `group_id` appears immediately after `asset_id`; readers who were relying on column-name ordering still find everything via the header, and column-position readers break the same way they'd break for any new column.

## Testing

- `cargo test --lib output` -> 26 passed (including both `write_activity*` unit tests).
- `cargo test --test regression` -> 8 passed (including the `simple` regression that compares the generated CSV byte-for-byte against the updated golden).
- Regeneration path: set `MUSE2_TEST_OUTPUT_DIR=/tmp/muse2`, run the test suite, inspect the produced `debug_dispatch_assets.csv`, copy it over the golden. That's the same flow the test harness documents for this file.

Fixes #1243

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
