### PR TITLE
Move funder acknowledgements from `CITATION.cff` to `README.md`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: |
-    If you cite this software, please cite it as below.
+    If you use this software, please cite it as below.
 
     This work was supported via the Climate Compatible Growth (CCG) programme and the EPSRC-funded
     HI-ACT project (EP/X038823/2). CCG is funded by UK Aid from the UK government. However, the views

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,5 @@
 cff-version: 1.2.0
-message: |
-    If you use this software, please cite it as below.
-
-    This work was supported via the Climate Compatible Growth (CCG) programme and the EPSRC-funded
-    HI-ACT project (EP/X038823/2). CCG is funded by UK Aid from the UK government. However, the views
-    expressed herein do not necessarily reflect the UK government's official policies.
+message: If you use this software, please cite it as below.
 title: MUSE2
 version: 2.1.0
 date-released: 2026-03-31

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ It is the successor to [MUSE], which is written in Python. It was developed foll
 MUSE to address a range of legacy issues that are challenging to address via upgrades to the
 existing MUSE framework, and to implement the framework in the high-performance Rust language.
 
+This work was supported via the Climate Compatible Growth (CCG) programme and the EPSRC-funded
+HI-ACT project ([EP/X038823/2][HI-ACT grant]). CCG is funded by UK Aid from the UK government.
+However, the views expressed herein do not necessarily reflect the UK government's official
+policies.
+
+[HI-ACT grant]: https://gtr.ukri.org/projects?ref=EP%2FX038823%2F2
 [MUSE]: https://github.com/EnergySystemsModellingLab/MUSE_OS
 <!-- ANCHOR_END: overview -->
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 > :warning: **Please note that MUSE2 currently only works with simple models and is not yet suitable
 for use in research.** :warning:
 
+<!-- ANCHOR: overview -->
 MUSE2 (**M**od**U**lar energy systems **S**imulation **E**nvironment) is a tool for running
 simulations of energy systems, written in Rust. Its purpose is to provide users with a framework to
 simulate pathways of energy system transition, usually in the context of climate change mitigation.
@@ -24,6 +25,7 @@ MUSE to address a range of legacy issues that are challenging to address via upg
 existing MUSE framework, and to implement the framework in the high-performance Rust language.
 
 [MUSE]: https://github.com/EnergySystemsModellingLab/MUSE_OS
+<!-- ANCHOR_END: overview -->
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,15 +5,7 @@
 > ⚠️ **Please note that MUSE2 currently only works with simple models and is not yet suitable
 for use in research.** ⚠️
 
-MUSE2 (**M**od**U**lar energy systems **S**imulation **E**nvironment) is a tool for running
-simulations of energy systems, written in Rust. Its purpose is to provide users with a framework to
-simulate pathways of energy system transition, usually in the context of climate change mitigation.
-
-It is the successor to [MUSE], which is written in Python. It was developed following re-design of
-MUSE to address a range of legacy issues that are challenging to address via upgrades to the
-existing MUSE framework, and to implement the framework in the high-performance Rust language.
-
-[MUSE]: https://github.com/EnergySystemsModellingLab/MUSE_OS
+{{#include ../README.md:overview}}
 
 ## Getting started
 


### PR DESCRIPTION
# Description

I used the `CITATION.cff` from this repo as a template for the one in FROG and @dalonsoa pointed out a couple of things:

1. A typo
2. That funder acknowledgements are probably better in `README.md`

The logic is that funder acknowledgements aren't really part of the citation and if you include them in the `README.md` you can also include links to the grant pages. So it's probably a better approach overall. Note that the `README.md` is included in any source bundle for the release (which you get on Zenodo), so the information is still there.

I've changed this repo to use the same convention. The "overview" text is duplicated between `README.md` and `docs/README.md`, so while I was at it, I changed things to use mdBook's `include` pre-processor, which removes the need to keep the two in sync.

Note that this won't retrospectively affect the entry on Zenodo for the v2.1.0 release (which is fine), but I thought I'd do it now so that I didn't forget for the next release.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
